### PR TITLE
Allowed `null` for `html` and `excerpt` on posts

### DIFF
--- a/features/create-article-from-post.feature
+++ b/features/create-article-from-post.feature
@@ -7,6 +7,13 @@ Feature: Deliver Create(Article) activities when a post.published webhook is rec
     Then a "Create(Article)" activity is in the Outbox
     And the found "Create(Article)" has property "object.attributedTo"
 
+  Scenario: We recieve a webhook for the post.published event and the post has no content
+    Given a valid "post.published(no content)" webhook
+    When it is sent to the webhook endpoint
+    Then the request is accepted
+    Then a "Create(Article)" activity is in the Outbox
+    And the found "Create(Article)" has property "object.attributedTo"
+
   Scenario: We recieve a webhook for the post.published event with an old signature
     Given a valid "post.published" webhook
     When it is sent to the webhook endpoint with an old signature

--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -1007,10 +1007,26 @@ const webhooks = {
             },
         },
     },
+    'post.published(no content)': {
+        post: {
+            current: {
+                uuid: '986108d9-3d50-4701-9808-eab62e0885cf',
+                title: 'This is a title.',
+                html: null,
+                feature_image: null,
+                visibility: 'paid',
+                published_at: '1970-01-01T00:00:00.000Z',
+                url: 'http://fake-external-activitypub/post/',
+                excerpt: null,
+            },
+        },
+    },
 };
 
 const endpoints = {
     'post.published':
+        'http://fake-ghost-activitypub/.ghost/activitypub/webhooks/post/published',
+    'post.published(no content)':
         'http://fake-ghost-activitypub/.ghost/activitypub/webhooks/post/published',
 };
 

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -35,8 +35,8 @@ import { getSiteSettings } from './helpers/ghost';
 const PostSchema = z.object({
     uuid: z.string().uuid(),
     title: z.string(),
-    html: z.string(),
-    excerpt: z.string(),
+    html: z.string().nullable(),
+    excerpt: z.string().nullable(),
     feature_image: z.string().url().nullable(),
     published_at: z.string().datetime(),
     url: z.string().url(),


### PR DESCRIPTION
closes https://linear.app/ghost/issue/AP-551

It's possible that posts have `null` for their `html` and `excerpt` properties, and we weren't handling that, resulting in errors!