### PR TITLE
Added workaround for Sentry disabling OTel

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -14,6 +14,11 @@ if (process.env.SENTRY_DSN) {
         dsn: process.env.SENTRY_DSN,
         environment: process.env.NODE_ENV || 'unknown',
         release: process.env.K_REVISION,
+
+        // Enabled sampling but disable default integrations
+        // Without this, OTel won't work, and I'm not sure why
+        defaultIntegrations: false,
+        tracesSampleRate: 1.0,
     });
 }
 


### PR DESCRIPTION
- for some reason, Sentry is disabling OTel unless you enable tracing in Sentry, I don't know why
- to workaround that, we can enable tracing but disable all the integrations