### PR TITLE
Fixed port assignment for Pub/Sub emulator

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,7 +154,7 @@ services:
   pubsub-testing:
     image: gcr.io/google.com/cloudsdktool/google-cloud-cli:499.0.0-emulators
     ports:
-      - "8085:8085"
+      - "8086:8085"
     command: gcloud beta emulators pubsub start --host-port=0.0.0.0:8085 --project=activitypub
     healthcheck:
       test: "curl -f http://localhost:8085 || exit 1"


### PR DESCRIPTION
- this mapped port collided with the one for the non-testing emulator, so it caused Docker to complain