### PR TITLE
Added endpoint for searching for Fediverse users

### DIFF
--- a/src/api/action/search.ts
+++ b/src/api/action/search.ts
@@ -1,0 +1,122 @@
+import { isActor } from '@fedify/fedify';
+import { Context } from 'hono';
+import ky from 'ky';
+import sanitizeHtml from 'sanitize-html';
+
+import {
+    type HonoContextVariables,
+    fedify
+} from '../../app';
+
+interface ProfileSearchResult {
+    actor: any;
+    handle: string;
+    followerCount: number;
+    isFollowing: boolean;
+}
+
+interface SearchResults {
+    profiles: ProfileSearchResult[];
+}
+
+// @<username>@<domain>.<tld>
+const HANDLE_REGEX = /^@([\w-]+)@([\w-]+\.[\w.-]+)$/;
+
+// http(s)://...
+const URI_REGEX = /^https?:\/\/[^\s/$.?#].[^\s]*$/;
+
+export async function searchAction(
+    ctx: Context<{ Variables: HonoContextVariables }>,
+) {
+    const db = ctx.get('db');
+    const apCtx = fedify.createContext(ctx.req.raw as Request, {
+        db,
+        globaldb: ctx.get('globaldb'),
+    });
+
+    // Parse "query" from query parameters
+    const query = ctx.req.query('query') || '';
+
+    // Init search results - At the moment we only support searching for an actor (ui calls them profiles)
+    const results: SearchResults = {
+        profiles: [],
+    };
+
+    // If the query is not a handle or URI, return early
+    if (HANDLE_REGEX.test(query) === false && URI_REGEX.test(query) === false) {
+        console.log(`Invalid query: ${query}`);
+
+        return new Response(JSON.stringify(results), {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            status: 200,
+        });
+    }
+
+    // Lookup actor by handle or url
+    try {
+        const actor = await apCtx.lookupObject(query);
+
+        if (actor && isActor(actor)) {
+            const result: ProfileSearchResult = {
+                actor: {},
+                handle: '',
+                followerCount: 0,
+                isFollowing: false,
+            };
+
+            // Retrieve actor data
+            result.actor = await actor.toJsonLd();
+
+            // Sanitize actor data
+            const sanitizeHtmlConfig = {
+                allowedTags: ['a', 'p', 'img', 'br', 'strong', 'em', 'span'],
+                allowedAttributes: {
+                    a: ['href'],
+                    img: ['src'],
+                }
+            };
+
+            result.actor.summary = sanitizeHtml(result.actor.summary, sanitizeHtmlConfig);
+
+            if (result.actor.attachment) {
+                result.actor.attachment = result.actor.attachment.map((attachment: any) => {
+                    if (attachment.type === 'PropertyValue') {
+                        attachment.value = sanitizeHtml(attachment.value, sanitizeHtmlConfig);
+                    }
+
+                    return attachment;
+                });
+            }
+
+            // Compute the full handle for the actor
+            result.handle = `@${actor.preferredUsername}@${actor.id!.host}`;
+
+            // Retrieve follower count for the actor
+            const followers = await ky
+                .get(actor.followersId!.href)
+                .json<{ totalItems: number }>();
+
+            result.followerCount = followers.totalItems;
+
+            // Determine if the current user is following the actor
+            const following = (await db.get<string[]>(['following'])) || [];
+
+            result.isFollowing = following.includes(actor.id!.href);
+
+            // Add to the results
+            results.profiles.push(result);
+        }
+    } catch (err) {
+        console.log(`Profile search failed: ${query}`, err);
+    }
+
+    // Return results
+    return new Response(JSON.stringify(results), {
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        status: 200,
+    });
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,1 @@
+export { searchAction } from './action/search';

--- a/src/app.ts
+++ b/src/app.ts
@@ -55,9 +55,7 @@ import {
     handleAnnounce,
     handleLike
 } from './dispatchers';
-import {
-    searchAction
-} from './api';
+import { searchAction } from './api';
 
 import {
     likeAction,

--- a/src/app.ts
+++ b/src/app.ts
@@ -55,8 +55,9 @@ import {
     handleAnnounce,
     handleLike
 } from './dispatchers';
-
-import { searchAction } from './api/action/search';
+import {
+    searchAction
+} from './api';
 
 import {
     likeAction,

--- a/src/app.ts
+++ b/src/app.ts
@@ -56,6 +56,8 @@ import {
     handleLike
 } from './dispatchers';
 
+import { searchAction } from './api/action/search';
+
 import {
     likeAction,
     unlikeAction,
@@ -293,6 +295,7 @@ app.post('/.ghost/activitypub/actions/follow/:handle', followAction);
 app.post('/.ghost/activitypub/actions/like/:id', likeAction);
 app.post('/.ghost/activitypub/actions/unlike/:id', unlikeAction);
 app.post('/.ghost/activitypub/actions/reply/:id', replyAction);
+app.get('/.ghost/activitypub/actions/search', searchAction);
 
 /** Federation wire up */
 

--- a/src/helpers/activitypub/actor.ts
+++ b/src/helpers/activitypub/actor.ts
@@ -1,0 +1,86 @@
+import { Actor, KvStore, PropertyValue, } from "@fedify/fedify";
+
+interface Attachment {
+    name: string;
+    value: string;
+}
+
+export async function getAttachments(actor: Actor, options?: {
+    sanitizeValue?: (content: string) => string;
+}): Promise<Attachment[]> {
+    const attachments: Attachment[] = [];
+
+    for await (const attachment of actor.getAttachments()) {
+        if (!(attachment instanceof PropertyValue)) {
+            continue;
+        }
+
+        const name = attachment.name?.toString() || '';
+        let value = attachment.value?.toString() || '';
+
+        if (options?.sanitizeValue) {
+            value = options.sanitizeValue(value);
+        }
+
+        attachments.push({ name, value });
+    }
+
+    return attachments;
+}
+
+export async function getFollowerCount(actor: Actor): Promise<number> {
+    const followers = await actor.getFollowers();
+
+    return followers?.totalItems || 0;
+}
+
+export function getHandle(actor: Actor): string {
+    const host = actor.id?.host || 'unknown';
+
+    return `@${actor?.preferredUsername || 'unknown'}@${host}`;
+}
+
+export async function getRecentActivities(actor: Actor, options?: {
+    sanitizeContent?: (content: string) => string;
+}): Promise<unknown[]> {
+    const activities: unknown[] = [];
+    const outbox = await actor.getOutbox();
+
+    if (!outbox) {
+        return [];
+    }
+
+    const firstPage = await outbox.getFirst();
+
+    if (!firstPage) {
+        return [];
+    }
+
+    for await (const activity of firstPage.getItems()) {
+        const activityJson = await activity.toJsonLd({ format: 'compact' }) as { content: string };
+
+        if (options?.sanitizeContent) {
+            activityJson.content = options.sanitizeContent(activityJson.content);
+        }
+
+        activities.push(activityJson);
+    }
+
+    return activities;
+}
+
+export async function isFollowing(actor: Actor, options: {
+    db: KvStore;
+}): Promise<boolean> {
+    const following = (
+        await options.db.get<string[]>(['following'])
+    ) || [];
+
+    return actor.id?.href
+        ? following.includes(actor.id.href)
+        : false;
+}
+
+export function isHandle(handle: string): boolean {
+    return /^@([\w-]+)@([\w-]+\.[\w.-]+)$/.test(handle);
+}

--- a/src/helpers/activitypub/actor.unit.test.ts
+++ b/src/helpers/activitypub/actor.unit.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { Actor, KvStore, PropertyValue } from '@fedify/fedify';
+
+import {
+    getAttachments,
+    getFollowerCount,
+    getHandle,
+    getRecentActivities,
+    isFollowing,
+    isHandle,
+} from './actor';
+
+describe('getAttachments', () => {
+    it('should return an array of attachments for the actor', async () => {
+        const actor = {
+            getAttachments: vi.fn().mockImplementation(async function* () {
+                yield new PropertyValue({ name: 'foo', value: 'bar' });
+                yield new PropertyValue({ name: 'baz', value: 'qux' });
+            })
+        } as unknown as Actor;
+
+        expect(await getAttachments(actor)).toEqual([
+            { name: 'foo', value: 'bar' },
+            { name: 'baz', value: 'qux' }
+        ]);
+    });
+
+    it('should skip non PropertyValue attachments', async () => {
+        const actor = {
+            getAttachments: vi.fn().mockImplementation(async function* () {
+                yield { name: 'foo', value: 'bar' };
+                yield new PropertyValue({ name: 'baz', value: 'qux' });
+            })
+        } as unknown as Actor;
+
+        expect(await getAttachments(actor)).toEqual([
+            { name: 'baz', value: 'qux' },
+        ]);
+    });
+
+    it('should use a default name if the attachment name is not available', async () => {
+        const actor = {
+            getAttachments: vi.fn().mockImplementation(async function* () {
+                yield new PropertyValue({ value: 'bar' });
+            })
+        } as unknown as Actor;
+
+        expect(await getAttachments(actor)).toEqual([
+            { name: '', value: 'bar' },
+        ]);
+    });
+
+    it('should use a default value if the attachment value is not available', async () => {
+        const actor = {
+            getAttachments: vi.fn().mockImplementation(async function* () {
+                yield new PropertyValue({ name: 'foo' });
+            })
+        } as unknown as Actor;
+
+        expect(await getAttachments(actor)).toEqual([
+            { name: 'foo', value: '' },
+        ]);
+    });
+
+    it('should sanitize the attachment value if a sanitizeValue function is provided', async () => {
+        const actor = {
+            getAttachments: vi.fn().mockImplementation(async function* () {
+                yield new PropertyValue({ name: 'foo', value: '<script>alert("XSS")</script>' });
+            })
+        } as unknown as Actor;
+
+        expect(
+            await getAttachments(actor, {
+                sanitizeValue: (value) => value
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+            })
+        ).toEqual([
+            { name: 'foo', value: '&lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;' }
+        ]);
+    });
+});
+
+describe('getFollowerCount', () => {
+    it('should return the follower count for the actor', async () => {
+        const actor = {
+            getFollowers: vi.fn().mockResolvedValue({ totalItems: 100 })
+        } as unknown as Actor;
+
+        expect(await getFollowerCount(actor)).toBe(100);
+    });
+
+    it('should return 0 if the actor followers are not available', async () => {
+        const actor = {
+            getFollowers: vi.fn().mockResolvedValue(null)
+        } as unknown as Actor;
+
+        expect(await getFollowerCount(actor)).toBe(0);
+    });
+});
+
+describe('getHandle', () => {
+    it('should return a handle for the actor', () => {
+        const actor = {
+            id: new URL('https://example.com/users/foo'),
+            preferredUsername: 'foo',
+        } as unknown as Actor;
+
+        expect(getHandle(actor)).toBe('@foo@example.com');
+    });
+
+    it('should return a handle if the actor id is not available', () => {
+        const actor = {
+            preferredUsername: 'foo',
+        } as unknown as Actor;
+
+        expect(getHandle(actor)).toBe('@foo@unknown');
+    });
+
+    it('should return a handle if the actor preferredUsername is not available', () => {
+        const actor = {
+            id: new URL('https://example.com/users/foo'),
+        } as unknown as Actor;
+
+        expect(getHandle(actor)).toBe('@unknown@example.com');
+    });
+
+    it('should return a handle if the actor id and preferredUsername are not available', () => {
+        const actor = {} as unknown as Actor;
+
+        expect(getHandle(actor)).toBe('@unknown@unknown');
+    });
+});
+
+describe('getRecentActivities', () => {
+    it('should return an array of recent activities for the actor', async () => {
+        const activityContent = 'Hello, world!';
+        const activityToJsonLdMock = vi.fn().mockResolvedValue({ content: activityContent });
+        const actor = {
+            getOutbox: vi.fn().mockResolvedValue({
+                getFirst: vi.fn().mockResolvedValue({
+                    getItems: vi.fn().mockImplementation(async function* () {
+                        yield { toJsonLd: activityToJsonLdMock };
+                    })
+                })
+            })
+        } as unknown as Actor;
+
+        expect(await getRecentActivities(actor)).toEqual([{ content: activityContent }]);
+
+        expect(activityToJsonLdMock).toHaveBeenCalledWith({ format: 'compact' });
+    });
+
+    it('should return an empty array if the actor outbox is not available', async () => {
+        const actor = {
+            getOutbox: vi.fn().mockResolvedValue(null)
+        } as unknown as Actor;
+
+        expect(await getRecentActivities(actor)).toEqual([]);
+    });
+
+    it('should return an empty array if the first page of the actor outbox is not available', async () => {
+        const actor = {
+            getOutbox: vi.fn().mockResolvedValue({
+                getFirst: vi.fn().mockResolvedValue(null)
+            })
+        } as unknown as Actor;
+
+        expect(await getRecentActivities(actor)).toEqual([]);
+    });
+
+    it('should sanitize the activity content if a sanitizeContent function is provided', async () => {
+        const actor = {
+            getOutbox: vi.fn().mockResolvedValue({
+                getFirst: vi.fn().mockResolvedValue({
+                    getItems: vi.fn().mockImplementation(async function* () {
+                        yield { toJsonLd: vi.fn().mockResolvedValue({ content: '<script>alert("XSS")</script>' }) };
+                    })
+                })
+            })
+        } as unknown as Actor;
+
+        expect(
+            await getRecentActivities(actor, {
+                sanitizeContent: (content) => content
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+            })
+        ).toEqual([{ content: '&lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;' }]);
+    });
+});
+
+describe('isFollowing', () => {
+    it('should return a boolean indicating if the current user is following the given actor', async () => {
+        const db = {
+            get: vi.fn().mockResolvedValue([
+                'https://example.com/users/foo',
+                'https://example.com/users/bar',
+                'https://example.com/users/baz'
+            ]),
+        } as unknown as KvStore;
+
+        const followedActor = {
+            id: new URL('https://example.com/users/bar'),
+        } as unknown as Actor;
+
+        const unfollowedActor = {
+            id: new URL('https://example.com/users/qux'),
+        } as unknown as Actor;
+
+        expect(await isFollowing(followedActor, { db })).toBe(true);
+        expect(await isFollowing(unfollowedActor, { db })).toBe(false);
+    });
+
+    it('should return false if the follower list is not available', async () => {
+        const db = {
+            get: vi.fn().mockResolvedValue(null),
+        } as unknown as KvStore;
+
+        const actor = {
+            id: new URL('https://example.com/users/foo'),
+        } as unknown as Actor;
+
+        expect(await isFollowing(actor, { db })).toBe(false);
+    });
+
+    it('should return false if the actor id is not available', async () => {
+        const db = {
+            get: vi.fn().mockResolvedValue([
+                'https://example.com/users/foo',
+                'https://example.com/users/bar',
+                'https://example.com/users/baz'
+            ]),
+        } as unknown as KvStore;
+
+        const actor = {
+            id: null,
+        } as unknown as Actor;
+
+        expect(await isFollowing(actor, { db })).toBe(false);
+    });
+});
+
+describe('isHandle', () => {
+    it('should return a boolean indicating if the provided string is a handle', () => {
+        expect(isHandle('@foo@example.com')).toBe(true);
+        expect(isHandle('@foo@example.com/bar')).toBe(false);
+        expect(isHandle('@foo@example')).toBe(false);
+        expect(isHandle('@example.com')).toBe(false);
+        expect(isHandle('@foo')).toBe(false);
+        expect(isHandle('@@foo')).toBe(false);
+        expect(isHandle('@foo@')).toBe(false);
+        expect(isHandle('@foo@@example.com')).toBe(false);
+    });
+});

--- a/src/helpers/sanitize.ts
+++ b/src/helpers/sanitize.ts
@@ -1,0 +1,15 @@
+import doSanitizeHtml from 'sanitize-html';
+
+export function sanitizeHtml(content: string): string {
+    if (!content) {
+        return content;
+    }
+
+    return doSanitizeHtml(content, {
+        allowedTags: ['a', 'p', 'img', 'br', 'strong', 'em', 'span'],
+        allowedAttributes: {
+            a: ['href'],
+            img: ['src'],
+        }
+    });
+}

--- a/src/helpers/sanitize.unit.test.ts
+++ b/src/helpers/sanitize.unit.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import doSanitizeHtml from 'sanitize-html';
+
+import { sanitizeHtml } from './sanitize';
+
+vi.mock('sanitize-html');
+
+describe('sanitizeHtml', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should return the provided content sanitized of any HTML', () => {
+        const unsanitizedContent = 'unsanitized content';
+        const sanitizedContent = 'sanitized content';
+
+        vi.mocked(doSanitizeHtml).mockReturnValue(sanitizedContent);
+
+        expect(sanitizeHtml(unsanitizedContent)).toEqual(sanitizedContent);
+        expect(doSanitizeHtml).toHaveBeenCalledWith(unsanitizedContent, {
+            allowedTags: ['a', 'p', 'img', 'br', 'strong', 'em', 'span'],
+            allowedAttributes: {
+                a: ['href'],
+                img: ['src'],
+            }
+        });
+    });
+
+    it('should do nothing if content is empty', () => {
+        const content = '';
+
+        expect(sanitizeHtml(content)).toEqual(content);
+        expect(doSanitizeHtml).not.toHaveBeenCalled();
+    });
+});

--- a/src/helpers/uri.ts
+++ b/src/helpers/uri.ts
@@ -1,0 +1,9 @@
+export function isUri(value: string): boolean {
+    try {
+        new URL(value);
+
+        return true;
+    } catch (err) {
+        return false;
+    }
+}

--- a/src/helpers/uri.unit.test.ts
+++ b/src/helpers/uri.unit.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import { isUri } from './uri';
+
+describe('isUri', () => {
+    it('should return a boolean indicating if the provided string is a valid URI', () => {
+        expect(isUri('https://example.com/user/foo')).toBe(true);
+        expect(isUri('http://example.com/user/foo')).toBe(true);
+        expect(isUri('://example.com/user/foo')).toBe(false);
+        expect(isUri('http//example.com/user/foo')).toBe(false);
+    });
+});


### PR DESCRIPTION
refs [AP-352](https://linear.app/tryghost/issue/AP-352/search-for-mastodon-usernames-in-ghost-admin)

Added a new endpoint to enable searching for Fediverse users by their handle or URL