### PR TITLE
Updated query for retrieving thread parents / children

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -125,18 +125,22 @@ export async function getActivityChildren(activity: ActivityJsonLd) {
     const results = await client
         .select('value')
         .from('key_value')
-        // If inReplyTo is a string
-        .where(
-            client.raw(
-                `JSON_EXTRACT(value, "$.object.inReplyTo") = "${objectId}"`,
-            ),
-        )
-        // If inReplyTo is an object
-        .orWhere(
-            client.raw(
-                `JSON_EXTRACT(value, "$.object.inReplyTo.id") = "${objectId}"`,
-            ),
-        );
+        .where(function () {
+            // If inReplyTo is a string
+            this.where(
+                client.raw(
+                    `JSON_EXTRACT(value, "$.object.inReplyTo") = "${objectId}"`,
+                ),
+            );
+
+            // If inReplyTo is an object
+            this.orWhere(
+                client.raw(
+                    `JSON_EXTRACT(value, "$.object.inReplyTo.id") = "${objectId}"`,
+                ),
+            );
+        })
+        .andWhere(client.raw(`JSON_EXTRACT(value, "$.type") = "Create"`));
 
     return results.map((result) => result.value);
 }
@@ -147,18 +151,22 @@ export async function getActivityChildrenCount(activity: ActivityJsonLd) {
     const result = await client
         .count('* as count')
         .from('key_value')
-        // If inReplyTo is a string
-        .where(
-            client.raw(
-                `JSON_EXTRACT(value, "$.object.inReplyTo") = "${objectId}"`,
-            ),
-        )
-        // If inReplyTo is an object
-        .orWhere(
-            client.raw(
-                `JSON_EXTRACT(value, "$.object.inReplyTo.id") = "${objectId}"`,
-            ),
-        );
+        .where(function () {
+            // If inReplyTo is a string
+            this.where(
+                client.raw(
+                    `JSON_EXTRACT(value, "$.object.inReplyTo") = "${objectId}"`,
+                ),
+            );
+
+            // If inReplyTo is an object
+            this.orWhere(
+                client.raw(
+                    `JSON_EXTRACT(value, "$.object.inReplyTo.id") = "${objectId}"`,
+                ),
+            );
+        })
+        .andWhere(client.raw(`JSON_EXTRACT(value, "$.type") = "Create"`));
 
     return result[0].count;
 }
@@ -174,7 +182,8 @@ export async function getActivityParents(activity: ActivityJsonLd) {
                 client.raw(
                     `JSON_EXTRACT(value, "$.object.id") = "${objectId}"`,
                 ),
-            );
+            )
+            .andWhere(client.raw(`JSON_EXTRACT(value, "$.type") = "Create"`));
 
         if (result.length === 1) {
             const parent = result[0];


### PR DESCRIPTION
refs [AP-579](https://linear.app/ghost/issue/AP-579/investigate-parent-post-visibility-issues-in-replies-to-articles)

Updated the query for retrieving thread parents / children so that it takes into account the activity type. This is needed because when we query on the object it is possible for there to be multiple activities with a matching object if the actvity embeds the object (i.e in the case of a `Like` activity). This is important when looking up the immediate parent of an activity (as we only expect there to be 1 parent). Scoping the type of activity should be fine for our use case of "threads" (a list of comments)