### PR TITLE
Filtered outbox activities to only include `Create` and `Announce` activities

### DIFF
--- a/features/outbox.feature
+++ b/features/outbox.feature
@@ -1,0 +1,14 @@
+Feature: Outbox
+  In order to view the activities performed by an actor
+  As a fediverse server
+  I want be able to retrieve an actor's activities from their outbox
+
+  Scenario: outbox contains relevant activities
+    Given an Actor "Alice"
+    And a "Create(Article)" Activity "C" by "Alice"
+    And a "Announce(C)" Activity "An" by "Alice"
+    And a "Follow(Us)" Activity "F" by "Alice"
+    And a "Accept(F)" Activity "A" by "Alice"
+    When the contents of the outbox is requested
+    Then the outbox contains 1 activity
+    And a "Create(Article)" activity is in the Outbox

--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -46,6 +46,20 @@ async function createActivity(activityType, object, actor, remote = true) {
             actor: actor,
         };
     }
+
+    if (activityType === 'Announce') {
+        return {
+            '@context': [
+                'https://www.w3.org/ns/activitystreams',
+                'https://w3id.org/security/data-integrity/v1',
+            ],
+            'type': 'Announce',
+            'id': 'http://wiremock:8080/announce/1',
+            'to': 'as:Public',
+            'object': object,
+            actor: actor,
+        };
+    }
 }
 
 async function createActor(name = 'Test', remote = true) {
@@ -331,4 +345,18 @@ Then('{string} is in our Followers once only', async function (actorName) {
     const found = followers.orderedItems.filter(item => item === actor.id);
 
     assert.equal(found.length, 1);
+});
+
+When('the contents of the outbox is requested', async function () {
+    const response = await fetch('http://activitypub-testing:8083/.ghost/activitypub/outbox/index', {
+        headers: {
+            'Content-Type': 'application/ld+json'
+        },
+    });
+
+    this.response = await response.json();
+});
+
+Then('the outbox contains {int} activity', function (count) {
+    assert.equal(this.response.totalItems, count);
 });

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -334,13 +334,19 @@ export async function followingCounter(
     return results.length;
 }
 
+function filterOutboxActivityUris (activityUris: string[]) {
+    // Only return Create and Announce activityUris
+    return activityUris.filter(uri => /(create|announce)/.test(uri));
+}
+
 export async function outboxDispatcher(
     ctx: RequestContext<ContextData>,
     handle: string,
 ) {
     console.log('Outbox Dispatcher');
-    const results = (await ctx.data.db.get<string[]>(['outbox'])) || [];
+    const results = filterOutboxActivityUris((await ctx.data.db.get<string[]>(['outbox'])) || []);
     console.log(results);
+
     let items: Activity[] = [];
     for (const result of results) {
         try {
@@ -361,7 +367,8 @@ export async function outboxCounter(
     handle: string,
 ) {
     const results = (await ctx.data.db.get<string[]>(['outbox'])) || [];
-    return results.length;
+
+    return filterOutboxActivityUris(results).length;
 }
 
 export async function articleDispatcher(


### PR DESCRIPTION
refs [AP-359](https://linear.app/tryghost/issue/AP-359/filter-outbox-activities-to-create-and-announce)

Filtered outbox activities to only include `Create` and `Announce` activities
which seems to be inline with what other implementations are doing (i.e Mastodon)