### PR TITLE
Returned followed Actor from follow action

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -387,7 +387,8 @@ export async function followAction(
         actorToFollow,
         follow,
     );
-    return new Response(JSON.stringify(followJson), {
+    // We return the actor because the serialisation of the object property is not working as expected
+    return new Response(JSON.stringify(await actorToFollow.toJsonLd()), {
         headers: {
             'Content-Type': 'application/activity+json',
         },

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -406,7 +406,6 @@ export async function postPublishedWebhook(
     ctx: Context<{ Variables: HonoContextVariables }>,
     next: Next,
 ) {
-    // TODO: Validate webhook with secret
     const data = PostPublishedWebhookSchema.parse(
         (await ctx.req.json()) as unknown,
     );


### PR DESCRIPTION
refs https://linear.app/ghost/issue/AP-523

The `object` property of the Follow activity doesn't contain the same serialised data that a serialised Actor does, which means we can't reuse it in the following collection in the frontend state management. For now we'll return the Actor instead so we can update the frontend without waiting for an Accept