### PR TITLE
Deduplicated Nginx config

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -14,5 +14,10 @@ http {
         https https;
     }
 
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $real_scheme;
+
     include /etc/nginx/conf.d/*.conf;
 }

--- a/nginx/server.conf
+++ b/nginx/server.conf
@@ -1,37 +1,17 @@
 server {
     location /.ghost/activitypub {
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $real_scheme;
-
         proxy_pass http://activitypub:8080;
     }
 
     location /.well-known/webfinger {
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $real_scheme;
-
         proxy_pass http://activitypub:8080;
     }
 
     location /.well-known/nodeinfo {
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $real_scheme;
-
         proxy_pass http://activitypub:8080;
     }
 
     location / {
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $real_scheme;
-
         proxy_pass http://host.docker.internal:2368;
     }
 }


### PR DESCRIPTION
- you can set these on the top-level `http` object and they get passed down, which means we can avoid duplication