### PR TITLE
Restricted inbox to following

### DIFF
--- a/features/handle-announce.feature
+++ b/features/handle-announce.feature
@@ -1,20 +1,20 @@
-Feature: Create(Article)
-  We want to handle Create(Article) activities in the Inbox
+Feature: Announce(Note)
+  We want to handle Announce(Note) activities in the Inbox
 
-  Scenario: We recieve a Create(Article) activity from someone we follow
+  Scenario: We recieve a Announce(Note) activity from someone we follow
     Given an Actor "Alice"
     Given we follow "Alice"
     Then the request is accepted
     Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
     And "Alice" sends "Accept" to the Inbox
-    Given a "Create(Article)" Activity "A" by "Alice"
+    Given a "Announce(Note)" Activity "A" by "Alice"
     When "Alice" sends "A" to the Inbox
     Then the request is accepted
     Then "A" is in our Inbox
 
-  Scenario: We recieve a Create(Article) activity from someone we don't follow
+  Scenario: We recieve a Announce(Note) activity from someone we don't follow
     Given an Actor "Alice"
-    Given a "Create(Article)" Activity "A" by "Alice"
+    Given a "Announce(Note)" Activity "A" by "Alice"
     When "Alice" sends "A" to the Inbox
     Then the request is accepted
     Then "A" is not in our Inbox

--- a/features/handle-like.feature
+++ b/features/handle-like.feature
@@ -1,7 +1,7 @@
 Feature: Like(Article)
   We want to handle Like(Article) activities in the Inbox
 
-  Scenario: We recieve a Like(Article) activity from someone we follow
+  Scenario: We recieve a Like(Article) activity from someone
     Given an Actor "Alice"
     And an Actor "Bob"
     And a "Create(Article)" Activity "A" by "Alice"

--- a/features/handle-replies.feature
+++ b/features/handle-replies.feature
@@ -1,0 +1,19 @@
+Feature: Create(Note<inReplyTo>)
+  We want to handle incoming replies to our content and add them to the inbox.
+
+  Scenario: We recieve a Create(Note) in response to our content from someone we don't follow
+    # Setup our article
+    Given a valid "post.published" webhook
+    When it is sent to the webhook endpoint
+    Then the request is accepted
+    Then a "Create(Article)" activity is in the Outbox
+
+    Given the found "Create(Article)" as "ArticleCreate(OurArticle)"
+
+    Given an Actor "Alice"
+    Given a "Note" Object "Reply" by "Alice"
+    And "Reply" is a reply to "OurArticle"
+    And a "Create(Reply)" Activity "A" by "Alice"
+    When "Alice" sends "A" to the Inbox
+    Then the request is accepted
+    Then "A" is in our Inbox

--- a/features/like-activity.feature
+++ b/features/like-activity.feature
@@ -5,6 +5,10 @@ Feature: Liking an object
 
   Scenario: Liking an object that has not been liked before
     Given an Actor "Alice"
+    Given we follow "Alice"
+    Then the request is accepted
+    Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
+    And "Alice" sends "Accept" to the Inbox
     Given a "Create(Note)" Activity "Note" by "Alice"
     When "Alice" sends "Note" to the Inbox
     And we like the object "Note"
@@ -15,6 +19,10 @@ Feature: Liking an object
 
   Scenario: Liking an object that has been liked before
     Given an Actor "Alice"
+    Given we follow "Alice"
+    Then the request is accepted
+    Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
+    And "Alice" sends "Accept" to the Inbox
     Given a "Create(Note)" Activity "Note" by "Alice"
     When "Alice" sends "Note" to the Inbox
     And we like the object "Note"
@@ -24,6 +32,10 @@ Feature: Liking an object
 
   Scenario: Unliking an object that has not been liked before
     Given an Actor "Alice"
+    Given we follow "Alice"
+    Then the request is accepted
+    Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
+    And "Alice" sends "Accept" to the Inbox
     Given a "Create(Note)" Activity "Note" by "Alice"
     When "Alice" sends "Note" to the Inbox
     Then we unlike the object "Note"
@@ -31,6 +43,10 @@ Feature: Liking an object
 
   Scenario: Unliking an object that has been liked before
     Given an Actor "Alice"
+    Given we follow "Alice"
+    Then the request is accepted
+    Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
+    And "Alice" sends "Accept" to the Inbox
     Given a "Create(Note)" Activity "Note" by "Alice"
     When "Alice" sends "Note" to the Inbox
     And we like the object "Note"

