### PR TITLE
Removed Docker Buildx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,6 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: ActivityPub Docker meta
         id: activitypub-docker-metadata
         uses: docker/metadata-action@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,7 @@ jobs:
         run: yarn test
 
       - name: "Login to GAR"
+        if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           registry: europe-west4-docker.pkg.dev
@@ -63,6 +64,7 @@ jobs:
           password: ${{ secrets.SERVICE_ACCOUNT_KEY }}
 
       - name: "Push ActivityPub Docker Image"
+        if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -70,6 +72,7 @@ jobs:
           tags: ${{ steps.activitypub-docker-metadata.outputs.tags }}
 
       - name: "Push Migrations Docker Image"
+        if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v6
         with:
           context: migrate


### PR DESCRIPTION
- this is only useful if we want to do multi-arch build and layer caching, but right now, the layer caching is slower than pulling it fresh every time, due to overhead
- this also avoids the delay from the `docker-container` driver having to import the layers into Docker