### PR TITLE
Added handling for `Group` announced `Create` activities

### DIFF
--- a/features/accept-follows.feature
+++ b/features/accept-follows.feature
@@ -1,7 +1,7 @@
 Feature: We automatically accept Follow requests
 
   Scenario: We can be followed
-    Given a Person "Alice"
+    Given an Actor "Person(Alice)"
     Given a "Follow(Us)" Activity "F" by "Alice"
     When "Alice" sends "F" to the Inbox
     And "F" is in our Inbox
@@ -12,7 +12,7 @@ Feature: We automatically accept Follow requests
   Rule: We can be followed multiple times by the same actor, but we only record them once
 
     Example: An actor attempts to follow us multiple times
-        Given a Person "Alice"
+        Given an Actor "Person(Alice)"
         And a "Follow(Us)" Activity "F1" by "Alice"
         And a "Follow(Us)" Activity "F2" by "Alice"
         When "Alice" sends "F1" to the Inbox

--- a/features/accept-follows.feature
+++ b/features/accept-follows.feature
@@ -1,7 +1,7 @@
 Feature: We automatically accept Follow requests
 
   Scenario: We can be followed
-    Given an Actor "Alice"
+    Given a Person "Alice"
     Given a "Follow(Us)" Activity "F" by "Alice"
     When "Alice" sends "F" to the Inbox
     And "F" is in our Inbox
@@ -12,7 +12,7 @@ Feature: We automatically accept Follow requests
   Rule: We can be followed multiple times by the same actor, but we only record them once
 
     Example: An actor attempts to follow us multiple times
-        Given an Actor "Alice"
+        Given a Person "Alice"
         And a "Follow(Us)" Activity "F1" by "Alice"
         And a "Follow(Us)" Activity "F2" by "Alice"
         When "Alice" sends "F1" to the Inbox

--- a/features/create-note.feature
+++ b/features/create-note.feature
@@ -24,8 +24,8 @@ Feature: Creating a note
         And "Note" has the content "<p>Hello<br />World</p>"
 
     Scenario: Created note is sent to followers
-        Given a Person "Alice"
-        And a Person "Bob"
+        Given an Actor "Person(Alice)"
+        And an Actor "Person(Bob)"
         And a "Follow(Us)" Activity "F1" by "Alice"
         And a "Follow(Us)" Activity "F2" by "Bob"
         And "Alice" sends "F1" to the Inbox

--- a/features/create-note.feature
+++ b/features/create-note.feature
@@ -24,8 +24,8 @@ Feature: Creating a note
         And "Note" has the content "<p>Hello<br />World</p>"
 
     Scenario: Created note is sent to followers
-        Given an Actor "Alice"
-        And an Actor "Bob"
+        Given a Person "Alice"
+        And a Person "Bob"
         And a "Follow(Us)" Activity "F1" by "Alice"
         And a "Follow(Us)" Activity "F2" by "Bob"
         And "Alice" sends "F1" to the Inbox

--- a/features/follow-account.feature
+++ b/features/follow-account.feature
@@ -1,7 +1,7 @@
 Feature: Follow accounts from their handle
 
   Scenario: We can follow an account only once
-    Given an Actor "Alice"
+    Given a Person "Alice"
     Given we follow "Alice"
     Then the request is accepted
     Given a "Accept(Follow(Alice))" Activity "A" by "Alice"

--- a/features/follow-account.feature
+++ b/features/follow-account.feature
@@ -1,7 +1,7 @@
 Feature: Follow accounts from their handle
 
   Scenario: We can follow an account only once
-    Given a Person "Alice"
+    Given an Actor "Person(Alice)"
     Given we follow "Alice"
     Then the request is accepted
     Given a "Accept(Follow(Alice))" Activity "A" by "Alice"

