### PR TITLE
Updated CI workflow triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,11 @@
 name: CI
 
 on:
+  workflow_dispatch:
+  pull_request:
   push:
+    branches:
+      - main
 
 jobs:
   lint:


### PR DESCRIPTION
- added `workflow_dispatch` so we can trigger manually
- added `pull_request` so we get CI on PRs
- configured `push` to only run on `main`
- this prevents random (non-PR) branches from being tested, but that's good because it reduces noise