### PR TITLE
Fixed handling of missing Host and invalid Authorization headers

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -493,8 +493,10 @@ app.use(async (ctx, next) => {
     const request = ctx.req;
     const host = request.header('host');
     if (!host) {
-        // TODO handle
-        throw new Error('No Host header');
+        ctx.get('logger').info('No Host header');
+        return new Response('No Host header', {
+            status: 401,
+        });
     }
     ctx.set('role', GhostRole.Anonymous);
 
@@ -507,7 +509,10 @@ app.use(async (ctx, next) => {
     const [match, token] = authorization.match(/Bearer\s+(.*)$/) || [null];
 
     if (!match) {
-        throw new Error('Invalid Authorization header');
+        ctx.get('logger').info('Invalid Authorization header');
+        return new Response('Invalid Authorization header', {
+            status: 401,
+        });
     }
 
     let protocol = 'https';
@@ -575,8 +580,10 @@ app.get(
         const request = ctx.req;
         const host = request.header('host');
         if (!host) {
-            // TODO handle
-            throw new Error('No Host header');
+            ctx.get('logger').info('No Host header');
+            return new Response('No Host header', {
+                status: 401,
+            });
         }
 
         const site = await getSite(host, true);
@@ -594,8 +601,10 @@ app.use(async (ctx, next) => {
     const request = ctx.req;
     const host = request.header('host');
     if (!host) {
-        // TODO handle
-        throw new Error('No Host header');
+        ctx.get('logger').info('No Host header');
+        return new Response('No Host header', {
+            status: 401,
+        });
     }
 
     const scopedDb = scopeKvStore(db, ['sites', host]);
@@ -603,6 +612,7 @@ app.use(async (ctx, next) => {
     const site = await getSite(host);
 
     if (!site) {
+        ctx.get('logger').info('No site found for {host}', { host });
         return new Response(null, {
             status: 403,
         });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-635/error-invalid-authorization-header

- in the case we aren't passed a valid Authorization header, we currently throw errors
- throwing an error will return in a 500, but we actually want a HTTP 401
- this also changes several other places where we throw errors to return HTTP status codes instead
- also adds logging so we can have visibility on why things are occurring