### PR TITLE
Updated @fedify/fedify to 0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typescript": "5.4.5"
   },
   "dependencies": {
-    "@fedify/fedify": "0.13.0-dev.318",
+    "@fedify/fedify": "0.13.0",
     "@hono/node-server": "1.11.1",
     "@js-temporal/polyfill": "0.4.4",
     "@sentry/node": "8.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,10 +292,10 @@
   resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.1.tgz#b9da6a878a371829a0502c9b6c1c143ef6663f4d"
   integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
 
-"@fedify/fedify@0.13.0-dev.318":
-  version "0.13.0-dev.318"
-  resolved "https://registry.yarnpkg.com/@fedify/fedify/-/fedify-0.13.0-dev.318.tgz#96146859d01888cb163908049bdb4d928ade0938"
-  integrity sha512-xzT3iz5IA9/9Wj30X+o0t0INDeLzn/7dq75nw5u966myzT0Ejq5L//fKNmVB04rFE6vx0+DWmZtpdxOL26YoNw==
+"@fedify/fedify@0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@fedify/fedify/-/fedify-0.13.0.tgz#cd0fca097b53b6477fb04efbe4e0bb6e54482728"
+  integrity sha512-HCecGj5PzQtRQ9VSZkG1xiiluabw+DbfOoRf5+OOO5oXy/tUDMcPkBO+XWWEKJ+0JU3e+iI7BDV9dFHSj0rHHQ==
   dependencies:
     "@deno/shim-crypto" "~0.3.1"
     "@deno/shim-deno" "~0.18.0"


### PR DESCRIPTION
Updated Fedify to [0.13.0](https://github.com/dahlia/fedify/releases/tag/0.13.0) which is a stable version.