### PR TITLE
Ensured consistent URL encoding in the endpoints

### DIFF
--- a/src/api/action/getActivities.ts
+++ b/src/api/action/getActivities.ts
@@ -27,9 +27,7 @@ export async function getActivitiesAction(
     // ?cursor=<string>
     // ?limit=<number>
     const queryCursor = ctx.req.query('cursor');
-    const cursor = queryCursor
-        ? Buffer.from(queryCursor, 'base64url').toString('utf-8')
-        : null;
+    const cursor = queryCursor ? decodeURIComponent(queryCursor) : null;
     const limit = Number.parseInt(
         ctx.req.query('limit') || DEFAULT_LIMIT.toString(),
         10,
@@ -44,7 +42,7 @@ export async function getActivitiesAction(
     // This is used to filter the activities by various criteria
     // ?filter={type: ['<activityType>', '<activityType>:<objectType>', '<activityType>:<objectType>:<criteria>']}
     const queryFilters = ctx.req.query('filter') || '[]';
-    const filters = JSON.parse(decodeURI(queryFilters));
+    const filters = JSON.parse(decodeURIComponent(queryFilters));
 
     const typeFilters = (filters.type || []).map((filter: string) => {
         const [activityType, objectType = null, criteria = null] =
@@ -207,9 +205,7 @@ export async function getActivitiesAction(
     // Determine the next cursor
     const nextCursor =
         startIndex + paginatedRefs.length < activityRefs.length
-            ? Buffer.from(paginatedRefs[paginatedRefs.length - 1]).toString(
-                  'base64url',
-              )
+            ? encodeURIComponent(paginatedRefs[paginatedRefs.length - 1])
             : null;
 
     // -------------------------------------------------------------------------
@@ -244,7 +240,7 @@ export async function getActivitiesAction(
     return new Response(
         JSON.stringify({
             items: activities,
-            nextCursor,
+            next: nextCursor,
         }),
         {
             headers: {

--- a/src/api/action/getActivityThread.ts
+++ b/src/api/action/getActivityThread.ts
@@ -23,9 +23,9 @@ export async function getActivityThreadAction(
 
     // Parse "activity_id" from request parameters
     // /thread/:activity_id
-    const activityIdParam = ctx.req.param('activity_id');
-    const activityId = activityIdParam
-        ? Buffer.from(activityIdParam, 'base64url').toString('utf-8')
+    const paramActivityId = ctx.req.param('activity_id');
+    const activityId = paramActivityId
+        ? decodeURIComponent(paramActivityId)
         : '';
 
     // If the provided activityId is invalid, return early

--- a/src/api/action/profile/getFollowers.ts
+++ b/src/api/action/profile/getFollowers.ts
@@ -37,9 +37,7 @@ export async function profileGetFollowersAction(
     // Parse "next" from query parameters
     // /profile/:handle/followers?next=<string>
     const queryNext = ctx.req.query('next') || '';
-    const next = queryNext
-        ? Buffer.from(queryNext, 'base64url').toString('utf-8')
-        : '';
+    const next = queryNext ? decodeURIComponent(queryNext) : '';
 
     // If the next parameter is not a valid URI, return early
     if (next !== '' && !isUri(next)) {
@@ -112,7 +110,7 @@ export async function profileGetFollowersAction(
     }
 
     result.next = page.nextId
-        ? Buffer.from(page.nextId.toString()).toString('base64url')
+        ? encodeURIComponent(page.nextId.toString())
         : null;
 
     return new Response(JSON.stringify(result), {

--- a/src/api/action/profile/getFollowing.ts
+++ b/src/api/action/profile/getFollowing.ts
@@ -37,9 +37,7 @@ export async function profileGetFollowingAction(
     // Parse "next" from query parameters
     // /profile/:handle/following?next=<string>
     const queryNext = ctx.req.query('next') || '';
-    const next = queryNext
-        ? Buffer.from(queryNext, 'base64url').toString('utf-8')
-        : '';
+    const next = queryNext ? decodeURIComponent(queryNext) : '';
 
     // If the next parameter is not a valid URI, return early
     if (next !== '' && !isUri(next)) {
@@ -113,7 +111,7 @@ export async function profileGetFollowingAction(
     }
 
     result.next = page.nextId
-        ? Buffer.from(page.nextId.toString()).toString('base64url')
+        ? encodeURIComponent(page.nextId.toString())
         : null;
 
     return new Response(JSON.stringify(result), {

--- a/src/api/action/search.ts
+++ b/src/api/action/search.ts
@@ -41,7 +41,8 @@ export async function searchAction(
 
     // Parse "query" from query parameters
     // ?query=<string>
-    const query = ctx.req.query('query') || '';
+    const queryQuery = ctx.req.query('query');
+    const query = queryQuery ? decodeURIComponent(queryQuery) : '';
 
     // Init search results - At the moment we only support searching for an actor (profile)
     const results: SearchResults = {


### PR DESCRIPTION
no refs

Updated the API endpoints to consistently use the same method of URL encoding ( previously we used `encodeURIComponent` in some places and base64 encoding in others). This change ensures that all endpoints use `encodeURIComponent` to encode URL parameters.

This change also normalises the naming of the `cursor` parameter in the endpoints - `cursor` and `next` are now used consistently across all endpoints