### PR TITLE
Implemented thread mechanism for replies

### DIFF
--- a/src/api/action/getActivities.ts
+++ b/src/api/action/getActivities.ts
@@ -4,7 +4,7 @@ import {
     type HonoContextVariables,
     fedify,
 } from '../../app';
-import { getActivityMeta, getRepliesMap } from '../../db';
+import { getActivityMeta } from '../../db';
 import { buildActivity } from '../../helpers/activitypub/activity';
 
 const DEFAULT_LIMIT = 10;
@@ -33,11 +33,6 @@ export async function getActivitiesAction(
     // This is used to include the user's own activities in the results
     // ?includeOwn=<boolean>
     const includeOwn = ctx.req.query('includeOwn') === 'true';
-
-    // Parse "includeReplies" from query parameters
-    // This is used to include nested replies in the results
-    // ?includeReplies=<boolean>
-    const includeReplies = ctx.req.query('includeReplies') === 'true';
 
     // Parse "filter" from query parameters
     // This is used to filter the activities by various criteria
@@ -200,16 +195,10 @@ export async function getActivitiesAction(
 
     const activities = [];
 
-    // If we need to include replies, fetch the replies map based on the paginated
-    // activity refs, which will be utilised when building the activities
-    const repliesMap = includeReplies
-        ? await getRepliesMap(paginatedRefs)
-        : null;
-
     // Build the activities
     for (const ref of paginatedRefs) {
         try {
-            const builtActivity = await buildActivity(ref, globaldb, apCtx, likedRefs, repliesMap, true);
+            const builtActivity = await buildActivity(ref, globaldb, apCtx, likedRefs, true);
 
             if (builtActivity) {
                 activities.push(builtActivity);

--- a/src/api/action/getActivityThread.ts
+++ b/src/api/action/getActivityThread.ts
@@ -1,0 +1,68 @@
+import type { Context } from 'hono';
+
+import {
+    type HonoContextVariables,
+    fedify,
+} from '../../app';
+import { getActivityThreadChildren, getActivityThreadParents } from '../../db';
+import { buildActivity } from '../../helpers/activitypub/activity';
+import { isUri } from '../../helpers/uri';
+
+interface ActivityJsonLd {
+    [key: string]: any;
+}
+
+export async function getActivityThreadAction(
+    ctx: Context<{ Variables: HonoContextVariables }>,
+) {
+    const db = ctx.get('db');
+    const globaldb = ctx.get('globaldb');
+    const logger = ctx.get('logger');
+    const apCtx = fedify.createContext(ctx.req.raw as Request, {db, globaldb, logger});
+
+    // Parse "activity_id" from request parameters
+    // /thread/:activity_id
+    const activityIdParam = ctx.req.param('activity_id')
+    const activityId = activityIdParam ? Buffer.from(activityIdParam, 'base64url').toString('utf-8') : '';
+
+    // If the provided activityId is invalid, return early
+    if (isUri(activityId) === false) {
+        return new Response(null, { status: 400 });
+    }
+
+    const activityJsonLd = await globaldb.get<ActivityJsonLd>([activityId]);
+
+    // If the activity can not be found, return early
+    if (activityJsonLd === undefined) {
+        return new Response(null, { status: 404 });
+    }
+
+    const items: ActivityJsonLd[] = [activityJsonLd];
+
+    // Find children (replies) and append to the thread
+    const children = await getActivityThreadChildren(activityJsonLd.object.id);
+    items.push(...children);
+
+    // Find parent(s) and prepend to the thread
+    const inReplyToId = activityJsonLd.object.inReplyTo?.id ?? activityJsonLd.object.inReplyTo; // inReplyTo can be a string or an object
+    const parents = await getActivityThreadParents(inReplyToId);
+    items.unshift(...parents);
+
+    // Build the activities so that they have all the data expected by the client
+    const likedRefs = (await db.get<string[]>(['liked'])) || [];
+    const builtActivities = await Promise.all(
+        items.map(item =>
+            buildActivity(item.id, globaldb, apCtx, likedRefs, true),
+        ),
+    );
+
+    // Return the response
+    return new Response(JSON.stringify({
+        items: builtActivities,
+    }), {
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        status: 200,
+    });
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,5 @@
 export { getActivitiesAction } from './action/getActivities';
+export { getActivityThreadAction } from './action/getActivityThread';
 export { profileGetAction } from './action/profile/get';
 export { profileGetFollowersAction } from './action/profile/getFollowers';
 export { profileGetFollowingAction } from './action/profile/getFollowing';

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,6 +26,7 @@ import jose from 'node-jose';
 import { behindProxy } from 'x-forwarded-fetch';
 import {
     getActivitiesAction,
+    getActivityThreadAction,
     profileGetAction,
     profileGetFollowersAction,
     profileGetFollowingAction,
@@ -491,6 +492,7 @@ app.get('/.ghost/activitypub/actions/search', requireRole(GhostRole.Owner), sear
 app.get('/.ghost/activitypub/profile/:handle', requireRole(GhostRole.Owner), profileGetAction);
 app.get('/.ghost/activitypub/profile/:handle/followers', requireRole(GhostRole.Owner), profileGetFollowersAction);
 app.get('/.ghost/activitypub/profile/:handle/following', requireRole(GhostRole.Owner), profileGetFollowingAction);
+app.get('/.ghost/activitypub/thread/:activity_id', getActivityThreadAction);
 
 /** Federation wire up */
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -12,12 +12,6 @@ export const client = Knex({
     },
 });
 
-// Helper function to get the meta data for an array of activity URIs
-// from the database. This allows us to fetch information about the activities
-// without having to fetch the full activity object. This is a bit of a hack to
-// support sorting / filtering of the activities and should be replaced when we
-// have a proper db schema
-
 type ActivityMeta = {
     id: number; // Used for sorting
     actor_id: string; // Used for filtering by follower / non-follower status
@@ -60,6 +54,11 @@ export async function getSite(host: string) {
     };
 }
 
+// Helper function to get the meta data for an array of activity URIs
+// from the database. This allows us to fetch information about the activities
+// without having to fetch the full activity object. This is a bit of a hack to
+// support sorting / filtering of the activities and should be replaced when we
+// have a proper db schema
 export async function getActivityMeta(uris: string[]): Promise<Map<string, ActivityMeta>> {
     const results = await client
         .select(
@@ -98,24 +97,53 @@ export async function getActivityMeta(uris: string[]): Promise<Map<string, Activ
     return map;
 }
 
-// Helper function to retrieve a map of replies for an array of activity URIs
-// from the database
-export async function getRepliesMap (uris: string[]): Promise<Map<string, string[]>> {
-    const map = new Map<string, string[]>();
-
+export async function getActivityThreadChildren(id: string) {
     const results = await client
         .select('value')
         .from('key_value')
-        .where(client.raw('JSON_EXTRACT(value, "$.object.inReplyTo") IS NOT NULL'))
-        .whereIn('key', uris.map(uri => `["${uri}"]`));
+        // If inReplyTo is a string
+        .where(client.raw(`JSON_EXTRACT(value, "$.object.inReplyTo") = "${id}"`))
+        // If inReplyTo is an object
+        .orWhere(client.raw(`JSON_EXTRACT(value, "$.object.inReplyTo.id") = "${id}"`));
 
-    for (const {value: result} of results) {
-        const replies = map.get(result.object.inReplyTo) ?? [];
+    return results.map((result) => result.value);
+}
 
-        replies.push(result);
+export async function getActivityThreadParents(activityObjectId: string) {
+    const parents: any[] = [];
 
-        map.set(result.object.inReplyTo, replies);
-    }
+    const getParent = async (objectId: string) => {
+        const result = await client
+            .select('value')
+            .from('key_value')
+            .where(client.raw(`JSON_EXTRACT(value, "$.object.id") = "${objectId}"`));
 
-    return map;
+        if (result.length === 1) {
+            const parent = result[0];
+
+            parents.unshift(parent.value);
+
+            const inReplyToId = parent.value.object.inReplyTo?.id ?? parent.value.object.inReplyTo; // inReplyTo can be a string or an object
+
+            if (inReplyToId) {
+                await getParent(inReplyToId);
+            }
+        }
+    };
+
+    await getParent(activityObjectId);
+
+    return parents;
+}
+
+export async function getActivityReplyCount(activityObjectId: string) {
+    const result = await client
+        .count('* as count')
+        .from('key_value')
+        // If inReplyTo is a string
+        .where(client.raw(`JSON_EXTRACT(value, "$.object.inReplyTo") = "${activityObjectId}"`))
+        // If inReplyTo is an object
+        .orWhere(client.raw(`JSON_EXTRACT(value, "$.object.inReplyTo.id") = "${activityObjectId}"`));
+
+    return result[0].count;
 }

--- a/src/helpers/activitypub/activity.ts
+++ b/src/helpers/activitypub/activity.ts
@@ -6,7 +6,7 @@ import {
 } from '@fedify/fedify';
 
 import type { ContextData } from '../../app';
-import { getActivityReplyCount } from '../../db';
+import { getActivityChildrenCount } from '../../db';
 import { sanitizeHtml } from '../../helpers/sanitize';
 import { lookupActor } from '../../lookup-helpers';
 
@@ -107,7 +107,7 @@ export async function buildActivity(
 
     // Add the reply count to the object, if it is an object
     if (typeof item.object !== 'string') {
-        item.object.replyCount = await getActivityReplyCount(item.object.id);
+        item.object.replyCount = await getActivityChildrenCount(item);
     }
 
     // Return the built item

--- a/src/helpers/activitypub/activity.ts
+++ b/src/helpers/activitypub/activity.ts
@@ -6,6 +6,7 @@ import {
 } from '@fedify/fedify';
 
 import type { ContextData } from '../../app';
+import { getActivityReplyCount } from '../../db';
 import { sanitizeHtml } from '../../helpers/sanitize';
 import { lookupActor } from '../../lookup-helpers';
 
@@ -24,7 +25,6 @@ export async function buildActivity(
     db: KvStore,
     apCtx: Context<ContextData>,
     liked: string[] = [],
-    repliesMap: Map<string, any> | null = null,
     expandInReplyTo = false,
 ): Promise<Activity | null> {
     const item = await db.get<Activity>([uri]);
@@ -41,22 +41,28 @@ export async function buildActivity(
         item.object = await db.get([item.object]) ?? item.object;
     }
 
+    // If the actor associated with the item is a string, it's probably a URI,
+    // so we should look it up
     if (typeof item.actor === 'string') {
         const actor = await lookupActor(apCtx, item.actor);
 
         if (actor) {
             const json = await actor.toJsonLd();
+
             if (typeof json === 'object' && json !== null) {
                 item.actor = json;
             }
         }
     }
 
+    // If the object associated with the item is an object with an attributedTo
+    // property, it's probably a URI, so we should look it up
     if (typeof item.object !== 'string' && typeof item.object.attributedTo === 'string') {
         const actor = await lookupActor(apCtx, item.object.attributedTo);
 
         if (actor) {
             const json = await actor.toJsonLd();
+
             if (typeof json === 'object' && json !== null) {
                 item.object.attributedTo = json;
             }
@@ -90,29 +96,6 @@ export async function buildActivity(
         }
     }
 
-    // If a replies map has been provided, the item is not a string, and the
-    // item has an id, we should nest any replies recursively (which involves
-    // calling this function again for each reply)
-    if (repliesMap && typeof item.object !== 'string' && item.object.id) {
-        item.object.replies = [];
-
-        const replies = repliesMap.get(item.object.id);
-
-        if (replies) {
-            const builtReplies = [];
-
-            for (const reply of replies) {
-                const builtReply = await buildActivity(reply.id, db, apCtx, liked, repliesMap);
-
-                if (builtReply) {
-                    builtReplies.push(builtReply);
-                }
-            }
-
-            item.object.replies = builtReplies;
-        }
-    }
-
     // Expand the inReplyTo object if it is a string and we are expanding inReplyTo
     if (expandInReplyTo && typeof item.object !== 'string' && item.object.inReplyTo) {
         const replyObject = await db.get([item.object.inReplyTo]);
@@ -120,6 +103,11 @@ export async function buildActivity(
         if (replyObject) {
             item.object.inReplyTo = replyObject;
         }
+    }
+
+    // Add the reply count to the object, if it is an object
+    if (typeof item.object !== 'string') {
+        item.object.replyCount = await getActivityReplyCount(item.object.id);
     }
 
     // Return the built item


### PR DESCRIPTION
refs:

- https://linear.app/ghost/issue/AP-439/seeing-parent-post-for-replies
- https://linear.app/ghost/issue/AP-481/reply-ui
- https://linear.app/ghost/issue/AP-482/replies-to-a-post-should-be-visible-when-opening-it

Implemented thread retrieval so that replies can be displayed in a thread by the client. This is done by adding a new endpoint to the API that retrieves the thread of a given activity

The thread returned is an array of activities ordered in chronological order - The first being the root activity and the last being the last reply

This also removes the existing replies implementation as it is no longer needed