### PR TITLE
Optimized looking up actors when building activity

### DIFF
--- a/src/helpers/activitypub/activity.ts
+++ b/src/helpers/activitypub/activity.ts
@@ -59,13 +59,18 @@ export async function buildActivity(
         typeof item.object !== 'string' &&
         typeof item.object.attributedTo === 'string'
     ) {
-        const actor = await lookupActor(apCtx, item.object.attributedTo);
+        // Shortcut the lookup if the actor is the same as the item's actor
+        if (item.actor && item.actor.id === item.object.attributedTo) {
+            item.object.attributedTo = item.actor;
+        } else {
+            const actor = await lookupActor(apCtx, item.object.attributedTo);
 
-        if (actor) {
-            const json = await actor.toJsonLd();
+            if (actor) {
+                const json = await actor.toJsonLd();
 
-            if (typeof json === 'object' && json !== null) {
-                item.object.attributedTo = json;
+                if (typeof json === 'object' && json !== null) {
+                    item.object.attributedTo = json;
+                }
             }
         }
     }


### PR DESCRIPTION
- in the case where the actor and the item's actor are the same person, we should avoid the lookup because it can be expensive