### PR TITLE
Increased DB connection pool size

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -10,6 +10,10 @@ export const client = Knex({
         password: process.env.MYSQL_PASSWORD,
         database: process.env.MYSQL_DATABASE,
     },
+    pool: {
+        min: 1,
+        max: 25,
+    },
 });
 
 type ActivityMeta = {


### PR DESCRIPTION
- the default of 10 is too small for this instance and it looks like we're running into stalled requests
- by increasing this, we should be able to get more throughput to the DB, and still stay under the connection limit imposed by Cloud SQL