### PR TITLE
Fixed sending application errors to Sentry

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -439,6 +439,15 @@ app.use(
     ),
 );
 
+// Send errors to Sentry
+app.onError((err, c) => {
+    Sentry.captureException(err);
+    console.error('Error:', err);
+
+    // TODO: should we return a JSON error?
+    return c.text('Internal Server Error', 500);
+});
+
 function forceAcceptHeader(fn: (req: Request) => unknown) {
     return function (request: Request) {
         request.headers.set('accept', 'application/activity+json');


### PR DESCRIPTION
- we didn't hook up any HTTP server middleware to Sentry, so we've been missing some alerts in Sentry
- Hono does have some Sentry middleware, but I'd like to investigate it some more
- for now, we can add an `onError` handler and manually send the error to Sentry