### PR TITLE
Correct addressing

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -141,7 +141,9 @@ export async function postPublishedWebhook(
                 .get('globaldb')
                 .set([article.id!.href], await article.toJsonLd());
             await addToList(ctx.get('db'), ['outbox'], create.id!.href);
-            await apCtx.sendActivity({ handle: 'index' }, 'followers', create);
+            await apCtx.sendActivity({ handle: 'index' }, 'followers', create, {
+                preferSharedInbox: true
+            });
         } catch (err) {
             console.log(err);
         }
@@ -196,7 +198,9 @@ export async function siteChangedWebhook(
 
         await ctx.get('globaldb').set([update.id!.href], await update.toJsonLd());
         await addToList(db, ['outbox'], update.id!.href);
-        await apCtx.sendActivity({ handle }, 'followers', update);
+        await apCtx.sendActivity({ handle }, 'followers', update, {
+            preferSharedInbox: true
+        });
     } catch (err) {
         console.log(err);
     }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -126,7 +126,8 @@ export async function postPublishedWebhook(
             actor,
             object: article,
             id: apCtx.getObjectUri(Create, { id: uuidv4() }),
-            to: apCtx.getFollowersUri('index'),
+            to: PUBLIC_COLLECTION,
+            cc: apCtx.getFollowersUri('index'),
         });
         try {
             await article.toJsonLd();
@@ -189,7 +190,8 @@ export async function siteChangedWebhook(
             id: apCtx.getObjectUri(Update, { id: uuidv4() }),
             actor: actor?.id,
             to: PUBLIC_COLLECTION,
-            object: actor
+            object: actor,
+            cc: apCtx.getFollowersUri('index'),
         });
 
         await ctx.get('globaldb').set([update.id!.href], await update.toJsonLd());


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/MOM-329

The `to` field for Create<Article> activities was incorrectly set to the
followers collection, but the content is intended to be public. This may have
been causing issues with users being able to see the content depending on if
they are following the actor.

What we've fixed here is made public activities addressed `to` the public
collection, and adding a `cc` to the followers because they are also an
intended recipient, though not the primary.

Using a shared inbox make for less network requests when delivering activities
and increases performance in terms of both load on the server as well as
delivery times because recipients on the same server can all be informed by the
same request