### PR TITLE
Ensured scoped kvstore is reinitialised on each incoming message

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -226,12 +226,13 @@ function ensureCorrectContext<B, R>(
         if (!ctx.data.globaldb) {
             ctx.data.globaldb = db;
         }
-        if (!ctx.data.db) {
-            ctx.data.db = scopeKvStore(db, ['sites', host]);
-        }
         if (!ctx.data.logger) {
             ctx.data.logger = logging;
         }
+        // Ensure scoped data / objects are initialised on each execution
+        // of this function - Fedify may reuse the context object across
+        // multiple executions of an inbox listener
+        ctx.data.db = scopeKvStore(db, ['sites', host]);
         return fn(ctx, b);
     };
 }


### PR DESCRIPTION
no refs

When using the message queue in production we was finding that seemingly randomly, activities would be attributed to the the wrong site. We narrowed this down to the fact that the scoped kvstore was not being reinitialised on each incoming message. Fedify reuses contexts when queueing messages so its possible that the already initialised scoped kvstore was being used for a different site. This change ensures that the scoped kvstore gets reinitialised on each incoming message.