### PR TITLE
Used actor URI in `site.changed` update activity

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -215,7 +215,7 @@ export async function siteChangedWebhook(
             id: apCtx.getObjectUri(Update, { id: uuidv4() }),
             actor: actor?.id,
             to: PUBLIC_COLLECTION,
-            object: actor,
+            object: actor?.id,
             cc: apCtx.getFollowersUri('index'),
         });
 


### PR DESCRIPTION
refs [AP-357](https://linear.app/tryghost/issue/AP-357/publickey-mismatch-on-update-causing-re-follows)

When publishing an update as a result of processing a `site.changed` webhook it was noticed that Mastodon was triggering a re-follow of the actor. This down to the `publicKey` property contained in the update object being different to the one Mastodon has stored for the actor. In the case here, `publicKey` is actually missing from the actor due to a serialisation issue within Fedify, so have opted to use the `id` of the actor instead of the full actor object and let Mastodon dereference to get the updated actor object