### PR TITLE
Added ability to run tagged cucumber scenarios

### DIFF
--- a/cucumber.js
+++ b/cucumber.js
@@ -1,1 +1,10 @@
-export default `--format-options '{"snippetInterface": "synchronous"}'`;
+let cmd = `--format-options '{"snippetInterface": "synchronous"}'`;
+
+if (process.env.TAGS) {
+    // @see https://cucumber.io/docs/cucumber/api/?lang=javascript#tags
+    cmd += ` --tags '${process.env.TAGS}'`;
+}
+
+console.log(cmd);
+
+export default cmd;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,6 +149,7 @@ services:
       - MYSQL_PORT=3306
       - MYSQL_DATABASE=activitypub
       - NODE_ENV=testing
+      - TAGS
     command: yarn run cucumber-js
     depends_on:
       fake-ghost-activitypub:

--- a/docker/cucumber-tests
+++ b/docker/cucumber-tests
@@ -1,0 +1,5 @@
+#! /bin/sh
+
+export TAGS=$1
+
+docker compose run --rm migrate-testing up && docker compose up cucumber-tests --exit-code-from cucumber-tests

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "db": "docker compose exec mysql mysql -uroot -proot activitypub",
     "fix": "docker compose down --rmi all activitypub activitypub-testing cucumber-tests nginx",
     "logs": "docker compose logs activitypub -f",
-    "test:cucumber": "docker compose run --rm migrate-testing up && docker compose up cucumber-tests --exit-code-from cucumber-tests",
+    "test:cucumber": "./docker/cucumber-tests",
     "test": "docker compose run --rm migrate-testing up && docker compose run --rm activitypub-testing yarn test:all && yarn test:cucumber",
     "test:types": "tsc --noEmit",
     "test:unit": "vitest run --dir src --coverage '.unit.test.ts'",


### PR DESCRIPTION
no refs

This change allows you to run only tagged scenarios when executing cucumber. This is useful when you want to run only a subset of scenarios

```
yarn test:cucumber '@only'
```

```
yarn test:cucumber '@foo and @bar'
```

```
yarn test:cucumber '@foo or @bar'
```