--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -354,6 +354,7 @@ AfterAll(async () => {
 
 Before(async () => {
     await externalActivityPub.clearAllRequests();
+    await client('key_value').truncate();
 });
 
 Before(async function () {

--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -493,6 +493,17 @@ Then('the object {string} should not be in the liked collection', async function
     assert(!found);
 });
 
+Given('a {string} Object {string} by {string}', async function (objectType, objectName, actorName) {
+    const actor  = this.actors[actorName];
+    const object = await createObject(objectType, actor);
+
+    this.objects[objectName] = object;
+});
+
+Given('{string} is a reply to {string}', async function (objectA, objectB) {
+    this.objects[objectA].inReplyTo = this.objects[objectB].id;
+});
+
 Given('a {string} Activity {string} by {string}', async function (activityDef, name, actorName) {
     const {activity: activityType, object: objectName} = parseActivityString(activityDef);
     if (!activityType) {
@@ -686,6 +697,15 @@ Then('a {string} activity is in the Outbox', async function (string) {
     assert.ok(found);
 });
 
+Then('the found {string} as {string}', function (foundName, name) {
+    const found = this.found[foundName];
+
+    const {activity, object} = parseActivityString(name);
+
+    this.activities[activity] = found;
+    this.objects[object] = found.object;
+});
+
 Then('the found {string} has property {string}', function (name, prop) {
     const found = this.found[name];
 
@@ -706,6 +726,20 @@ Then('{string} is in our Inbox', async function (activityName) {
     const found = inbox.items.find(item => item.id === activity.id);
 
     assert(found);
+});
+
+Then('{string} is not in our Inbox', async function (activityName) {
+    const response = await fetchActivityPub('http://fake-ghost-activitypub/.ghost/activitypub/inbox/index', {
+        headers: {
+            Accept: 'application/ld+json'
+        }
+    });
+    const inbox = await response.json();
+    const activity = this.activities[activityName];
+
+    const found = inbox.items.find(item => item.id === activity.id);
+
+    assert(!found);
 });
 
 Then('{string} is in our Followers', async function (actorName) {

--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -466,7 +466,7 @@ Then('the object {string} should be in the liked collection', async function (na
     const object = this.objects[name];
 
     // TODO Change this when liked collection is fixed to contain objects not Likes
-    const found = liked.orderedItems.find(item => item.object.id === object.id);
+    const found = (liked.orderedItems || []).find(item => item.object.id === object.id);
 
     assert(found);
 });
@@ -487,7 +487,7 @@ Then('the object {string} should not be in the liked collection', async function
     const object = this.objects[name];
 
     // TODO Change this when liked collection is fixed to contain objects not Likes
-    const found = liked.orderedItems.find(item => item.object.id === object.id);
+    const found = (liked.orderedItems || []).find(item => item.object.id === object.id);
 
     assert(!found);
 });
@@ -675,7 +675,7 @@ Then('a {string} activity is in the Outbox', async function (string) {
         }
     });
     const outbox = await firstPageReponse.json();
-    const found = outbox.orderedItems.find((item) => {
+    const found = (outbox.orderedItems || []).find((item) => {
         return item.type === activity && item.object?.type === object
     });
     if (!this.found) {
@@ -723,7 +723,7 @@ Then('{string} is in our Followers', async function (actorName) {
 
     const actor = this.actors[actorName];
 
-    const found = followers.orderedItems.find(item => item.id === actor.id);
+    const found = (followers.orderedItems || []).find(item => item.id === actor.id);
 
     assert(found);
 });
@@ -742,7 +742,7 @@ Then('{string} is in our Followers once only', async function (actorName) {
     });
     const followers = await firstPageResponse.json();
     const actor = this.actors[actorName];
-    const found = followers.orderedItems.filter(item => item.id === actor.id);
+    const found = (followers.orderedItems || []).filter(item => item.id === actor.id);
 
     assert.equal(found.length, 1);
 });

--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -249,8 +249,14 @@ function generateObject(type) {
     }
 }
 
-async function createObject(type) {
+async function createObject(type, actor) {
     const object = generateObject(type);
+
+    if (!object) {
+        throw new Error(`Cannot create objects of type ${type}`);
+    }
+
+    object.attributedTo = actor.id
 
     const url = new URL(object.id);
 
@@ -492,8 +498,8 @@ Given('a {string} Activity {string} by {string}', async function (activityDef, n
         throw new Error(`could not match ${activityDef} to an activity`);
     }
 
-    const object = this.actors[objectName] ?? this.activities[objectName] ?? this.objects[objectName] ?? await createObject(objectName);
     const actor  = this.actors[actorName];
+    const object = this.actors[objectName] ?? this.activities[objectName] ?? this.objects[objectName] ?? await createObject(objectName, actor);
 
     const activity = await createActivity(activityType, object, actor);
 
@@ -507,8 +513,8 @@ Then('an {string} Activity {string} is created by {string}', async function (act
         throw new Error(`could not match ${activityDef} to an activity`);
     }
 
-    const object = this.actors[objectName] ?? this.activities[objectName] ?? this.objects[objectName] ?? await createObject(objectName);
     const actor  = this.actors[actorName];
+    const object = this.actors[objectName] ?? this.activities[objectName] ?? this.objects[objectName] ?? await createObject(objectName, actor);
 
     const activity = await createActivity(activityType, object, actor);
 

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -224,8 +224,8 @@ export async function handleAnnounce(
 
         if (typeof objectJson === 'object' && objectJson !== null) {
             if ('attributedTo' in objectJson && typeof objectJson.attributedTo === 'string') {
-                const actor = await ctx.data.globaldb.get([objectJson.attributedTo]) ?? await lookupObject(ctx, objectJson.attributedTo)
-                objectJson.attributedTo = await (actor as any)?.toJsonLd();
+                const actor = await lookupActor(ctx, objectJson.attributedTo);
+                objectJson.attributedTo = await actor?.toJsonLd();
             }
         }
 

--- a/src/helpers/user.ts
+++ b/src/helpers/user.ts
@@ -1,7 +1,6 @@
 import {
     type Context,
     Image,
-    type RequestContext,
     exportJwk,
     generateCryptoKeyPair,
     importJwk,
@@ -27,7 +26,7 @@ export type PersonData = {
     url: string;
 };
 
-export async function getUserData(ctx: RequestContext<ContextData>, handle: string) {
+export async function getUserData(ctx: Context<ContextData>, handle: string) {
     const existing = await ctx.data.db.get<PersonData>(['handle', handle]);
 
     if (existing) {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/AP-545

Previously we were adding all incoming messages in our inbox to our inbox, now
we restrict it to only people we're following. We do still store the object in
the global db - but we maybe be able to optimise this in future.

We're only restricting Create and Announce activities at the moment. We expect
to receive Likes from Actors we don't follow, as well as Follow activities too!