### PR TITLE
[WIP] Sending & Un-sending Likes

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -56,7 +56,7 @@ import {
     handleLike
 } from './dispatchers';
 
-import { followAction, inboxHandler, postPublishedWebhook, siteChangedWebhook } from './handlers';
+import { likeAction, unlikeAction, followAction, inboxHandler, postPublishedWebhook, siteChangedWebhook } from './handlers';
 
 if (process.env.SENTRY_DSN) {
     Sentry.init({ dsn: process.env.SENTRY_DSN });
@@ -279,6 +279,8 @@ app.get('/.ghost/activitypub/inbox/:handle', inboxHandler);
 app.post('/.ghost/activitypub/webhooks/post/published', postPublishedWebhook);
 app.post('/.ghost/activitypub/webhooks/site/changed', siteChangedWebhook);
 app.post('/.ghost/activitypub/actions/follow/:handle', followAction);
+app.post('/.ghost/activitypub/actions/like/:id', likeAction);
+app.post('/.ghost/activitypub/actions/unlike/:id', unlikeAction);
 
 /** Federation wire up */
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,6 +18,7 @@ import {
     Announce,
     Context,
     Like,
+    Undo,
 } from '@fedify/fedify';
 import { federation } from '@fedify/fedify/x/hono';
 import { Hono, Context as HonoContext } from 'hono';
@@ -43,6 +44,8 @@ import {
     outboxCounter,
     likedDispatcher,
     likedCounter,
+    likeDispatcher,
+    undoDispatcher,
     articleDispatcher,
     noteDispatcher,
     followDispatcher,
@@ -180,6 +183,16 @@ fedify.setObjectDispatcher(
     Update,
     `/.ghost/activitypub/update/{id}`,
     updateDispatcher,
+);
+fedify.setObjectDispatcher(
+    Like,
+    `/.ghost/activitypub/like/{id}`,
+    likeDispatcher,
+);
+fedify.setObjectDispatcher(
+    Undo,
+    `/.ghost/activitypub/undo/{id}`,
+    undoDispatcher,
 );
 
 /** Hono */

--- a/src/app.ts
+++ b/src/app.ts
@@ -41,6 +41,8 @@ import {
     followingCounter,
     outboxDispatcher,
     outboxCounter,
+    likedDispatcher,
+    likedCounter,
     articleDispatcher,
     noteDispatcher,
     followDispatcher,
@@ -141,6 +143,13 @@ fedify
         outboxDispatcher,
     )
     .setCounter(outboxCounter);
+
+fedify
+    .setLikedDispatcher(
+        '/.ghost/activitypub/liked/{handle}',
+        likedDispatcher,
+    )
+    .setCounter(likedCounter);
 
 fedify.setObjectDispatcher(
     Article,

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -23,6 +23,7 @@ import { addToList } from './kv-helpers';
 import { ContextData } from './app';
 import { ACTOR_DEFAULT_HANDLE } from './constants';
 import { getUserData, getUserKeypair } from './user';
+import { lookupActor } from './lookup-helpers';
 
 export async function actorDispatcher(
     ctx: RequestContext<ContextData>,
@@ -300,31 +301,6 @@ export async function inboxErrorHandler(
 ) {
     console.error('Error handling incoming activity');
     console.error(error);
-}
-
-async function lookupActor(ctx: RequestContext<ContextData>, url: string) {
-    try {
-        console.log('Looking up actor locally', url);
-        const local = await ctx.data.globaldb.get([url]);
-        return await APObject.fromJsonLd(local);
-    } catch (err) {
-        console.log('Error looking up actor locally', url);
-        console.log(err);
-        console.log('Looking up actor remotely', url);
-        const documentLoader = await ctx.getDocumentLoader({handle: 'index'});
-        try {
-            const remote = await lookupObject(url, {documentLoader});
-            if (isActor(remote)) {
-                await ctx.data.globaldb.set([url], await remote.toJsonLd());
-                return remote;
-            }
-        } catch (err) {
-            console.log('Error looking up actor remotely', url);
-            console.log(err)
-            return null;
-        }
-    }
-    return null;
 }
 
 function convertJsonLdToRecipient(result: any): Recipient {

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -16,6 +16,7 @@ import {
     Object as APObject,
     Recipient,
     Like,
+    Undo,
 } from '@fedify/fedify';
 import { v4 as uuidv4 } from 'uuid';
 import { addToList } from './kv-helpers';
@@ -537,4 +538,28 @@ export async function noteDispatcher(
         return null;
     }
     return Note.fromJsonLd(exists);
+}
+
+export async function likeDispatcher(
+    ctx: RequestContext<ContextData>,
+    data: Record<'id', string>,
+) {
+    const id = ctx.getObjectUri(Like, data);
+    const exists = await ctx.data.globaldb.get([id.href]);
+    if (!exists) {
+        return null;
+    }
+    return Like.fromJsonLd(exists);
+}
+
+export async function undoDispatcher(
+    ctx: RequestContext<ContextData>,
+    data: Record<'id', string>,
+) {
+    const id = ctx.getObjectUri(Undo, data);
+    const exists = await ctx.data.globaldb.get([id.href]);
+    if (!exists) {
+        return null;
+    }
+    return Undo.fromJsonLd(exists);
 }

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -435,6 +435,38 @@ export async function outboxCounter(
     return filterOutboxActivityUris(results).length;
 }
 
+export async function likedDispatcher(
+    ctx: RequestContext<ContextData>,
+    handle: string,
+) {
+    console.log('Liked Dispatcher');
+    const results = (await ctx.data.db.get<string[]>(['liked'])) || [];
+    console.log(results);
+
+    let items: Like[] = [];
+    for (const result of results) {
+        try {
+            const thing = await ctx.data.globaldb.get([result]);
+            const activity = await Like.fromJsonLd(thing);
+            items.push(activity);
+        } catch (err) {
+            console.log(err);
+        }
+    }
+    return {
+        items: items.reverse(),
+    };
+}
+
+export async function likedCounter(
+    ctx: RequestContext<ContextData>,
+    handle: string,
+) {
+    const results = (await ctx.data.db.get<string[]>(['liked'])) || [];
+
+    return results.length;
+}
+
 export async function articleDispatcher(
     ctx: RequestContext<ContextData>,
     data: Record<'id', string>,

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -9,6 +9,7 @@ import {
     Create,
     Note,
     Update,
+    Actor,
     PUBLIC_COLLECTION
 } from '@fedify/fedify';
 import { Context, Next } from 'hono';
@@ -22,6 +23,7 @@ import type { PersonData } from './user';
 import { ACTOR_DEFAULT_HANDLE } from './constants';
 import { Temporal } from '@js-temporal/polyfill';
 import { createHash } from 'node:crypto';
+import { lookupActor } from 'lookup-helpers';
 
 type StoredThing = {
     id: string;
@@ -121,6 +123,16 @@ export async function unlikeAction(
     await removeFromList(ctx.get('db'), ['liked'], likeId!.href);
     await ctx.get('globaldb').delete([likeId!.href]);
 
+    let attributionActor: Actor | null = null;
+    if (objectToLike.attributionId) {
+        attributionActor = await lookupActor(apCtx, objectToLike.attributionId.href);
+    }
+    if (attributionActor) {
+        apCtx.sendActivity({ handle: ACTOR_DEFAULT_HANDLE }, attributionActor, undo, {
+            preferSharedInbox: true
+        });
+    }
+
     apCtx.sendActivity({ handle: ACTOR_DEFAULT_HANDLE }, 'followers', undo, {
         preferSharedInbox: true
     });
@@ -170,6 +182,16 @@ export async function likeAction(
     await ctx.get('globaldb').set([like.id!.href], likeJson);
 
     await addToList(ctx.get('db'), ['liked'], like.id!.href);
+
+    let attributionActor: Actor | null = null;
+    if (objectToLike.attributionId) {
+        attributionActor = await lookupActor(apCtx, objectToLike.attributionId.href);
+    }
+    if (attributionActor) {
+        apCtx.sendActivity({ handle: ACTOR_DEFAULT_HANDLE }, attributionActor, like, {
+            preferSharedInbox: true
+        });
+    }
 
     apCtx.sendActivity({ handle: ACTOR_DEFAULT_HANDLE }, 'followers', like, {
         preferSharedInbox: true

--- a/src/lookup-helpers.ts
+++ b/src/lookup-helpers.ts
@@ -1,0 +1,37 @@
+import {
+    isActor,
+    lookupObject,
+    Actor,
+    RequestContext,
+    Object as APObject,
+} from '@fedify/fedify';
+import { ContextData } from './app';
+
+export async function lookupActor(ctx: RequestContext<ContextData>, url: string): Promise<Actor | null> {
+    try {
+        console.log('Looking up actor locally', url);
+        const local = await ctx.data.globaldb.get([url]);
+        const object = await APObject.fromJsonLd(local);
+        if (isActor(object)) {
+            return object;
+        }
+        return null;
+    } catch (err) {
+        console.log('Error looking up actor locally', url);
+        console.log(err);
+        console.log('Looking up actor remotely', url);
+        const documentLoader = await ctx.getDocumentLoader({handle: 'index'});
+        try {
+            const remote = await lookupObject(url, {documentLoader});
+            if (isActor(remote)) {
+                await ctx.data.globaldb.set([url], await remote.toJsonLd());
+                return remote;
+            }
+        } catch (err) {
+            console.log('Error looking up actor remotely', url);
+            console.log(err)
+            return null;
+        }
+    }
+    return null;
+}

--- a/src/user.ts
+++ b/src/user.ts
@@ -23,6 +23,7 @@ export type PersonData = {
     outbox: string;
     following: string;
     followers: string;
+    liked?: string;
     url: string;
 };
 
@@ -55,6 +56,7 @@ export async function getUserData(ctx: RequestContext<ContextData>, handle: stri
             outbox: new URL(existing.outbox),
             following: new URL(existing.following),
             followers: new URL(existing.followers),
+            liked: existing.liked ? new URL(existing.liked) : ctx.getLikedUri(handle),
             publicKeys: (await ctx.getActorKeyPairs(handle)).map(
                 (key) => key.cryptographicKey,
             ),
@@ -72,6 +74,7 @@ export async function getUserData(ctx: RequestContext<ContextData>, handle: stri
         outbox: ctx.getOutboxUri(handle),
         following: ctx.getFollowingUri(handle),
         followers: ctx.getFollowersUri(handle),
+        liked: ctx.getLikedUri(handle),
         publicKeys: (await ctx.getActorKeyPairs(handle)).map(
             (key) => key.cryptographicKey,
         ),
@@ -88,6 +91,7 @@ export async function getUserData(ctx: RequestContext<ContextData>, handle: stri
         outbox: data.outbox.href,
         following: data.following.href,
         followers: data.followers.href,
+        liked: data.liked.href,
         url: data.url.href,
     };
 

--- a/src/user.unit.test.ts
+++ b/src/user.unit.test.ts
@@ -13,6 +13,7 @@ const HANDLE = 'foo';
 const ACTOR_URI = `https://example.com/${HANDLE}`;
 const INBOX_URI = `https://example.com/${HANDLE}/inbox`;
 const OUTBOX_URI = `https://example.com/${HANDLE}/outbox`;
+const LIKED_URI = `https://example.com/${HANDLE}/liked`;
 const FOLLOWING_URI = `https://example.com/${HANDLE}/following`;
 const FOLLOWERS_URI = `https://example.com/${HANDLE}/followers`;
 
@@ -30,6 +31,7 @@ function getCtx() {
         getActorUri: sinon.stub(),
         getInboxUri: sinon.stub(),
         getOutboxUri: sinon.stub(),
+        getLikedUri: sinon.stub(),
         getFollowingUri: sinon.stub(),
         getFollowersUri: sinon.stub(),
         host,
@@ -43,6 +45,7 @@ function getCtx() {
     ctx.getInboxUri.withArgs(HANDLE).returns(new URL(INBOX_URI));
     ctx.getOutboxUri.withArgs(HANDLE).returns(new URL(OUTBOX_URI));
     ctx.getFollowingUri.withArgs(HANDLE).returns(new URL(FOLLOWING_URI));
+    ctx.getLikedUri.withArgs(HANDLE).returns(new URL(LIKED_URI));
     ctx.getFollowersUri.withArgs(HANDLE).returns(new URL(FOLLOWERS_URI));
 
     return ctx as any;
@@ -64,6 +67,7 @@ describe('getUserData', function () {
             icon: new Image({ url: new URL(ACTOR_DEFAULT_ICON) }),
             inbox: new URL(INBOX_URI),
             outbox: new URL(OUTBOX_URI),
+            liked: new URL(LIKED_URI),
             following: new URL(FOLLOWING_URI),
             followers: new URL(FOLLOWERS_URI),
             publicKeys: ['abc123'],
@@ -79,6 +83,7 @@ describe('getUserData', function () {
                 icon: ACTOR_DEFAULT_ICON,
                 inbox: expectedUserData.inbox.href,
                 outbox: expectedUserData.outbox.href,
+                liked: expectedUserData.liked.href,
                 following: expectedUserData.following.href,
                 followers: expectedUserData.followers.href,
                 url: expectedUserData.url.href,
@@ -98,6 +103,7 @@ describe('getUserData', function () {
             icon: `https://${ctx.host}/icon.png`,
             inbox: INBOX_URI,
             outbox: OUTBOX_URI,
+            liked: LIKED_URI,
             following: FOLLOWING_URI,
             followers: FOLLOWERS_URI,
             url: `https://${ctx.host}`,
@@ -115,6 +121,7 @@ describe('getUserData', function () {
             icon: new Image({ url: new URL(`https://${ctx.host}/icon.png`) }),
             inbox: new URL(INBOX_URI),
             outbox: new URL(OUTBOX_URI),
+            liked: new URL(LIKED_URI),
             following: new URL(FOLLOWING_URI),
             followers: new URL(FOLLOWERS_URI),
             publicKeys: ['abc123'],
@@ -135,6 +142,7 @@ describe('getUserData', function () {
             preferredUsername: HANDLE,
             inbox: INBOX_URI,
             outbox: OUTBOX_URI,
+            liked: LIKED_URI,
             following: FOLLOWING_URI,
             followers: FOLLOWERS_URI,
             url: `https://${ctx.host}`,
@@ -152,6 +160,7 @@ describe('getUserData', function () {
             icon: null,
             inbox: new URL(INBOX_URI),
             outbox: new URL(OUTBOX_URI),
+            liked: new URL(LIKED_URI),
             following: new URL(FOLLOWING_URI),
             followers: new URL(FOLLOWERS_URI),
             publicKeys: ['abc123'],
@@ -173,6 +182,7 @@ describe('getUserData', function () {
             icon: `https://${ctx.host}/icon.png`,
             inbox: INBOX_URI,
             outbox: OUTBOX_URI,
+            liked: LIKED_URI,
             following: FOLLOWING_URI,
             followers: FOLLOWERS_URI
         }
@@ -189,6 +199,7 @@ describe('getUserData', function () {
             icon: new Image({ url: new URL(`https://${ctx.host}/icon.png`) }),
             inbox: new URL(INBOX_URI),
             outbox: new URL(OUTBOX_URI),
+            liked: new URL(LIKED_URI),
             following: new URL(FOLLOWING_URI),
             followers: new URL(FOLLOWERS_URI),
             publicKeys: ['abc123'],


### PR DESCRIPTION
🍦 

We got a few things happening here!

We're adding a liked collection to actors, this is so that we can render a list of the liked content in the Admin. The liked collection functions similar to how we're doing the inbox and outbox, we're storing an array of the ids belonging to the collection.

We've got some basic object dispatchers wired up for `Like` and `Undo` which is necessary so that we can generate id's for those objects.

The inbox handler has been updating to attached a `liked` property to the `object` of the activity, this allows us to render the item correctly in the frontend with a filled in heart. I didn't store the `liked` property on the object, because of concerns of losing the data - e.g. if we start handling `Update` activities and we overwrite the object in the DB - we might lose the `liked` status. There's also the issue of what happens when we support multiple users, we can't store it on the object itself.

Adding the `liked` property is not efficient though - and we really need to rethink storage solutions around this.

And of course we have two actions "like" and "unlike" - they are fairly simple - we first check if the object we're trying to like/unlike exists, and 404 if it doesn't. Then we check if we've already performed that action, and 409 if we have. After that we construct the relevant activity, store it, and send it to our followers - we also need to send it to the original author of the object using `attributedTo` 