### PR TITLE
Fixed getting exit code from child container

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "db": "docker compose exec mysql mysql -uroot -proot activitypub",
     "fix": "docker compose rm activitypub nginx -sf && docker compose build activitypub nginx",
     "logs": "docker compose logs activitypub -f",
-    "test:cucumber": "docker compose run --rm migrate-testing up && docker compose up cucumber-tests",
+    "test:cucumber": "docker compose run --rm migrate-testing up && docker compose up cucumber-tests --exit-code-from cucumber-tests",
     "test": "docker compose run --rm migrate-testing up && docker compose run --rm activitypub-testing yarn test:all && yarn test:cucumber",
     "test:types": "tsc --noEmit",
     "test:unit": "vitest run --dir src --coverage '.unit.test.ts'",


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C06TE92R3JR/p1730199912121529

- if `cucumber-tests` fails (ie. tests fail), `docker-compose` doesn't set the exit code correctly, so we don't know when the tests fail
- this fixes that by using `--exit-code-from <container>`, which seems to be the recommended way