### PR TITLE
Added endpoints for retrieving profile following / followers

### DIFF
--- a/src/api/action/profile/getFollowers.ts
+++ b/src/api/action/profile/getFollowers.ts
@@ -1,0 +1,147 @@
+import { type Context } from 'hono';
+import { Actor, CollectionPage, isActor } from '@fedify/fedify';
+
+import { isFollowing, isHandle } from '../../../helpers/activitypub/actor';
+import { isUri } from '../../../helpers/uri';
+import {
+    type HonoContextVariables,
+    fedify,
+} from '../../../app';
+
+interface ProfileFollowers {
+    followers: {
+        actor: any;
+        isFollowing: boolean;
+    }[];
+    next: string | null;
+}
+
+export async function profileGetFollowersAction(
+    ctx: Context<{ Variables: HonoContextVariables }>,
+) {
+    const db = ctx.get('db');
+    const apCtx = fedify.createContext(ctx.req.raw as Request, {
+        db,
+        globaldb: ctx.get('globaldb'),
+    });
+
+    // Parse "handle" from request parameters
+    // /profile/:handle/followers
+    const handle = ctx.req.param('handle') || '';
+
+    // If the provided handle is invalid, return early
+    if (!isHandle(handle)) {
+        return new Response(JSON.stringify({}), {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            status: 400,
+        });
+    }
+
+    // Parse "next" from query parameters
+    // /profile/:handle/followers?next=<string>
+    const queryNext = ctx.req.query('next') || '';
+    const next = queryNext ? Buffer.from(queryNext, 'base64url').toString('utf-8') : '';
+
+    // If the next parameter is not a valid URI, return early
+    if (next !== '' && !isUri(next)) {
+        return new Response(JSON.stringify({}), {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            status: 400,
+        });
+    }
+
+    // Lookup actor by handle
+    const actor = await apCtx.lookupObject(handle);
+
+    if (!isActor(actor)) {
+        return new Response(JSON.stringify({}), {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            status: 404,
+        });
+    }
+
+    // Retrieve actor's followers
+    // If a next parameter was provided, use it to retrieve a specific page of
+    // followers. Otherwise, retrieve the first page of followers
+    const result: ProfileFollowers = {
+        followers: [],
+        next: null,
+    };
+
+    let page: CollectionPage | null = null;
+
+    try {
+        if (next !== '') {
+            // Ensure the next parameter is for the same host as the actor. We
+            // do this to prevent blindly passing URIs to lookupObject (i.e next
+            // param has been tampered with)
+            // @TODO: Does this provide enough security? Can the host of the
+            // actor be different to the host of the actor's followers collection?
+            const { host: actorHost } = actor?.id || new URL('');
+            const { host: nextHost } = new URL(next);
+
+            if (actorHost !== nextHost) {
+                return new Response(JSON.stringify({}), {
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    status: 400,
+                });
+            }
+
+            page = await apCtx.lookupObject(next) as CollectionPage | null;
+
+            // Explicitly check that we have a valid page seeming though we
+            // can't be type safe due to lookupObject returning a generic object
+            if (!page?.itemIds) {
+                page = null;
+            }
+        } else {
+            const followers = await actor.getFollowers();
+
+            if (followers) {
+                page = await followers.getFirst();
+            }
+        }
+    } catch (err) {
+        console.error(err);
+    }
+
+    if (!page) {
+        return new Response(JSON.stringify({}), {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            status: 404,
+        });
+    }
+
+    // Return result
+    try {
+        for await (const item of page.getItems()) {
+            result.followers.push({
+                actor: await item.toJsonLd(),
+                isFollowing: await isFollowing(item as Actor, { db }),
+            });
+        }
+    } catch (err) {
+        console.error(err);
+    }
+
+    result.next = page.nextId
+        ? Buffer.from(page.nextId.toString()).toString('base64url')
+        : null;
+
+    return new Response(JSON.stringify(result), {
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        status: 200,
+    });
+}

