### PR TITLE
Added commit metadata to Sentry reports

### DIFF
--- a/src/helpers/request-data.ts
+++ b/src/helpers/request-data.ts
@@ -1,0 +1,14 @@
+/**
+ * Extracts request data from a Request object into the format that
+ * Sentry expects
+ *
+ * @param {Request} req - The request object
+ * @returns {Sentry.PolymorphicRequest}
+ */
+export function getRequestData(req: Request) {
+    return {
+        url: req.url,
+        method: req.method,
+        headers: Object.fromEntries(req.headers.entries()),
+    };
+}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-432/pipe-500-errors-into-slack

- this adds the request metadata to Sentry by coercing it from a Request into a PolymorphicRequest that Sentry expects
- this means we get metadata in Sentry about the request and where it came from