### PR TITLE
Fixed `:noReply` filter not filtering replies when retrieving activities

### DIFF
--- a/src/api/action/getActivities.ts
+++ b/src/api/action/getActivities.ts
@@ -63,13 +63,13 @@ export async function getActivitiesAction(
 
     logger.info('Request query = {query}', { query: ctx.req.query() });
     logger.info('Processed query params = {params}', {
-        params: JSON.stringify({
+        params: {
             cursor,
             limit,
             includeOwn,
             typeFilters,
             excludeNonFollowers,
-        }),
+        },
     });
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
no refs

The query for retrieving `activityMeta` needed to be updated to factor in that `inReplyTo` on an object can be a string OR an object