### PR TITLE
Fixed loading profiles for actors from wordpress plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "wiremock-captain": "3.5.0"
   },
   "dependencies": {
-    "@fedify/fedify": "1.2.5",
+    "@fedify/fedify": "1.2.6",
     "@google-cloud/opentelemetry-cloud-trace-exporter": "2.4.1",
     "@google-cloud/opentelemetry-cloud-trace-propagator": "0.20.0",
     "@google-cloud/pubsub": "4.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -501,10 +501,10 @@
   resolved "https://registry.yarnpkg.com/@fedify/cli/-/cli-1.2.5.tgz#0be77c59776c3349efed327ad47fdbccae17f249"
   integrity sha512-H7zeegBXdHRsW80fyzpH1Xfe3go9LpQb45YeA0vRRz2aDe/BaY/rHiey6mYqjoS2t6tWvKrncs6sbvmkvXUphw==
 
-"@fedify/fedify@1.2.5":
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/@fedify/fedify/-/fedify-1.2.5.tgz#b1d4f66ae1d038399cea31d6f7ce2f06f5ca35a8"
-  integrity sha512-dNaUWahN+SxMDh56gXM+0j82upDhj7KuT+OVLFjDEc8S7ImH2rsYLUIh0jWIfXhmiMkhSpN35qXcwAXzwTw5CQ==
+"@fedify/fedify@1.2.6":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@fedify/fedify/-/fedify-1.2.6.tgz#b4b02cc264d74c3dfbfbc33d9d4c127c58c16dc6"
+  integrity sha512-q+gcDvOx8wS4nsFg5W7nDfWl/CDfi//tC7drgUiIc0PowY4Nee5X55nL6r+5D5/0Gw/O4KpwsyLIMZCKeBWUig==
   dependencies:
     "@deno/shim-crypto" "~0.3.1"
     "@deno/shim-deno" "~0.18.0"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-597

There was a bug in fedify when loading the outbox for an Actor if the outbox was the type of OrderedCollectionPage. This was causing our code to throw an error when loading their profile as we would fetch their outbox to get the recent activities. This bug was fixed in v1.2.6 of fedify.