### PR TITLE
Updated `nodeinfo` software version to `0.1.0`

### DIFF
--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -726,7 +726,7 @@ export async function nodeInfoDispatcher(ctx: RequestContext<ContextData>) {
     return {
         software: {
             name: 'ghost',
-            version: { major: 0, minor: 0, patch: 0 },
+            version: { major: 0, minor: 1, patch: 0 },
             homepage: new URL('https://ghost.org/'),
             repository: new URL('https://github.com/TryGhost/Ghost'),
         },

--- a/src/dispatchers.unit.test.ts
+++ b/src/dispatchers.unit.test.ts
@@ -411,7 +411,7 @@ describe('dispatchers', () => {
             expect(result).toEqual({
                 software: {
                     name: 'ghost',
-                    version: { major: 0, minor: 0, patch: 0 },
+                    version: { major: 0, minor: 1, patch: 0 },
                     homepage: new URL('https://ghost.org/'),
                     repository: new URL('https://github.com/TryGhost/Ghost'),
                 },


### PR DESCRIPTION
refs [AP-485](https://linear.app/ghost/issue/AP-485/add-nodeinfo-endpoint)

Updated the `software.version` property to `0.1.0` for the response returned by the `nodeinfo` endpoint to better reflect the current state of the software (currently under development)