### PR TITLE
Fixed docker-compose interval period

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,11 @@
-name: Test, Build and Push to Artifact Registry
+name: CI
 
 on:
   push:
 
 jobs:
   build-test-deploy:
+    name: Build, Test and Deploy
     environment: build
     runs-on: ubuntu-latest
     steps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,9 +86,9 @@ services:
       mysql-testing:
         condition: service_healthy
     healthcheck:
-      test: "wget --spider http://0.0.0.0:8083/ping"
-      interval: 300s
-      retries: 3
+      test: "if [ ! -f /tmp/health.txt ]; then touch /tmp/health.txt && wget --spider http://0.0.0.0:8083/ping || exit 1 ; else echo \"healthcheck already executed\"; fi"
+      interval: 1s
+      retries: 120
       start_period: 5s
 
   cucumber-tests:


### PR DESCRIPTION
- interval of 300s means it'll only check every 5 minutes, which is WAY too slow for us
- we can just do with checking every second and increasing the number of retries
- this cuts 5 mins from CI time