### PR TITLE
Added support for updating the site actor

### DIFF
--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -414,6 +414,28 @@ BeforeAll(async () => {
             },
         },
     );
+
+    ghostActivityPub.register(
+        {
+            method: 'GET',
+            endpoint: '/ghost/api/admin/site',
+        },
+        {
+            status: 200,
+            body: {
+                settings: {
+                    site: {
+                        title: 'Testing Blog',
+                        icon: 'https://ghost.org/favicon.ico',
+                        description: 'A blog for testing',
+                    },
+                },
+            },
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        },
+    );
 });
 
 AfterAll(async () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -78,6 +78,7 @@ import {
 } from './dispatchers';
 import {
     followAction,
+    getSiteDataHandler,
     inboxHandler,
     likeAction,
     noteAction,
@@ -576,25 +577,7 @@ if (queue instanceof GCloudPubSubPushMessageQueue) {
 app.get(
     '/.ghost/activitypub/site',
     requireRole(GhostRole.Owner),
-    async (ctx) => {
-        const request = ctx.req;
-        const host = request.header('host');
-        if (!host) {
-            ctx.get('logger').info('No Host header');
-            return new Response('No Host header', {
-                status: 401,
-            });
-        }
-
-        const site = await getSite(host, true);
-
-        return new Response(JSON.stringify(site), {
-            status: 200,
-            headers: {
-                'Content-Type': 'application/json',
-            },
-        });
-    },
+    getSiteDataHandler,
 );
 
 app.use(async (ctx, next) => {

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -26,10 +26,10 @@ import { getUserData } from './helpers/user';
 import { addToList, removeFromList } from './kv-helpers';
 import { lookupActor, lookupObject } from './lookup-helpers';
 
-import { getSiteSettings } from './helpers/ghost';
 import z from 'zod';
 import { getSite } from './db';
 import { updateSiteActor } from './helpers/activitypub/actor';
+import { getSiteSettings } from './helpers/ghost';
 
 const PostSchema = z.object({
     uuid: z.string().uuid(),
@@ -570,11 +570,7 @@ export async function getSiteDataHandler(
     // This is to ensure that the actor exists - e.g. for a brand new a site
     await getUserData(apCtx, handle);
 
-    await updateSiteActor(
-        apCtx,
-        getSiteSettings,
-        host,
-    );
+    await updateSiteActor(apCtx, getSiteSettings, host);
 
     return new Response(JSON.stringify(site), {
         status: 200,
@@ -599,11 +595,7 @@ export async function siteChangedWebhook(
             logger,
         });
 
-        await updateSiteActor(
-            apCtx,
-            getSiteSettings,
-            host,
-        );
+        await updateSiteActor(apCtx, getSiteSettings, host);
     } catch (err) {
         ctx.get('logger').error('Site changed webhook failed: {error}', {
             error: err,

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -571,10 +571,7 @@ export async function getSiteDataHandler(
     await getUserData(apCtx, handle);
 
     await updateSiteActor(
-        ctx.get('db'),
-        ctx.get('globaldb'),
         apCtx,
-        ctx.get('logger'),
         getSiteSettings,
         host,
     );
@@ -603,10 +600,7 @@ export async function siteChangedWebhook(
         });
 
         await updateSiteActor(
-            db,
-            globaldb,
             apCtx,
-            logger,
             getSiteSettings,
             host,
         );

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -29,6 +29,7 @@ import { lookupActor, lookupObject } from './lookup-helpers';
 import z from 'zod';
 import { getSite } from './db';
 import { updateSiteActor } from './helpers/activitypub/actor';
+import { getSiteSettings } from 'helpers/ghost';
 
 const PostSchema = z.object({
     uuid: z.string().uuid(),
@@ -574,6 +575,7 @@ export async function getSiteDataHandler(
         ctx.get('globaldb'),
         apCtx,
         ctx.get('logger'),
+        getSiteSettings,
         host,
     );
 
@@ -600,7 +602,7 @@ export async function siteChangedWebhook(
             logger,
         });
 
-        await updateSiteActor(db, globaldb, apCtx, logger, host);
+        await updateSiteActor(db, globaldb, apCtx, logger, getSiteSettings, host);
     } catch (err) {
         ctx.get('logger').error('Site changed webhook failed: {error}', {
             error: err,

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -26,10 +26,10 @@ import { getUserData } from './helpers/user';
 import { addToList, removeFromList } from './kv-helpers';
 import { lookupActor, lookupObject } from './lookup-helpers';
 
+import { getSiteSettings } from './helpers/ghost';
 import z from 'zod';
 import { getSite } from './db';
 import { updateSiteActor } from './helpers/activitypub/actor';
-import { getSiteSettings } from 'helpers/ghost';
 
 const PostSchema = z.object({
     uuid: z.string().uuid(),
@@ -602,7 +602,14 @@ export async function siteChangedWebhook(
             logger,
         });
 
-        await updateSiteActor(db, globaldb, apCtx, logger, getSiteSettings, host);
+        await updateSiteActor(
+            db,
+            globaldb,
+            apCtx,
+            logger,
+            getSiteSettings,
+            host,
+        );
     } catch (err) {
         ctx.get('logger').error('Site changed webhook failed: {error}', {
             error: err,

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -31,6 +31,7 @@ import { lookupActor, lookupObject } from './lookup-helpers';
 
 import type { Logger } from '@logtape/logtape';
 import z from 'zod';
+import { getSite } from './db';
 
 const PostSchema = z.object({
     uuid: z.string().uuid(),
@@ -544,6 +545,28 @@ export async function postPublishedWebhook(
             'Content-Type': 'application/activity+json',
         },
         status: 200,
+    });
+}
+
+export async function getSiteDataHandler(
+    ctx: Context<{ Variables: HonoContextVariables }>,
+) {
+    const request = ctx.req;
+    const host = request.header('host');
+    if (!host) {
+        ctx.get('logger').info('No Host header');
+        return new Response('No Host header', {
+            status: 401,
+        });
+    }
+
+    const site = await getSite(host, true);
+
+    return new Response(JSON.stringify(site), {
+        status: 200,
+        headers: {
+            'Content-Type': 'application/json',
+        },
     });
 }
 

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -570,7 +570,7 @@ export async function getSiteDataHandler(
     // This is to ensure that the actor exists - e.g. for a brand new a site
     await getUserData(apCtx, handle);
 
-    await updateSiteActor(apCtx, getSiteSettings, host);
+    await updateSiteActor(apCtx, getSiteSettings);
 
     return new Response(JSON.stringify(site), {
         status: 200,
@@ -595,7 +595,7 @@ export async function siteChangedWebhook(
             logger,
         });
 
-        await updateSiteActor(apCtx, getSiteSettings, host);
+        await updateSiteActor(apCtx, getSiteSettings);
     } catch (err) {
         ctx.get('logger').error('Site changed webhook failed: {error}', {
             error: err,

--- a/src/helpers/activitypub/actor.ts
+++ b/src/helpers/activitypub/actor.ts
@@ -7,11 +7,10 @@ import {
     type RequestContext,
     Update,
 } from '@fedify/fedify';
-import type { Logger } from '@logtape/logtape';
 import { v4 as uuidv4 } from 'uuid';
 import type { ContextData } from '../../app';
 import { ACTOR_DEFAULT_HANDLE } from '../../constants';
-import { getUserData, setUserData, UserData, type PersonData } from '../user';
+import { type UserData, getUserData, setUserData } from '../user';
 
 interface Attachment {
     name: string;
@@ -95,7 +94,9 @@ export async function updateSiteActor(
         current.name === settings.site.title &&
         current.summary === settings.site.description
     ) {
-        apCtx.data.logger.info('No site settings changed, not updating site actor');
+        apCtx.data.logger.info(
+            'No site settings changed, not updating site actor',
+        );
         return false;
     }
 

--- a/src/helpers/activitypub/actor.ts
+++ b/src/helpers/activitypub/actor.ts
@@ -10,7 +10,6 @@ import type { Logger } from '@logtape/logtape';
 import { v4 as uuidv4 } from 'uuid';
 import type { ContextData } from '../../app';
 import { ACTOR_DEFAULT_HANDLE } from '../../constants';
-import { getSiteSettings } from '../ghost';
 import type { PersonData } from '../user';
 
 interface Attachment {
@@ -76,11 +75,15 @@ export async function isFollowing(
 export function isHandle(handle: string): boolean {
     return /^@([\w-]+)@([\w-]+\.[\w.-]+)$/.test(handle);
 }
+
 export async function updateSiteActor(
     db: KvStore,
     globaldb: KvStore,
     apCtx: RequestContext<ContextData>,
     logger: Logger,
+    getSiteSettings: (
+        host: string,
+    ) => Promise<{ site: { icon: string; title: string; description: string } }>,
     host: string,
 ) {
     const settings = await getSiteSettings(host);

--- a/src/helpers/activitypub/actor.ts
+++ b/src/helpers/activitypub/actor.ts
@@ -81,9 +81,9 @@ export async function updateSiteActor(
     globaldb: KvStore,
     apCtx: RequestContext<ContextData>,
     logger: Logger,
-    getSiteSettings: (
-        host: string,
-    ) => Promise<{ site: { icon: string; title: string; description: string } }>,
+    getSiteSettings: (host: string) => Promise<{
+        site: { icon: string; title: string; description: string };
+    }>,
     host: string,
 ) {
     const settings = await getSiteSettings(host);

--- a/src/helpers/activitypub/actor.ts
+++ b/src/helpers/activitypub/actor.ts
@@ -78,10 +78,7 @@ export function isHandle(handle: string): boolean {
 }
 
 export async function updateSiteActor(
-    db: KvStore,
-    globaldb: KvStore,
     apCtx: RequestContext<ContextData>,
-    logger: Logger,
     getSiteSettings: (host: string) => Promise<{
         site: { icon: string; title: string; description: string };
     }>,
@@ -98,7 +95,7 @@ export async function updateSiteActor(
         current.name === settings.site.title &&
         current.summary === settings.site.description
     ) {
-        logger.info('No site settings changed, not updating site actor');
+        apCtx.data.logger.info('No site settings changed, not updating site actor');
         return false;
     }
 
@@ -109,7 +106,7 @@ export async function updateSiteActor(
     try {
         updated.icon = new Image({ url: new URL(settings.site.icon) });
     } catch (err) {
-        logger.error(
+        apCtx.data.logger.error(
             'Could not create Image from Icon value ({icon}): {error}',
             { icon: settings.site.icon, error: err },
         );
@@ -120,7 +117,7 @@ export async function updateSiteActor(
 
     await setUserData(apCtx, updated, handle);
 
-    logger.info('Site settings changed, will notify followers');
+    apCtx.data.logger.info('Site settings changed, will notify followers');
 
     const actor = await apCtx.getActor(handle);
 
@@ -132,7 +129,7 @@ export async function updateSiteActor(
         cc: apCtx.getFollowersUri('index'),
     });
 
-    await globaldb.set([update.id!.href], await update.toJsonLd());
+    await apCtx.data.globaldb.set([update.id!.href], await update.toJsonLd());
 
     await apCtx.sendActivity({ handle }, 'followers', update, {
         preferSharedInbox: true,

--- a/src/helpers/activitypub/actor.ts
+++ b/src/helpers/activitypub/actor.ts
@@ -81,9 +81,8 @@ export async function updateSiteActor(
     getSiteSettings: (host: string) => Promise<{
         site: { icon: string; title: string; description: string };
     }>,
-    host: string,
 ) {
-    const settings = await getSiteSettings(host);
+    const settings = await getSiteSettings(apCtx.host);
     const handle = ACTOR_DEFAULT_HANDLE;
 
     const current = await getUserData(apCtx, handle);

--- a/src/helpers/activitypub/actor.unit.test.ts
+++ b/src/helpers/activitypub/actor.unit.test.ts
@@ -7,7 +7,6 @@ import {
     type RequestContext,
 } from '@fedify/fedify';
 
-import assert from 'node:assert';
 import type { Logger } from '@logtape/logtape';
 import type { ContextData } from '../../app';
 import {
@@ -312,10 +311,10 @@ describe('updateSiteActor', () => {
 
         const result = await updateSiteActor(apCtx, getSiteSettings, host);
 
-        assert(result === false);
+        expect(result).toBe(false);
     });
 
-    it('Should update the site actor if the site settings have changed', async () => {
+    it('should update the site actor if the site settings have changed', async () => {
         const db = {
             get: vi.fn().mockResolvedValue({
                 id: 'https://example.com/user/1',
@@ -352,6 +351,6 @@ describe('updateSiteActor', () => {
 
         const result = await updateSiteActor(apCtx, getSiteSettings, host);
 
-        assert(result === true);
+        expect(result).toBe(true);
     });
 });

--- a/src/helpers/activitypub/actor.unit.test.ts
+++ b/src/helpers/activitypub/actor.unit.test.ts
@@ -308,11 +308,9 @@ describe('updateSiteActor', () => {
             },
         });
 
-        const host = 'example.com';
-
         const apCtx = mockApContext(db, globaldb);
 
-        const result = await updateSiteActor(apCtx, getSiteSettings, host);
+        const result = await updateSiteActor(apCtx, getSiteSettings);
 
         expect(result).toBe(false);
     });
@@ -338,11 +336,9 @@ describe('updateSiteActor', () => {
             },
         });
 
-        const host = 'example.com';
-
         const apCtx = mockApContext(db, globaldb);
 
-        const result = await updateSiteActor(apCtx, getSiteSettings, host);
+        const result = await updateSiteActor(apCtx, getSiteSettings);
 
         expect(result).toBe(true);
 
@@ -394,11 +390,9 @@ describe('updateSiteActor', () => {
             },
         });
 
-        const host = 'example.com';
-
         const apCtx = mockApContext(db, globaldb);
 
-        const result = await updateSiteActor(apCtx, getSiteSettings, host);
+        const result = await updateSiteActor(apCtx, getSiteSettings);
 
         expect(result).toBe(true);
 

--- a/src/helpers/activitypub/actor.unit.test.ts
+++ b/src/helpers/activitypub/actor.unit.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { type Actor, type KvStore, PropertyValue, RequestContext } from '@fedify/fedify';
+import {
+    type Actor,
+    type KvStore,
+    PropertyValue,
+    type RequestContext,
+} from '@fedify/fedify';
 
+import assert from 'assert';
+import type { Logger } from '@logtape/logtape';
+import type { ContextData } from '../../app';
 import {
     getAttachments,
     getFollowerCount,
@@ -11,9 +19,6 @@ import {
     isHandle,
     updateSiteActor,
 } from './actor';
-import { Logger } from '@logtape/logtape';
-import { ContextData } from '../../app';
-import assert from 'assert';
 
 describe('getAttachments', () => {
     it('should return an array of attachments for the actor', async () => {
@@ -239,12 +244,12 @@ describe('updateSiteActor', () => {
                 name: 'Site Title',
                 summary: 'Site Description',
             }),
-            set: vi.fn()
+            set: vi.fn(),
         } as unknown as KvStore;
 
         const globaldb = {
             get: vi.fn().mockResolvedValue(null),
-            set: vi.fn()
+            set: vi.fn(),
         } as unknown as KvStore;
 
         const getSiteSettings = vi.fn().mockResolvedValue({
@@ -261,7 +266,14 @@ describe('updateSiteActor', () => {
 
         const apCtx = {} as unknown as RequestContext<ContextData>;
 
-        const result = await updateSiteActor(db, globaldb, apCtx, logger, getSiteSettings, host);
+        const result = await updateSiteActor(
+            db,
+            globaldb,
+            apCtx,
+            logger,
+            getSiteSettings,
+            host,
+        );
 
         assert(result === false);
     });
@@ -295,13 +307,24 @@ describe('updateSiteActor', () => {
 
         const apCtx = {
             getActor: vi.fn().mockResolvedValue({}),
-            getObjectUri: vi.fn().mockReturnValue(new URL('https://example.com')),
-            getFollowersUri: vi.fn().mockReturnValue(new URL('https://example.com/followers')),
+            getObjectUri: vi
+                .fn()
+                .mockReturnValue(new URL('https://example.com')),
+            getFollowersUri: vi
+                .fn()
+                .mockReturnValue(new URL('https://example.com/followers')),
             sendActivity: vi.fn(),
         } as unknown as RequestContext<ContextData>;
 
-        const result = await updateSiteActor(db, globaldb, apCtx, logger, getSiteSettings, host);
+        const result = await updateSiteActor(
+            db,
+            globaldb,
+            apCtx,
+            logger,
+            getSiteSettings,
+            host,
+        );
 
         assert(result === true);
-    })
+    });
 });

--- a/src/helpers/activitypub/actor.unit.test.ts
+++ b/src/helpers/activitypub/actor.unit.test.ts
@@ -235,14 +235,16 @@ describe('updateSiteActor', () => {
     it('should return false if the site settings have not changed', async () => {
         const db = {
             get: vi.fn().mockResolvedValue({
-                icon: 'https://example.com/baz.png',
+                icon: 'https://example.com/icon.png',
                 name: 'Site Title',
                 summary: 'Site Description',
             }),
+            set: vi.fn()
         } as unknown as KvStore;
 
         const globaldb = {
             get: vi.fn().mockResolvedValue(null),
+            set: vi.fn()
         } as unknown as KvStore;
 
         const getSiteSettings = vi.fn().mockResolvedValue({
@@ -263,4 +265,43 @@ describe('updateSiteActor', () => {
 
         assert(result === false);
     });
+
+    it('Should update the site actor if the site settings have changed', async () => {
+        const db = {
+            get: vi.fn().mockResolvedValue({
+                icon: 'https://example.com/baz.png',
+                name: 'Site Title',
+                summary: 'Site Description',
+            }),
+            set: vi.fn(),
+        } as unknown as KvStore;
+
+        const globaldb = {
+            get: vi.fn().mockResolvedValue(null),
+            set: vi.fn(),
+        } as unknown as KvStore;
+
+        const getSiteSettings = vi.fn().mockResolvedValue({
+            site: {
+                description: 'New Site Description',
+                title: 'New Site Title',
+                icon: 'https://example.com/icon.png',
+            },
+        });
+
+        const host = 'example.com';
+
+        const logger = console as unknown as Logger;
+
+        const apCtx = {
+            getActor: vi.fn().mockResolvedValue({}),
+            getObjectUri: vi.fn().mockReturnValue(new URL('https://example.com')),
+            getFollowersUri: vi.fn().mockReturnValue(new URL('https://example.com/followers')),
+            sendActivity: vi.fn(),
+        } as unknown as RequestContext<ContextData>;
+
+        const result = await updateSiteActor(db, globaldb, apCtx, logger, getSiteSettings, host);
+
+        assert(result === true);
+    })
 });

--- a/src/helpers/activitypub/actor.unit.test.ts
+++ b/src/helpers/activitypub/actor.unit.test.ts
@@ -237,12 +237,54 @@ describe('isHandle', () => {
 });
 
 describe('updateSiteActor', () => {
+    function mockApContext(db: KvStore, globaldb: KvStore) {
+        return {
+            data: {
+                db,
+                globaldb,
+                logger: console as unknown as Logger,
+            },
+            getActor: vi.fn().mockResolvedValue({}),
+            getInboxUri: vi
+                .fn()
+                .mockReturnValue(new URL('https://example.com/inbox')),
+            getOutboxUri: vi
+                .fn()
+                .mockReturnValue(new URL('https://example.com/outbox')),
+            getLikedUri: vi.fn().mockReturnValue(new URL('https://example.com/liked')),
+            getFollowingUri: vi
+                .fn()
+                .mockReturnValue(new URL('https://example.com/following')),
+            getActorUri: vi.fn().mockReturnValue(new URL('https://example.com/user/1')),
+            getActorKeyPairs: vi.fn().mockReturnValue([
+                {
+                    cryptographicKey: 'abc123',
+                },
+            ]),
+            getObjectUri: vi
+                .fn()
+                .mockReturnValue(new URL('https://example.com')),
+            getFollowersUri: vi
+                .fn()
+                .mockReturnValue(new URL('https://example.com/followers')),
+            sendActivity: vi.fn(),
+        } as unknown as RequestContext<ContextData>;
+    }
+
     it('should return false if the site settings have not changed', async () => {
         const db = {
             get: vi.fn().mockResolvedValue({
-                icon: 'https://example.com/icon.png',
+                id: 'https://example.com/user/1',
                 name: 'Site Title',
                 summary: 'Site Description',
+                preferredUsername: 'index',
+                icon: 'https://example.com/icon.png',
+                inbox: 'https://example.com/inbox',
+                outbox: 'https://example.com/outbox',
+                following: 'https://example.com/following',
+                followers: 'https://example.com/followers',
+                liked: 'https://example.com/liked',
+                url: 'https://example.com',
             }),
             set: vi.fn(),
         } as unknown as KvStore;
@@ -262,15 +304,10 @@ describe('updateSiteActor', () => {
 
         const host = 'example.com';
 
-        const logger = console as unknown as Logger;
-
-        const apCtx = {} as unknown as RequestContext<ContextData>;
+        const apCtx = mockApContext(db, globaldb);
 
         const result = await updateSiteActor(
-            db,
-            globaldb,
             apCtx,
-            logger,
             getSiteSettings,
             host,
         );
@@ -281,9 +318,17 @@ describe('updateSiteActor', () => {
     it('Should update the site actor if the site settings have changed', async () => {
         const db = {
             get: vi.fn().mockResolvedValue({
-                icon: 'https://example.com/baz.png',
+                id: 'https://example.com/user/1',
                 name: 'Site Title',
                 summary: 'Site Description',
+                preferredUsername: 'index',
+                icon: 'https://example.com/icon.png',
+                inbox: 'https://example.com/inbox',
+                outbox: 'https://example.com/outbox',
+                following: 'https://example.com/following',
+                followers: 'https://example.com/followers',
+                liked: 'https://example.com/liked',
+                url: 'https://example.com',
             }),
             set: vi.fn(),
         } as unknown as KvStore;
@@ -303,24 +348,10 @@ describe('updateSiteActor', () => {
 
         const host = 'example.com';
 
-        const logger = console as unknown as Logger;
-
-        const apCtx = {
-            getActor: vi.fn().mockResolvedValue({}),
-            getObjectUri: vi
-                .fn()
-                .mockReturnValue(new URL('https://example.com')),
-            getFollowersUri: vi
-                .fn()
-                .mockReturnValue(new URL('https://example.com/followers')),
-            sendActivity: vi.fn(),
-        } as unknown as RequestContext<ContextData>;
+        const apCtx = mockApContext(db, globaldb);
 
         const result = await updateSiteActor(
-            db,
-            globaldb,
             apCtx,
-            logger,
             getSiteSettings,
             host,
         );

--- a/src/helpers/activitypub/actor.unit.test.ts
+++ b/src/helpers/activitypub/actor.unit.test.ts
@@ -7,7 +7,7 @@ import {
     type RequestContext,
 } from '@fedify/fedify';
 
-import assert from 'assert';
+import assert from 'node:assert';
 import type { Logger } from '@logtape/logtape';
 import type { ContextData } from '../../app';
 import {
@@ -251,11 +251,15 @@ describe('updateSiteActor', () => {
             getOutboxUri: vi
                 .fn()
                 .mockReturnValue(new URL('https://example.com/outbox')),
-            getLikedUri: vi.fn().mockReturnValue(new URL('https://example.com/liked')),
+            getLikedUri: vi
+                .fn()
+                .mockReturnValue(new URL('https://example.com/liked')),
             getFollowingUri: vi
                 .fn()
                 .mockReturnValue(new URL('https://example.com/following')),
-            getActorUri: vi.fn().mockReturnValue(new URL('https://example.com/user/1')),
+            getActorUri: vi
+                .fn()
+                .mockReturnValue(new URL('https://example.com/user/1')),
             getActorKeyPairs: vi.fn().mockReturnValue([
                 {
                     cryptographicKey: 'abc123',
@@ -306,11 +310,7 @@ describe('updateSiteActor', () => {
 
         const apCtx = mockApContext(db, globaldb);
 
-        const result = await updateSiteActor(
-            apCtx,
-            getSiteSettings,
-            host,
-        );
+        const result = await updateSiteActor(apCtx, getSiteSettings, host);
 
         assert(result === false);
     });
@@ -350,11 +350,7 @@ describe('updateSiteActor', () => {
 
         const apCtx = mockApContext(db, globaldb);
 
-        const result = await updateSiteActor(
-            apCtx,
-            getSiteSettings,
-            host,
-        );
+        const result = await updateSiteActor(apCtx, getSiteSettings, host);
 
         assert(result === true);
     });

--- a/src/helpers/user.ts
+++ b/src/helpers/user.ts
@@ -70,24 +70,31 @@ export async function getUserData(
             );
             url = new URL(`https://${ctx.host}`);
         }
-        return {
-            id: new URL(existing.id),
-            name: existing.name,
-            summary: existing.summary,
-            preferredUsername: existing.preferredUsername,
-            icon,
-            inbox: new URL(existing.inbox),
-            outbox: new URL(existing.outbox),
-            following: new URL(existing.following),
-            followers: new URL(existing.followers),
-            liked: existing.liked
-                ? new URL(existing.liked)
-                : ctx.getLikedUri(handle),
-            publicKeys: (await ctx.getActorKeyPairs(handle)).map(
-                (key) => key.cryptographicKey,
-            ),
-            url,
-        };
+        try {
+            return {
+                id: new URL(existing.id),
+                name: existing.name,
+                summary: existing.summary,
+                preferredUsername: existing.preferredUsername,
+                icon,
+                inbox: new URL(existing.inbox),
+                outbox: new URL(existing.outbox),
+                following: new URL(existing.following),
+                followers: new URL(existing.followers),
+                liked: existing.liked
+                    ? new URL(existing.liked)
+                    : ctx.getLikedUri(handle),
+                publicKeys: (await ctx.getActorKeyPairs(handle)).map(
+                    (key) => key.cryptographicKey,
+                ),
+                url,
+            };
+        } catch (err) {
+            ctx.data.logger.error(
+                'Could not create UserData from store value (id: {id}): {error}',
+                { id: existing.id, error: err },
+            );
+        }
     }
 
     const data = {

--- a/src/helpers/user.unit.test.ts
+++ b/src/helpers/user.unit.test.ts
@@ -174,7 +174,7 @@ describe('getUserData', () => {
             name: 'foo',
             summary: 'bar',
             preferredUsername: HANDLE,
-            icon: null,
+            icon: new Image({ url: new URL(ACTOR_DEFAULT_ICON) }),
             inbox: new URL(INBOX_URI),
             outbox: new URL(OUTBOX_URI),
             liked: new URL(LIKED_URI),
@@ -220,7 +220,7 @@ describe('getUserData', () => {
             following: new URL(FOLLOWING_URI),
             followers: new URL(FOLLOWERS_URI),
             publicKeys: ['abc123'],
-            url: null,
+            url: new URL(`https://${ctx.host}`),
         };
 
         expect(ctx.data.db.set).toBeCalledTimes(0);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-592

When we fetch the site data we'll attempt to update the site actor too, this
will ensure that when Ghost boots any changes are propagated to us.

We're handling the sending of the Update activity ourself, and there's room to
remove duplication here. I'd like to think about what pattern we use for this.
Ideally I think a repository would be responsible for this or at least abstract
it.