--- a/src/api/action/profile/getFollowing.ts
+++ b/src/api/action/profile/getFollowing.ts
@@ -1,0 +1,148 @@
+import { type Context } from 'hono';
+import { Actor, CollectionPage, isActor } from '@fedify/fedify';
+
+import { isFollowing, isHandle } from '../../../helpers/activitypub/actor';
+import { isUri } from '../../../helpers/uri';
+import {
+    type HonoContextVariables,
+    fedify,
+} from '../../../app';
+
+interface ProfileFollowing {
+    following: {
+        actor: any;
+        isFollowing: boolean;
+    }[];
+    next: string | null;
+}
+
+export async function profileGetFollowingAction(
+    ctx: Context<{ Variables: HonoContextVariables }>,
+) {
+    const db = ctx.get('db');
+    const apCtx = fedify.createContext(ctx.req.raw as Request, {
+        db,
+        globaldb: ctx.get('globaldb'),
+    });
+
+    // Parse "handle" from request parameters
+    // /profile/:handle/following
+    const handle = ctx.req.param('handle') || '';
+
+    // If the provided handle is invalid, return early
+    if (!isHandle(handle)) {
+        return new Response(JSON.stringify({}), {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            status: 400,
+        });
+    }
+
+    // Parse "next" from query parameters
+    // /profile/:handle/following?next=<string>
+    const queryNext = ctx.req.query('next') || '';
+    const next = queryNext ? Buffer.from(queryNext, 'base64url').toString('utf-8') : '';
+
+    // If the next parameter is not a valid URI, return early
+    if (next !== '' && !isUri(next)) {
+        return new Response(JSON.stringify({}), {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            status: 400,
+        });
+    }
+
+    // Lookup actor by handle
+    const actor = await apCtx.lookupObject(handle);
+
+    if (!isActor(actor)) {
+        return new Response(JSON.stringify({}), {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            status: 404,
+        });
+    }
+
+    // Retrieve actor's following
+    // If a next parameter was provided, use it to retrieve a specific page of
+    // the actor's following. Otherwise, retrieve the first page of the actor's
+    // following
+    const result: ProfileFollowing = {
+        following: [],
+        next: null,
+    };
+
+    let page: CollectionPage | null = null;
+
+    try {
+        if (next !== '') {
+            // Ensure the next parameter is for the same host as the actor. We
+            // do this to prevent blindly passing URIs to lookupObject (i.e next
+            // param has been tampered with)
+            // @TODO: Does this provide enough security? Can the host of the
+            // actor be different to the host of the actor's following collection?
+            const { host: actorHost } = actor?.id || new URL('');
+            const { host: nextHost } = new URL(next);
+
+            if (actorHost !== nextHost) {
+                return new Response(JSON.stringify({}), {
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    status: 400,
+                });
+            }
+
+            page = await apCtx.lookupObject(next) as CollectionPage | null;
+
+            // Explicitly check that we have a valid page seeming though we
+            // can't be type safe due to lookupObject returning a generic object
+            if (!page?.itemIds) {
+                page = null;
+            }
+        } else {
+            const following = await actor.getFollowing();
+
+            if (following) {
+                page = await following.getFirst();
+            }
+        }
+    } catch (err) {
+        console.error(err);
+    }
+
+    if (!page) {
+        return new Response(JSON.stringify({}), {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            status: 404,
+        });
+    }
+
+    // Return result
+    try {
+        for await (const item of page.getItems()) {
+            result.following.push({
+                actor: await item.toJsonLd(),
+                isFollowing: await isFollowing(item as Actor, { db }),
+            });
+        }
+    } catch (err) {
+        console.error(err);
+    }
+
+    result.next = page.nextId
+        ? Buffer.from(page.nextId.toString()).toString('base64url')
+        : null;
+
+    return new Response(JSON.stringify(result), {
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        status: 200,
+    });
+}

--- a/src/api/action/search.ts
+++ b/src/api/action/search.ts
@@ -4,6 +4,7 @@ import { isActor } from '@fedify/fedify';
 import {
     getAttachments,
     getFollowerCount,
+    getFollowingCount,
     getHandle,
     getRecentActivities,
     isFollowing,
@@ -20,6 +21,7 @@ interface ProfileSearchResult {
     actor: any;
     handle: string;
     followerCount: number;
+    followingCount: number;
     isFollowing: boolean;
     posts: any[];
 }
@@ -67,6 +69,7 @@ export async function searchAction(
                 actor: {},
                 handle: '',
                 followerCount: 0,
+                followingCount: 0,
                 isFollowing: false,
                 posts: [],
             };
@@ -79,6 +82,7 @@ export async function searchAction(
             });
             result.handle = getHandle(actor);
             result.followerCount = await getFollowerCount(actor);
