### PR TITLE
Added support for sampled flag on trace contexts

### DIFF
--- a/src/helpers/context-header.ts
+++ b/src/helpers/context-header.ts
@@ -1,14 +1,15 @@
-export function getTraceAndSpanId(traceContext: string | undefined) {
+export function getTraceContext(traceContext: string | undefined) {
     if (!traceContext) {
-        return { traceId: null, spanId: null };
+        return { traceId: null, spanId: null, sampled: null };
     }
 
     const parts = traceContext.split('-');
 
     if (parts.length !== 4) {
-        return { traceId: null, spanId: null };
+        return { traceId: null, spanId: null, sampled: null };
     }
 
-    const [_a, traceId, spanId, _b] = parts;
-    return { traceId, spanId };
+    const [_version, traceId, spanId, flags] = parts;
+    const sampled = (Number.parseInt(flags, 16) & 0x1) === 1;
+    return { traceId, spanId, sampled };
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-603/logging-and-debugging-improvements

- this adds support for the `sampled` / `traceSampled` flag in trace spans, which allows us to propagate whether a span is being sampled or not