### PR TITLE
Added temporary endpoint to retrieve expanded followers list

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -70,6 +70,7 @@ import {
     likeAction,
     unlikeAction,
     followAction,
+    followersExpandedHandler,
     inboxHandler,
     postPublishedWebhook,
     siteChangedWebhook,
@@ -413,6 +414,7 @@ function requireRole(role: GhostRole) {
 }
 
 app.get('/.ghost/activitypub/inbox/:handle', requireRole(GhostRole.Owner), inboxHandler);
+app.get('/.ghost/activitypub/followers-expanded/:handle', followersExpandedHandler);
 app.get('/.ghost/activitypub/activities/:handle', requireRole(GhostRole.Owner), getActivitiesAction);
 app.post('/.ghost/activitypub/actions/follow/:handle', requireRole(GhostRole.Owner), followAction);
 app.post('/.ghost/activitypub/actions/like/:id', requireRole(GhostRole.Owner), likeAction);


### PR DESCRIPTION
refs [AP-489](https://linear.app/ghost/issue/AP-489/followers-showing-unknown-on-user-profile)

Added temporary endpoint to retrieve expanded followers list as the regular followers endpoint only return the ids of the followers and not the full object (which is required by the client). Once we have a better way to query for this information, we can remove this endpoint.