--- a/features/handle-announce.feature
+++ b/features/handle-announce.feature
@@ -2,7 +2,7 @@ Feature: Announce(Note)
   We want to handle Announce(Note) activities in the Inbox
 
   Scenario: We recieve a Announce(Note) activity from someone we follow
-    Given a Person "Alice"
+    Given an Actor "Person(Alice)"
     Given we follow "Alice"
     Then the request is accepted
     Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
@@ -14,7 +14,7 @@ Feature: Announce(Note)
     Then "A" is in our Inbox
 
   Scenario: We recieve a Announce(Note) activity from someone we don't follow
-    Given a Person "Alice"
+    Given an Actor "Person(Alice)"
     Given a "Announce(Note)" Activity "A" by "Alice"
     When "Alice" sends "A" to the Inbox
     Then the request is accepted

--- a/features/handle-announce.feature
+++ b/features/handle-announce.feature
@@ -2,7 +2,7 @@ Feature: Announce(Note)
   We want to handle Announce(Note) activities in the Inbox
 
   Scenario: We recieve a Announce(Note) activity from someone we follow
-    Given an Actor "Alice"
+    Given a Person "Alice"
     Given we follow "Alice"
     Then the request is accepted
     Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
@@ -14,7 +14,7 @@ Feature: Announce(Note)
     Then "A" is in our Inbox
 
   Scenario: We recieve a Announce(Note) activity from someone we don't follow
-    Given an Actor "Alice"
+    Given a Person "Alice"
     Given a "Announce(Note)" Activity "A" by "Alice"
     When "Alice" sends "A" to the Inbox
     Then the request is accepted

--- a/features/handle-create-article.feature
+++ b/features/handle-create-article.feature
@@ -2,7 +2,7 @@ Feature: Create(Article)
   We want to handle Create(Article) activities in the Inbox
 
   Scenario: We recieve a Create(Article) activity from someone we follow
-    Given an Actor "Alice"
+    Given a Person "Alice"
     Given we follow "Alice"
     Then the request is accepted
     Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
@@ -14,7 +14,7 @@ Feature: Create(Article)
     Then "A" is in our Inbox
 
   Scenario: We recieve a Create(Article) activity from someone we don't follow
-    Given an Actor "Alice"
+    Given a Person "Alice"
     Given a "Create(Article)" Activity "A" by "Alice"
     When "Alice" sends "A" to the Inbox
     Then the request is accepted

--- a/features/handle-create-article.feature
+++ b/features/handle-create-article.feature
@@ -2,7 +2,7 @@ Feature: Create(Article)
   We want to handle Create(Article) activities in the Inbox
 
   Scenario: We recieve a Create(Article) activity from someone we follow
-    Given a Person "Alice"
+    Given an Actor "Person(Alice)"
     Given we follow "Alice"
     Then the request is accepted
     Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
@@ -14,7 +14,7 @@ Feature: Create(Article)
     Then "A" is in our Inbox
 
   Scenario: We recieve a Create(Article) activity from someone we don't follow
-    Given a Person "Alice"
+    Given an Actor "Person(Alice)"
     Given a "Create(Article)" Activity "A" by "Alice"
     When "Alice" sends "A" to the Inbox
     Then the request is accepted

--- a/features/handle-group-announce.feature
+++ b/features/handle-group-announce.feature
@@ -1,0 +1,14 @@
+Feature: Handling activities announced by a Group
+  Background:
+    Given a Person "Alice"
+    And a Group "Wonderland"
+    And "Alice" is a member of "Wonderland"
+    And we follow "Wonderland"
+    And the request is accepted
+    And a "Accept(Follow(Wonderland))" Activity "Accept" by "Wonderland"
+    And "Wonderland" sends "Accept" to the Inbox
+
+  Scenario: We recieve a Create(Article) activity announced by a Group
+    When a "Create(Article)" Activity "Create" by "Alice"
+    And "Wonderland" announces "Create"
+    Then "Create" is in our Inbox

