### PR TITLE
[WIP] Fix followers collection output

### DIFF
--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -285,6 +285,7 @@ Then('a {string} activity is in the Outbox', async function (string) {
         }
     });
     const outbox = await response.json();
+    console.log(JSON.stringify(outbox, null, 4));
     const found = outbox.orderedItems.find((item) => {
         return item.type === activity && item.object?.type === object
     });
@@ -300,6 +301,7 @@ Then('{string} is in our Inbox', async function (activityName) {
     const inbox = await response.json();
     const activity = this.activities[activityName];
 
+    console.log(JSON.stringify(inbox, null, 4));
     const found = inbox.items.find(item => item.id === activity.id);
 
     assert(found);
@@ -313,6 +315,8 @@ Then('{string} is in our Followers', async function (actorName) {
     });
     const followers = await response.json();
     const actor = this.actors[actorName];
+
+    console.log(JSON.stringify(followers, null, 4));
 
     const found = followers.orderedItems.find(item => item.id === actor.id);
 

--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -314,7 +314,7 @@ Then('{string} is in our Followers', async function (actorName) {
     const followers = await response.json();
     const actor = this.actors[actorName];
 
-    const found = followers.orderedItems.find(item => item === actor.id);
+    const found = followers.orderedItems.find(item => item.id === actor.id);
 
     assert(found);
 });

--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -285,7 +285,6 @@ Then('a {string} activity is in the Outbox', async function (string) {
         }
     });
     const outbox = await response.json();
-    console.log(JSON.stringify(outbox, null, 4));
     const found = outbox.orderedItems.find((item) => {
         return item.type === activity && item.object?.type === object
     });
@@ -301,7 +300,6 @@ Then('{string} is in our Inbox', async function (activityName) {
     const inbox = await response.json();
     const activity = this.activities[activityName];
 
-    console.log(JSON.stringify(inbox, null, 4));
     const found = inbox.items.find(item => item.id === activity.id);
 
     assert(found);
@@ -315,8 +313,6 @@ Then('{string} is in our Followers', async function (actorName) {
     });
     const followers = await response.json();
     const actor = this.actors[actorName];
-
-    console.log(JSON.stringify(followers, null, 4));
 
     const found = followers.orderedItems.find(item => item.id === actor.id);
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "wiremock-captain": "3.3.1"
   },
   "dependencies": {
-    "@fedify/fedify": "0.14.0-dev.331",
+    "@fedify/fedify": "0.14.0-dev.334",
     "@hono/node-server": "1.11.1",
     "@js-temporal/polyfill": "0.4.4",
     "@sentry/node": "8.13.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "wiremock-captain": "3.3.1"
   },
   "dependencies": {
-    "@fedify/fedify": "0.13.0-dev.318",
+    "@fedify/fedify": "0.14.0-dev.331",
     "@hono/node-server": "1.11.1",
     "@js-temporal/polyfill": "0.4.4",
     "@sentry/node": "8.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,10 +292,10 @@
   resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.1.tgz#b9da6a878a371829a0502c9b6c1c143ef6663f4d"
   integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
 
-"@fedify/fedify@0.14.0-dev.331":
-  version "0.14.0-dev.331"
-  resolved "https://registry.yarnpkg.com/@fedify/fedify/-/fedify-0.14.0-dev.331.tgz#c18984f35bfef945baafecfbe5dbf9c9dc122d50"
-  integrity sha512-WSx9HxqJoaUNvL1IXX41HmZo7HuwszPLGARfenW2i7wFcwW4smCHoogQg0njfBNE3QizgfOsrGW7WpFiNm2x5Q==
+"@fedify/fedify@0.14.0-dev.334":
+  version "0.14.0-dev.334"
+  resolved "https://registry.yarnpkg.com/@fedify/fedify/-/fedify-0.14.0-dev.334.tgz#326c3696501b83b1b052a7a539b7548e9edf598e"
+  integrity sha512-1YEjUiQv2/reKuZLPCjsojOCYkUhs5A7zX1ZXqO726QHVVRZtxinz6RW2wHWYAiMVsY6Ko1KGva/FzwBssGR6A==
   dependencies:
     "@deno/shim-crypto" "~0.3.1"
     "@deno/shim-deno" "~0.18.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,10 +292,10 @@
   resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.1.tgz#b9da6a878a371829a0502c9b6c1c143ef6663f4d"
   integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
 
-"@fedify/fedify@0.13.0-dev.318":
-  version "0.13.0-dev.318"
-  resolved "https://registry.yarnpkg.com/@fedify/fedify/-/fedify-0.13.0-dev.318.tgz#96146859d01888cb163908049bdb4d928ade0938"
-  integrity sha512-xzT3iz5IA9/9Wj30X+o0t0INDeLzn/7dq75nw5u966myzT0Ejq5L//fKNmVB04rFE6vx0+DWmZtpdxOL26YoNw==
+"@fedify/fedify@0.14.0-dev.331":
+  version "0.14.0-dev.331"
+  resolved "https://registry.yarnpkg.com/@fedify/fedify/-/fedify-0.14.0-dev.331.tgz#c18984f35bfef945baafecfbe5dbf9c9dc122d50"
+  integrity sha512-WSx9HxqJoaUNvL1IXX41HmZo7HuwszPLGARfenW2i7wFcwW4smCHoogQg0njfBNE3QizgfOsrGW7WpFiNm2x5Q==
   dependencies:
     "@deno/shim-crypto" "~0.3.1"
     "@deno/shim-deno" "~0.18.0"


### PR DESCRIPTION
Fedify doesn't support returning plain objects for a collection dispatcher and using the whole object, instead it just uses the id - which isn't suitable for us.

But currently fedify objects are expensive to instantiate, so we're waiting on a fix to fedify to allow us to return actors again.

This PR includes fixing the test for the followers check, as well as returning Actors again and a bump to fedify.

