### PR TITLE
Looked up remote objects with authenticated fetch

### DIFF
--- a/src/api/action/profile/get.ts
+++ b/src/api/action/profile/get.ts
@@ -1,7 +1,6 @@
 import { isActor } from '@fedify/fedify';
 import type { Context } from 'hono';
 
-import { lookupObject } from 'lookup-helpers';
 import {
     type HonoContextVariables,
     fedify,
@@ -16,6 +15,7 @@ import {
     isHandle,
 } from '../../../helpers/activitypub/actor';
 import { sanitizeHtml } from '../../../helpers/sanitize';
+import { lookupObject } from '../../../lookup-helpers';
 
 interface Profile {
     actor: any;

--- a/src/api/action/profile/get.ts
+++ b/src/api/action/profile/get.ts
@@ -1,6 +1,7 @@
 import { isActor } from '@fedify/fedify';
 import type { Context } from 'hono';
 
+import { lookupObject } from 'lookup-helpers';
 import {
     type HonoContextVariables,
     fedify,
@@ -56,7 +57,7 @@ export async function profileGetAction(
     };
 
     try {
-        const actor = await apCtx.lookupObject(handle);
+        const actor = await lookupObject(apCtx, handle);
 
         if (!isActor(actor)) {
             return new Response(null, { status: 404 });

--- a/src/api/action/profile/getFollowers.ts
+++ b/src/api/action/profile/getFollowers.ts
@@ -1,6 +1,7 @@
 import { type Actor, type CollectionPage, isActor } from '@fedify/fedify';
 import type { Context } from 'hono';
 
+import { lookupObject } from 'lookup-helpers';
 import {
     type HonoContextVariables,
     fedify,
@@ -47,7 +48,7 @@ export async function profileGetFollowersAction(
     }
 
     // Lookup actor by handle
-    const actor = await apCtx.lookupObject(handle);
+    const actor = await lookupObject(apCtx, handle);
 
     if (!isActor(actor)) {
         return new Response(null, { status: 404 });
@@ -77,7 +78,7 @@ export async function profileGetFollowersAction(
                 return new Response(null, { status: 400 });
             }
 
-            page = await apCtx.lookupObject(next) as CollectionPage | null;
+            page = await lookupObject(apCtx, next) as CollectionPage | null;
 
             // Explicitly check that we have a valid page seeming though we
             // can't be type safe due to lookupObject returning a generic object

--- a/src/api/action/profile/getFollowers.ts
+++ b/src/api/action/profile/getFollowers.ts
@@ -1,13 +1,13 @@
 import { type Actor, type CollectionPage, isActor } from '@fedify/fedify';
 import type { Context } from 'hono';
 
-import { lookupObject } from 'lookup-helpers';
 import {
     type HonoContextVariables,
     fedify,
 } from '../../../app';
 import { isFollowing, isHandle } from '../../../helpers/activitypub/actor';
 import { isUri } from '../../../helpers/uri';
+import { lookupObject } from '../../../lookup-helpers';
 
 interface ProfileFollowers {
     followers: {

--- a/src/api/action/profile/getFollowing.ts
+++ b/src/api/action/profile/getFollowing.ts
@@ -1,6 +1,7 @@
 import { type Actor, type CollectionPage, isActor } from '@fedify/fedify';
 import type { Context } from 'hono';
 
+import { lookupObject } from 'lookup-helpers';
 import {
     type HonoContextVariables,
     fedify,
@@ -47,7 +48,7 @@ export async function profileGetFollowingAction(
     }
 
     // Lookup actor by handle
-    const actor = await apCtx.lookupObject(handle);
+    const actor = await lookupObject(apCtx, handle);
 
     if (!isActor(actor)) {
         return new Response(null, { status: 404 });
@@ -78,7 +79,7 @@ export async function profileGetFollowingAction(
                 return new Response(null, { status: 400 });
             }
 
-            page = await apCtx.lookupObject(next) as CollectionPage | null;
+            page = await lookupObject(apCtx, next) as CollectionPage | null;
 
             // Explicitly check that we have a valid page seeming though we
             // can't be type safe due to lookupObject returning a generic object

--- a/src/api/action/profile/getFollowing.ts
+++ b/src/api/action/profile/getFollowing.ts
@@ -1,13 +1,13 @@
 import { type Actor, type CollectionPage, isActor } from '@fedify/fedify';
 import type { Context } from 'hono';
 
-import { lookupObject } from 'lookup-helpers';
 import {
     type HonoContextVariables,
     fedify,
 } from '../../../app';
 import { isFollowing, isHandle } from '../../../helpers/activitypub/actor';
 import { isUri } from '../../../helpers/uri';
+import { lookupObject } from '../../../lookup-helpers';
 
 interface ProfileFollowing {
     following: {

--- a/src/api/action/search.ts
+++ b/src/api/action/search.ts
@@ -1,7 +1,6 @@
 import { isActor } from '@fedify/fedify';
 import type { Context } from 'hono';
 
-import { lookupObject } from 'lookup-helpers';
 import {
     type HonoContextVariables,
     fedify,
@@ -17,6 +16,7 @@ import {
 } from '../../helpers/activitypub/actor';
 import { sanitizeHtml } from '../../helpers/sanitize';
 import { isUri } from '../../helpers/uri';
+import { lookupObject } from '../../lookup-helpers';
 
 interface ProfileSearchResult {
     actor: any;

--- a/src/api/action/search.ts
+++ b/src/api/action/search.ts
@@ -1,6 +1,7 @@
 import { isActor } from '@fedify/fedify';
 import type { Context } from 'hono';
 
+import { lookupObject } from 'lookup-helpers';
 import {
     type HonoContextVariables,
     fedify,
@@ -60,9 +61,10 @@ export async function searchAction(
         });
     }
 
+
     // Lookup actor by handle or URI
     try {
-        const actor = await apCtx.lookupObject(query);
+        const actor = await lookupObject(apCtx, query);
 
         if (isActor(actor)) {
             const result: ProfileSearchResult = {

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -29,7 +29,7 @@ import {
 } from './constants';
 import { getUserData, getUserKeypair } from './helpers/user';
 import { addToList } from './kv-helpers';
-import { lookupActor } from './lookup-helpers';
+import { lookupActor, lookupObject } from './lookup-helpers';
 
 export async function actorDispatcher(
     ctx: RequestContext<ContextData>,
@@ -198,7 +198,7 @@ export async function handleAnnounce(
 
     if (!existing) {
         ctx.data.logger.info('Announce object not found in globalDb, performing network lookup');
-        object = await ctx.lookupObject(announce.objectId);
+        object = await lookupObject(ctx, announce.objectId);
     }
 
     // Validate object
@@ -224,7 +224,7 @@ export async function handleAnnounce(
 
         if (typeof objectJson === 'object' && objectJson !== null) {
             if ('attributedTo' in objectJson && typeof objectJson.attributedTo === 'string') {
-                const actor = await ctx.data.globaldb.get([objectJson.attributedTo]) ?? await ctx.lookupObject(objectJson.attributedTo)
+                const actor = await ctx.data.globaldb.get([objectJson.attributedTo]) ?? await lookupObject(ctx, objectJson.attributedTo)
                 objectJson.attributedTo = await (actor as any)?.toJsonLd();
             }
         }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -23,7 +23,7 @@ import { getSiteSettings } from './helpers/ghost';
 import { toURL } from './helpers/uri';
 import type { PersonData } from './helpers/user';
 import { addToList, removeFromList } from './kv-helpers';
-import { lookupActor } from './lookup-helpers';
+import { lookupActor, lookupObject } from './lookup-helpers';
 
 import z from 'zod';
 
@@ -77,7 +77,7 @@ export async function unlikeAction(
         logger: ctx.get('logger'),
     });
 
-    const objectToLike = await apCtx.lookupObject(id);
+    const objectToLike = await lookupObject(apCtx, id);
     if (!objectToLike) {
         return new Response(null, {
             status: 404
@@ -147,7 +147,7 @@ export async function likeAction(
         logger: ctx.get('logger'),
     });
 
-    const objectToLike = await apCtx.lookupObject(id);
+    const objectToLike = await lookupObject(apCtx, id);
     if (!objectToLike) {
         return new Response(null, {
             status: 404
@@ -219,7 +219,7 @@ export async function replyAction(
         logger: ctx.get('logger'),
     });
 
-    const objectToReplyTo = await apCtx.lookupObject(id);
+    const objectToReplyTo = await lookupObject(apCtx, id);
     if (!objectToReplyTo) {
         return new Response(null, {
             status: 404,
@@ -313,7 +313,7 @@ export async function followAction(
         globaldb: ctx.get('globaldb'),
         logger: ctx.get('logger'),
     });
-    const actorToFollow = await apCtx.lookupObject(handle);
+    const actorToFollow = await lookupObject(apCtx, handle);
     if (!isActor(actorToFollow)) {
         // Not Found?
         return new Response(null, {
@@ -347,7 +347,7 @@ export async function followAction(
     const followJson = await follow.toJsonLd();
     ctx.get('globaldb').set([follow.id!.href], followJson);
 
-    apCtx.sendActivity({ handle: ACTOR_DEFAULT_HANDLE }, actorToFollow, follow);
+    await apCtx.sendActivity({ handle: ACTOR_DEFAULT_HANDLE }, actorToFollow, follow);
     return new Response(JSON.stringify(followJson), {
         headers: {
             'Content-Type': 'application/activity+json',

--- a/src/lookup-helpers.ts
+++ b/src/lookup-helpers.ts
@@ -32,3 +32,16 @@ export async function lookupActor(ctx: Context<ContextData>, url: string): Promi
     }
     return null;
 }
+
+export async function lookupObject(ctx: Context<ContextData>, identifier: string | URL) {
+    let documentLoader = null;
+    try {
+        documentLoader = await ctx.getDocumentLoader({identifier: 'index'});
+    } catch (err) {
+        ctx.data.logger.warn("Could not get authenticated document loader for lookupObject");
+    }
+    if (documentLoader === null) {
+        return ctx.lookupObject(identifier);
+    }
+        return ctx.lookupObject(identifier, {documentLoader});
+}


### PR DESCRIPTION
refs https://linear.app/ghost/issue/AP-533

Threads requires authenticated fetch when interacting with their API, which is something we should default to, for now we've added a helper, but this should eventually be opt-out rather than opt-in