### PR TITLE
Misc cucumber tweaks

### DIFF
--- a/cucumber.js
+++ b/cucumber.js
@@ -1,10 +1,12 @@
-let cmd = `--format-options '{"snippetInterface": "synchronous"}'`;
+// https://github.com/cucumber/cucumber-js/blob/main/docs/configuration.md
 
-if (process.env.TAGS) {
-    // @see https://cucumber.io/docs/cucumber/api/?lang=javascript#tags
-    cmd += ` --tags '${process.env.TAGS}'`;
-}
-
-console.log(cmd);
-
-export default cmd;
+export default {
+    backtrace: true,
+    format: ['progress'],
+    formatOptions: {
+        snippetInterface: 'synchronous',
+    },
+    failFast: true,
+    // @see https://github.com/cucumber/cucumber-js/blob/main/docs/filtering.md#tags
+    tags: process.env.TAGS,
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,7 +152,7 @@ services:
       - MYSQL_DATABASE=activitypub
       - NODE_ENV=testing
       - TAGS
-    command: yarn run cucumber-js
+    command: /opt/activitypub/node_modules/.bin/cucumber-js
     depends_on:
       fake-ghost-activitypub:
         condition: service_started

--- a/docker/cucumber-tests
+++ b/docker/cucumber-tests
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Export the input provided to the script as the TAGS environment variable. This
+# will then be used by the cucumber-tests container to run only the scenarios
+# matching the provided tags expression
 export TAGS=$1
 
-docker compose run --rm migrate-testing up && docker compose up cucumber-tests --exit-code-from cucumber-tests
+docker compose run --rm migrate-testing up && docker compose run --rm cucumber-tests


### PR DESCRIPTION
no refs

Misc cucumber tweaks:

- Use `docker compose run` instead of `docker compose up` to get a `TTY` for live updating of progress + colorization of output. Also removes the annoying service name prefix from the output (making it easier to copy/paste undefined snippets)
![CleanShot 2024-12-19 at 11 51 29@2x](https://github.com/user-attachments/assets/31c9fc0e-104e-44b0-aa58-bb48814420c6)
- Use `progress` as the formatter so we can see that things are happening
- Use JS based config instead of cmd line args
- Added `failFast` to the config so we can stop on the first failure
- Use `cucumber-js` bin directly to prevent double `yarn run` output at the end of the run