### PR TITLE
Added `service.name` attribute to tracing spans

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -306,7 +306,10 @@ app.use(async (ctx, next) => {
         {
             op: 'http.server',
             name: `${ctx.req.method} ${ctx.req.path}`,
-            attributes: extra,
+            attributes: {
+                ...extra,
+                'service.name': 'activitypub',
+            },
         },
         () => {
             return withContext(extra, () => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-555/add-requestdb-tracing-to-activitypub

- this allows us to differentiate parts of the stack easier