### PR TITLE
Changed following dispatcher to return all types of followers

### DIFF
--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -363,11 +363,11 @@ export async function followingDispatcher(
     console.log('Following Dispatcher');
     const results = (await ctx.data.db.get<string[]>(['following'])) || [];
     console.log(results);
-    let items: Person[] = [];
+    let items: Actor[] = [];
     for (const result of results) {
         try {
             const thing = await lookupActor(ctx, result);
-            if (thing instanceof Person) {
+            if (isActor(thing)) {
                 items.push(thing);
             }
         } catch (err) {


### PR DESCRIPTION
refs [AP-473](https://linear.app/ghost/issue/AP-490/following-does-not-show-all-of-following)

Changed following dispatcher to return all types of followers and not just `Person`