### PR TITLE
Fixed followers dispatcher and api endpoint

### DIFF
--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -343,7 +343,7 @@ Then('{string} is in our Followers', async function (actorName) {
     const followers = await response.json();
     const actor = this.actors[actorName];
 
-    const found = followers.orderedItems.find(item => item === actor.id);
+    const found = followers.orderedItems.find(item => item.id === actor.id);
 
     assert(found);
 });
@@ -356,7 +356,7 @@ Then('{string} is in our Followers once only', async function (actorName) {
     });
     const followers = await response.json();
     const actor = this.actors[actorName];
-    const found = followers.orderedItems.filter(item => item === actor.id);
+    const found = followers.orderedItems.filter(item => item.id === actor.id);
 
     assert.equal(found.length, 1);
 });


### PR DESCRIPTION
There was a bug in fedify with serialising Actors which mean we had to return incompleter followers data, which broke our frontend, this has now been fixed so we can update the followers dispatcher to return full Actor objects again