+            result.followingCount = await getFollowingCount(actor);
             result.isFollowing = await isFollowing(actor, { db });
             result.posts = await getRecentActivities(actor, {
                 sanitizeContent: (content: string) => sanitizeHtml(content)

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,1 +1,2 @@
 export { searchAction } from './action/search';
+export { profileGetFollowersAction } from './action/profile/getFollowers';

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,2 +1,3 @@
 export { searchAction } from './action/search';
 export { profileGetFollowersAction } from './action/profile/getFollowers';
+export { profileGetFollowingAction } from './action/profile/getFollowing';

--- a/src/app.ts
+++ b/src/app.ts
@@ -58,7 +58,7 @@ import {
     handleAnnounce,
     handleLike
 } from './dispatchers';
-import { searchAction } from './api';
+import { searchAction, profileGetFollowersAction } from './api';
 
 import {
     likeAction,
@@ -414,7 +414,7 @@ app.post('/.ghost/activitypub/actions/like/:id', requireRole(GhostRole.Owner), l
 app.post('/.ghost/activitypub/actions/unlike/:id', requireRole(GhostRole.Owner), unlikeAction);
 app.post('/.ghost/activitypub/actions/reply/:id', requireRole(GhostRole.Owner), replyAction);
 app.get('/.ghost/activitypub/actions/search', requireRole(GhostRole.Owner), searchAction);
-
+app.get('/.ghost/activitypub/profile/:handle/followers', requireRole(GhostRole.Owner), profileGetFollowersAction);
 /** Federation wire up */
 
 app.use(

--- a/src/app.ts
+++ b/src/app.ts
@@ -58,7 +58,11 @@ import {
     handleAnnounce,
     handleLike
 } from './dispatchers';
-import { searchAction, profileGetFollowersAction } from './api';
+import {
+    searchAction,
+    profileGetFollowersAction,
+    profileGetFollowingAction,
+} from './api';
 
 import {
     likeAction,
@@ -415,6 +419,8 @@ app.post('/.ghost/activitypub/actions/unlike/:id', requireRole(GhostRole.Owner),
 app.post('/.ghost/activitypub/actions/reply/:id', requireRole(GhostRole.Owner), replyAction);
 app.get('/.ghost/activitypub/actions/search', requireRole(GhostRole.Owner), searchAction);
 app.get('/.ghost/activitypub/profile/:handle/followers', requireRole(GhostRole.Owner), profileGetFollowersAction);
+app.get('/.ghost/activitypub/profile/:handle/following', requireRole(GhostRole.Owner), profileGetFollowingAction);
+
 /** Federation wire up */
 
 app.use(

--- a/src/helpers/activitypub/actor.ts
+++ b/src/helpers/activitypub/actor.ts
@@ -34,6 +34,12 @@ export async function getFollowerCount(actor: Actor): Promise<number> {
     return followers?.totalItems || 0;
 }
 
+export async function getFollowingCount(actor: Actor): Promise<number> {
+    const following = await actor.getFollowing();
+
+    return following?.totalItems || 0;
+}
+
 export function getHandle(actor: Actor): string {
     const host = actor.id?.host || 'unknown';
 

--- a/src/helpers/activitypub/actor.unit.test.ts
+++ b/src/helpers/activitypub/actor.unit.test.ts
@@ -5,6 +5,7 @@ import { Actor, KvStore, PropertyValue } from '@fedify/fedify';
 import {
     getAttachments,
     getFollowerCount,
+    getFollowingCount,
     getHandle,
     getRecentActivities,
     isFollowing,
@@ -98,6 +99,24 @@ describe('getFollowerCount', () => {
         } as unknown as Actor;
 
         expect(await getFollowerCount(actor)).toBe(0);
+    });
+});
+
+describe('getFollowingCount', () => {
+    it('should return the following count for the actor', async () => {
+        const actor = {
+            getFollowing: vi.fn().mockResolvedValue({ totalItems: 100 })
+        } as unknown as Actor;
+
+        expect(await getFollowingCount(actor)).toBe(100);
+    });
+
+    it('should return 0 if the actor following is not available', async () => {
+        const actor = {
+            getFollowing: vi.fn().mockResolvedValue(null)
+        } as unknown as Actor;
+
+        expect(await getFollowingCount(actor)).toBe(0);
     });
 });
 


### PR DESCRIPTION
refs [AP-442](https://linear.app/tryghost/issue/AP-442/add-dynamic-following-followers-to-search-result-profile), [TryGhost/Ghost#21170](https://github.com/TryGhost/Ghost/pull/21170)

Added endpoints for retrieving profile following / followers