### PR TITLE
Added support for configuring log level with env

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -19,12 +19,14 @@ import {
 import { federation } from '@fedify/fedify/x/hono';
 import { serve } from '@hono/node-server';
 import {
+    type LogLevel,
     type LogRecord,
     type Logger,
     configure,
     getAnsiColorFormatter,
     getConsoleSink,
     getLogger,
+    isLogLevel,
     withContext,
 } from '@logtape/logtape';
 import * as Sentry from '@sentry/node';
@@ -91,6 +93,16 @@ import { getRequestData } from './helpers/request-data';
 
 const logging = getLogger(['activitypub']);
 
+function toLogLevel(level: unknown): LogLevel | null {
+    if (typeof level !== 'string') {
+        return null;
+    }
+    if (isLogLevel(level)) {
+        return level;
+    }
+    return null;
+}
+
 await configure({
     contextLocalStorage: new AsyncLocalStorage(),
     sinks: {
@@ -113,8 +125,22 @@ await configure({
     },
     filters: {},
     loggers: [
-        { category: 'activitypub', sinks: ['console'], level: 'info' },
-        { category: 'fedify', sinks: ['console'], level: 'warning' },
+        {
+            category: 'activitypub',
+            sinks: ['console'],
+            level:
+                toLogLevel(process.env.LOG_LEVEL_ACTIVITYPUB) ||
+                toLogLevel(process.env.LOG_LEVEL) ||
+                'info',
+        },
+        {
+            category: 'fedify',
+            sinks: ['console'],
+            level:
+                toLogLevel(process.env.LOG_LEVEL_FEDIFY) ||
+                toLogLevel(process.env.LOG_LEVEL) ||
+                'warning',
+        },
     ],
 });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-551

We are unable to replicate some issues locally and would like to enable more specific logs in production, rather than having to change the hardcoded values we should be able to do this via the enviroment.

This adds support for three new environment variables:

  - `LOG_LEVEL_FEDIFY` sets the log level for internal fedify logs
  - `LOG_LEVEL_ACTIVITYPUB` sets the log level for our logs
  - `LOG_LEVEL` is a fallback if either of the above are not set

If none of these are set we continue to default to the existing hardcoded values.