--- a/features/handle-group-announce.feature
+++ b/features/handle-group-announce.feature
@@ -1,8 +1,7 @@
 Feature: Handling activities announced by a Group
   Background:
-    Given a Person "Alice"
-    And a Group "Wonderland"
-    And "Alice" is a member of "Wonderland"
+    Given an Actor "Person(Alice)"
+    And an Actor "Group(Wonderland)"
     And we follow "Wonderland"
     And the request is accepted
     And a "Accept(Follow(Wonderland))" Activity "Accept" by "Wonderland"
@@ -11,5 +10,17 @@ Feature: Handling activities announced by a Group
 
   Scenario: We recieve a Create(Article) activity announced by a Group
     Given a "Create(Article)" Activity "Create" by "Alice"
-    When "Wonderland" announces "Create"
+    And a "Announce(Create)" Activity "Announce" by "Wonderland"
+    When "Wonderland" sends "Announce" to the Inbox
     Then "Create" is in our Inbox
+    And "Announce" is not in our Inbox
+
+  Scenario: We recieve a Create(Article) activity with a tampered object announced by a Group
+    Given an Actor "Person(Bob)"
+    And a "Note" Object "Spam" by "Bob"
+    And a "Article" Object "Article" by "Alice"
+    And a "Create(Article)" Activity "Create" by "Alice"
+    And "Create" has Object "Spam"
+    And a "Announce(Create)" Activity "Announce" by "Wonderland"
+    When "Wonderland" sends "Announce" to the Inbox
+    Then "Create" is in our Inbox with Object "Article"

--- a/features/handle-group-announce.feature
+++ b/features/handle-group-announce.feature
@@ -7,8 +7,9 @@ Feature: Handling activities announced by a Group
     And the request is accepted
     And a "Accept(Follow(Wonderland))" Activity "Accept" by "Wonderland"
     And "Wonderland" sends "Accept" to the Inbox
+    And "Accept" is in our Inbox
 
   Scenario: We recieve a Create(Article) activity announced by a Group
-    When a "Create(Article)" Activity "Create" by "Alice"
-    And "Wonderland" announces "Create"
+    Given a "Create(Article)" Activity "Create" by "Alice"
+    When "Wonderland" announces "Create"
     Then "Create" is in our Inbox

--- a/features/handle-like.feature
+++ b/features/handle-like.feature
@@ -2,8 +2,8 @@ Feature: Like(Article)
   We want to handle Like(Article) activities in the Inbox
 
   Scenario: We recieve a Like(Article) activity from someone
-    Given a Person "Alice"
-    And a Person "Bob"
+    Given an Actor "Person(Alice)"
+    And an Actor "Person(Bob)"
     And a "Create(Article)" Activity "A" by "Alice"
     And a "Like(A)" Activity "L" by "Bob"
     When "Bob" sends "L" to the Inbox

--- a/features/handle-like.feature
+++ b/features/handle-like.feature
@@ -2,8 +2,8 @@ Feature: Like(Article)
   We want to handle Like(Article) activities in the Inbox
 
   Scenario: We recieve a Like(Article) activity from someone
-    Given an Actor "Alice"
-    And an Actor "Bob"
+    Given a Person "Alice"
+    And a Person "Bob"
     And a "Create(Article)" Activity "A" by "Alice"
     And a "Like(A)" Activity "L" by "Bob"
     When "Bob" sends "L" to the Inbox

--- a/features/handle-replies.feature
+++ b/features/handle-replies.feature
@@ -10,7 +10,7 @@ Feature: Create(Note<inReplyTo>)
 
     Given the found "Create(Article)" as "ArticleCreate(OurArticle)"
 
-    Given an Actor "Alice"
+    Given a Person "Alice"
     Given a "Note" Object "Reply" by "Alice"
     And "Reply" is a reply to "OurArticle"
     And a "Create(Reply)" Activity "A" by "Alice"

