### PR TITLE
Shrunk Docker images by removing Yarn cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /opt/activitypub
 COPY package.json .
 COPY yarn.lock .
 
-RUN yarn
+RUN yarn && \
+    yarn cache clean
 
 COPY tsconfig.json .
 


### PR DESCRIPTION
- we can remove the yarn cache after installing dependencies, which cuts 900MB from the image size