### PR TITLE
Fixed tests not running as expected for `yarn test` command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,12 +39,12 @@ jobs:
         run: |
           echo "
           services:
-            activitypub:
+            activitypub-testing:
               image: $IMAGE_NAME:$DOCKER_METADATA_OUTPUT_VERSION" > docker-compose.ci.yml
 
       - name: "Run tests"
         run: |
-          docker compose -f docker-compose.testing.yml -f docker-compose.ci.yml up --abort-on-container-exit --exit-code-from activitypub
+          docker compose -f docker-compose.testing.yml -f docker-compose.ci.yml up --abort-on-container-exit --exit-code-from activitypub-testing
 
       - name: Login to GAR
         uses: docker/login-action@v3

--- a/docker-compose.testing.yml
+++ b/docker-compose.testing.yml
@@ -1,6 +1,8 @@
 services:
-  activitypub:
+  activitypub-testing:
     build: .
+    volumes:
+      - ./src:/opt/activitypub/src
     environment:
       - MYSQL_USER=ghost
       - MYSQL_PASSWORD=password

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:integration": "c8 --src src --all --reporter text --reporter cobertura mocha -r tsx './src/**/*.integration.test.ts'",
     "test:code": "c8 --src src --all --reporter text --reporter cobertura mocha -r tsx './src/**/*.test.ts'",
     "test:all": "yarn test:types && yarn test:code",
-    "test": "docker compose -f docker-compose.testing.yml up --abort-on-container-exit --exit-code-from activitypub",
+    "test": "docker compose -f docker-compose.testing.yml up --abort-on-container-exit --exit-code-from activitypub-testing",
     "lint:code": "eslint *.js lib/ --ext .js --cache",
     "lint": "yarn lint:code"
   },


### PR DESCRIPTION
When executing tests via `yarn test` they are executed inside of a container. The tests that are being executed are the ones added when the container was first built. Subsequent changes to the tests are not causing docker-compose to rebuild the container meaning the same set of tests were always being executed. This change mounts the `src` directory into the container so that the tests are always up to date.