### PR TITLE
Added middleware to shortcut nodeinfo endpoint when site not registered

### DIFF
--- a/src/api/action/getActivities.ts
+++ b/src/api/action/getActivities.ts
@@ -152,7 +152,7 @@ export async function getActivitiesAction(
                         // checking that the hostname associated with the reply object
                         // is the same as the hostname of the site. This is not a bullet
                         // proof check, but it's a good enough for now (i think 😅)
-                        const siteHost = ctx.get('site').host;
+                        const siteHost = ctx.get('site')?.host;
                         const { hostname: replyHost } = new URL(
                             meta.reply_object_url,
                         );

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto';
 import Knex from 'knex';
 
 export const client = Knex({
@@ -38,14 +37,8 @@ interface ActivityJsonLd {
 export async function getSite(host: string) {
     const rows = await client.select('*').from('sites').where({ host });
 
-    if (!rows || !rows.length) {
-        const webhook_secret = crypto.randomBytes(32).toString('hex');
-        await client.insert({ host, webhook_secret }).into('sites');
-
-        return {
-            host,
-            webhook_secret,
-        };
+    if (rows.length === 0) {
+        return null;
     }
 
     if (rows.length > 1) {

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -11,7 +11,6 @@ import {
     Like,
     Note,
     Person,
-    type Protocol,
     type Recipient,
     type RequestContext,
     Undo,
@@ -720,22 +719,4 @@ export async function undoDispatcher(
         return null;
     }
     return Undo.fromJsonLd(exists);
-}
-
-export async function nodeInfoDispatcher(ctx: RequestContext<ContextData>) {
-    return {
-        software: {
-            name: 'ghost',
-            version: { major: 0, minor: 1, patch: 0 },
-            homepage: new URL('https://ghost.org/'),
-            repository: new URL('https://github.com/TryGhost/Ghost'),
-        },
-        protocols: ['activitypub'] as Protocol[],
-        openRegistrations: false,
-        usage: {
-            users: {},
-            localPosts: 0,
-            localComments: 0,
-        },
-    };
 }

--- a/src/dispatchers.unit.test.ts
+++ b/src/dispatchers.unit.test.ts
@@ -11,7 +11,6 @@ import {
     actorDispatcher,
     followingDispatcher,
     likedDispatcher,
-    nodeInfoDispatcher,
     outboxDispatcher,
 } from './dispatchers';
 
@@ -401,28 +400,6 @@ describe('dispatchers', () => {
             expect(result.items[0].id.toString()).toEqual(
                 'https://example.com/create/123',
             );
-        });
-    });
-
-    describe('nodeInfoDispatcher', () => {
-        it('returns the node info', async () => {
-            const result = await nodeInfoDispatcher({} as RequestContext<any>);
-
-            expect(result).toEqual({
-                software: {
-                    name: 'ghost',
-                    version: { major: 0, minor: 1, patch: 0 },
-                    homepage: new URL('https://ghost.org/'),
-                    repository: new URL('https://github.com/TryGhost/Ghost'),
-                },
-                protocols: ['activitypub'],
-                openRegistrations: false,
-                usage: {
-                    users: {},
-                    localPosts: 0,
-                    localComments: 0,
-                },
-            });
         });
     });
 });

--- a/src/fedify/nodeinfo.ts
+++ b/src/fedify/nodeinfo.ts
@@ -1,0 +1,36 @@
+import type { Protocol, RequestContext } from '@fedify/fedify';
+import type { Context as HonoContext, Next } from 'hono';
+import type { ContextData, HonoContextVariables } from '../app';
+
+export const NODEINFO_PATH = '/.ghost/activitypub/nodeinfo/2.1';
+
+export async function nodeInfoMiddleware(
+    ctx: HonoContext<{ Variables: HonoContextVariables }>,
+    next: Next,
+) {
+    const site = ctx.get('site');
+
+    if (ctx.req.path === NODEINFO_PATH && !site) {
+        return new Response(null, { status: 404 });
+    }
+
+    return next();
+}
+
+export async function nodeInfoDispatcher(ctx: RequestContext<ContextData>) {
+    return {
+        software: {
+            name: 'ghost',
+            version: { major: 0, minor: 1, patch: 0 },
+            homepage: new URL('https://ghost.org/'),
+            repository: new URL('https://github.com/TryGhost/Ghost'),
+        },
+        protocols: ['activitypub'] as Protocol[],
+        openRegistrations: false,
+        usage: {
+            users: {},
+            localPosts: 0,
+            localComments: 0,
+        },
+    };
+}

--- a/src/fedify/nodeinfo.unit.test.ts
+++ b/src/fedify/nodeinfo.unit.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { RequestContext } from '@fedify/fedify';
+import type { Context as HonoContext } from 'hono';
+
+import type { HonoContextVariables } from '../app';
+
+import {
+    NODEINFO_PATH,
+    nodeInfoDispatcher,
+    nodeInfoMiddleware,
+} from './nodeinfo';
+
+describe('nodeInfo', () => {
+    describe('nodeInfoMiddleware', () => {
+        it('returns 404 if the site is not found', async () => {
+            const ctxGet = vi.fn().mockReturnValue(null);
+
+            const ctx = {
+                get: ctxGet,
+                req: { path: NODEINFO_PATH },
+            } as unknown as HonoContext<{ Variables: HonoContextVariables }>;
+
+            const next = vi.fn();
+
+            const result = await nodeInfoMiddleware(ctx, next);
+
+            expect(result).toBeInstanceOf(Response);
+            expect(result?.status).toBe(404);
+            expect(next).not.toHaveBeenCalled();
+            expect(ctxGet).toHaveBeenCalledWith('site');
+        });
+    });
+
+    describe('nodeInfoDispatcher', () => {
+        it('returns the node info', async () => {
+            const result = await nodeInfoDispatcher({} as RequestContext<any>);
+
+            expect(result).toEqual({
+                software: {
+                    name: 'ghost',
+                    version: { major: 0, minor: 1, patch: 0 },
+                    homepage: new URL('https://ghost.org/'),
+                    repository: new URL('https://github.com/TryGhost/Ghost'),
+                },
+                protocols: ['activitypub'],
+                openRegistrations: false,
+                usage: {
+                    users: {},
+                    localPosts: 0,
+                    localComments: 0,
+                },
+            });
+        });
+    });
+});


### PR DESCRIPTION
refs [AP-485](https://linear.app/ghost/issue/AP-485/add-nodeinfo-endpoint)

Added a middleware to shortcut requests to the nodeinfo endpoint if there is no `site` record for the requesting host. This is to prevent the endpoint from being hit by Ghost(Pro) sites that are not yet using the activitypub feature (as we have a global route set up for `.well-known/nodeinfo` that routes to the ActivityPub service)

This has to be done as a middleware as the `setNodeInfoDispatcher` from Fedify requires the type `NodeInfo` or `Promise<NodeInfo>` to be returned (meaning we cannot just return a 404 response)

This also moves the `nodeInfoDispatcher` to a separate module in an attempt to keep things more organized