### PR TITLE
Switched to using `traceparent` header for tracing

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -308,7 +308,7 @@ app.use(async (ctx, next) => {
     const extra: Record<string, string> = {};
 
     const { traceId, spanId } = getTraceAndSpanId(
-        ctx.req.header('x-cloud-trace-context'),
+        ctx.req.header('traceparent'),
     );
     if (traceId && spanId) {
         extra['logging.googleapis.com/trace'] =

--- a/src/helpers/context-header.ts
+++ b/src/helpers/context-header.ts
@@ -1,16 +1,14 @@
 export function getTraceAndSpanId(traceContext: string | undefined) {
-    // Get the `X-Cloud-Trace-Context` header from the incoming headers
     if (!traceContext) {
         return { traceId: null, spanId: null };
     }
 
-    // Split by "/" to separate TRACE_ID and SPAN_ID
-    const [traceId, spanIdPart] = traceContext.split('/');
+    const parts = traceContext.split('-');
 
-    if (traceId && spanIdPart) {
-        const spanId = spanIdPart.split(';')[0];
-        return { traceId, spanId };
+    if (parts.length !== 4) {
+        return { traceId: null, spanId: null };
     }
 
-    return { traceId: null, spanId: null };
+    const [_a, traceId, spanId, _b] = parts;
+    return { traceId, spanId };
 }


### PR DESCRIPTION
refs https://www.w3.org/TR/trace-context/
refs https://cloud.google.com/trace/docs/trace-context

- this is preferred over `x-cloud-trace-context` as it's a standard and not GCP-specific