### PR TITLE
Optimized migrations image size

### DIFF
--- a/migrate/Dockerfile
+++ b/migrate/Dockerfile
@@ -1,9 +1,10 @@
-FROM debian:bookworm
+FROM debian:bookworm-slim
 
-RUN apt-get update -y
-RUN apt-get install -y curl
-RUN curl -L https://github.com/golang-migrate/migrate/releases/download/v4.17.1/migrate.linux-amd64.tar.gz | tar xvz
-RUN mv migrate /usr/bin/
+RUN apt-get update -y && \
+    apt-get install -y curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl -L https://github.com/golang-migrate/migrate/releases/download/v4.17.1/migrate.linux-amd64.tar.gz | tar xvz && \
+    mv migrate /usr/bin/
 
 COPY bin /usr/local/bin
 


### PR DESCRIPTION
- switched to `bookworm-slim` for smaller initial size
- removed apt cache after we're done with it
- this shrinks the image size by about 100MB and increases `dive` image efficiency to 99%