--- a/features/handle-replies.feature
+++ b/features/handle-replies.feature
@@ -10,7 +10,7 @@ Feature: Create(Note<inReplyTo>)
 
     Given the found "Create(Article)" as "ArticleCreate(OurArticle)"
 
-    Given a Person "Alice"
+    Given an Actor "Person(Alice)"
     Given a "Note" Object "Reply" by "Alice"
     And "Reply" is a reply to "OurArticle"
     And a "Create(Reply)" Activity "A" by "Alice"

--- a/features/like-activity.feature
+++ b/features/like-activity.feature
@@ -4,7 +4,7 @@ Feature: Liking an object
   So that I can express my approval of the content
 
   Scenario: Liking an object that has not been liked before
-    Given a Person "Alice"
+    Given an Actor "Person(Alice)"
     Given we follow "Alice"
     Then the request is accepted
     Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
@@ -20,7 +20,7 @@ Feature: Liking an object
     And a "Like(Note)" activity is sent to "Alice"
 
   Scenario: Liking an object that has been liked before
-    Given a Person "Alice"
+    Given an Actor "Person(Alice)"
     Given we follow "Alice"
     Then the request is accepted
     Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
@@ -35,7 +35,7 @@ Feature: Liking an object
     Then the request is rejected with a 409
 
   Scenario: Unliking an object that has not been liked before
-    Given a Person "Alice"
+    Given an Actor "Person(Alice)"
     Given we follow "Alice"
     Then the request is accepted
     Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
@@ -48,7 +48,7 @@ Feature: Liking an object
     Then the request is rejected with a 409
 
   Scenario: Unliking an object that has been liked before
-    Given a Person "Alice"
+    Given an Actor "Person(Alice)"
     Given we follow "Alice"
     Then the request is accepted
     Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"

--- a/features/like-activity.feature
+++ b/features/like-activity.feature
@@ -4,7 +4,7 @@ Feature: Liking an object
   So that I can express my approval of the content
 
   Scenario: Liking an object that has not been liked before
-    Given an Actor "Alice"
+    Given a Person "Alice"
     Given we follow "Alice"
     Then the request is accepted
     Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
@@ -20,7 +20,7 @@ Feature: Liking an object
     And a "Like(Note)" activity is sent to "Alice"
 
   Scenario: Liking an object that has been liked before
-    Given an Actor "Alice"
+    Given a Person "Alice"
     Given we follow "Alice"
     Then the request is accepted
     Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
@@ -35,7 +35,7 @@ Feature: Liking an object
     Then the request is rejected with a 409
 
   Scenario: Unliking an object that has not been liked before
-    Given an Actor "Alice"
+    Given a Person "Alice"
     Given we follow "Alice"
     Then the request is accepted
     Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
@@ -48,7 +48,7 @@ Feature: Liking an object
     Then the request is rejected with a 409
 
   Scenario: Unliking an object that has been liked before
-    Given an Actor "Alice"
+    Given a Person "Alice"
     Given we follow "Alice"
     Then the request is accepted
     Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"

--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -21,80 +21,101 @@ import { WireMock } from 'wiremock-captain';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-async function createActivity(activityType, object, actor, remote = true) {
-    if (activityType === 'Follow') {
-        return {
+const ACTOR_TYPE_PERSON = 'Person';
+const ACTOR_TYPE_GROUP = 'Group';
+
+const URL_EXTERNAL_ACTIVITY_PUB = 'http://fake-external-activitypub';
+const URL_GHOST_ACTIVITY_PUB = 'http://fake-ghost-activitypub';
+
+async function createActivity(type, object, actor) {
+    let activity;
+
+    if (type === 'Follow') {
+        activity = {
             '@context': [
                 'https://www.w3.org/ns/activitystreams',
                 'https://w3id.org/security/data-integrity/v1',
             ],
             type: 'Follow',
-            id: `http://fake-external-activitypub/follow/${uuidv4()}`,
+            id: `${URL_EXTERNAL_ACTIVITY_PUB}/follow/${uuidv4()}`,
             to: 'as:Public',
             object: object,
             actor: actor,
         };
     }
 
-    if (activityType === 'Accept') {
-        return {
+    if (type === 'Accept') {
+        activity = {
             '@context': [
                 'https://www.w3.org/ns/activitystreams',
                 'https://w3id.org/security/data-integrity/v1',
             ],
             type: 'Accept',
-            id: `http://fake-external-activitypub/accept/${uuidv4()}`,
+            id: `${URL_EXTERNAL_ACTIVITY_PUB}/accept/${uuidv4()}`,
             to: 'as:Public',
             object: object,
             actor: actor,
         };
     }
 
-    if (activityType === 'Create') {
-        return {
+    if (type === 'Create') {
+        activity = {
             '@context': [
                 'https://www.w3.org/ns/activitystreams',
                 'https://w3id.org/security/data-integrity/v1',
             ],
             type: 'Create',
-            id: `http://fake-external-activitypub/create/${uuidv4()}`,
+            id: `${URL_EXTERNAL_ACTIVITY_PUB}/create/${uuidv4()}`,
             to: 'as:Public',
             object: object,
             actor: actor,
         };
     }
 
-    if (activityType === 'Announce') {
-        return {
+    if (type === 'Announce') {
+        activity = {
             '@context': [
                 'https://www.w3.org/ns/activitystreams',
                 'https://w3id.org/security/data-integrity/v1',
             ],
             type: 'Announce',
-            id: `http://fake-external-activitypub/announce/${uuidv4()}`,
+            id: `${URL_EXTERNAL_ACTIVITY_PUB}/announce/${uuidv4()}`,
             to: 'as:Public',
             object: object,
             actor: actor,
         };
     }
 
-    if (activityType === 'Like') {
-        return {
+    if (type === 'Like') {
+        activity = {
             '@context': [
                 'https://www.w3.org/ns/activitystreams',
                 'https://w3id.org/security/data-integrity/v1',
             ],
             type: 'Like',
-            id: `http://fake-external-activitypub/like/${uuidv4()}`,
+            id: `${URL_EXTERNAL_ACTIVITY_PUB}/like/${uuidv4()}`,
             to: 'as:Public',
             object: object,
             actor: actor,
         };
     }
-}
 
-const ACTOR_TYPE_PERSON = 'Person';
-const ACTOR_TYPE_GROUP = 'Group';
+    externalActivityPub.register(
+        {
+            method: 'GET',
+            endpoint: activity.id.replace(URL_EXTERNAL_ACTIVITY_PUB, ''),
+        },
+        {
+            status: 200,
+            body: activity,
+            headers: {
+                'Content-Type': 'application/activity+json',
+            },
+        },
+    );
+
+    return activity;
+}
 
 async function createActor(
     name,
@@ -350,8 +371,8 @@ BeforeAll(async () => {
 });
 
 BeforeAll(async () => {
-    externalActivityPub = new WireMock('http://fake-external-activitypub');
-    ghostActivityPub = new WireMock('http://fake-ghost-activitypub');
+    externalActivityPub = new WireMock(URL_EXTERNAL_ACTIVITY_PUB);
+    ghostActivityPub = new WireMock(URL_GHOST_ACTIVITY_PUB);
 
     const publicKey = fs.readFileSync(
         resolve(__dirname, '../fixtures/private.key'),


### PR DESCRIPTION
refs [AP-608](https://linear.app/ghost/issue/AP-608/ghost-does-not-work-with-lemmy-or-wordpress)

Added handling for `Group` announced `Create` activities so that these activities are processed by the service. Activities are usually only announced as part of Group federation

See https://codeberg.org/fediverse/fep/src/branch/main/fep/1b12/fep-1b12.md for more details