### PR TITLE
Refactored cucumber webhook scenarios

### DIFF
--- a/features/create-article-from-post.feature
+++ b/features/create-article-from-post.feature
@@ -1,25 +1,28 @@
 Feature: Deliver Create(Article) activities when a post.published webhook is received
 
   Scenario: We recieve a webhook for the post.published event
-    Given a valid "post.published" webhook
+    Given a "post.published" webhook
     When it is sent to the webhook endpoint
     Then the request is accepted
     Then a "Create(Article)" activity is in the Outbox
     And the found "Create(Article)" has property "object.attributedTo"
 
   Scenario: We recieve a webhook for the post.published event and the post has no content
-    Given a valid "post.published(no content)" webhook
+    Given a "post.published" webhook:
+      | property             | value |
+      | post.current.html    | null  |
+      | post.current.excerpt | null  |
     When it is sent to the webhook endpoint
     Then the request is accepted
     Then a "Create(Article)" activity is in the Outbox
     And the found "Create(Article)" has property "object.attributedTo"
 
   Scenario: We recieve a webhook for the post.published event with an old signature
-    Given a valid "post.published" webhook
+    Given a "post.published" webhook
     When it is sent to the webhook endpoint with an old signature
     Then the request is rejected with a 401
 
   Scenario: We recieve a webhook for the post.published event without a signature
-    Given a valid "post.published" webhook
+    Given a "post.published" webhook
     When it is sent to the webhook endpoint without a signature
     Then the request is rejected with a 401

--- a/features/handle-replies.feature
+++ b/features/handle-replies.feature
@@ -3,7 +3,7 @@ Feature: Create(Note<inReplyTo>)
 
   Scenario: We recieve a Create(Note) in response to our content from someone we don't follow
     # Setup our article
-    Given a valid "post.published" webhook
+    Given a "post.published" webhook
     When it is sent to the webhook endpoint
     Then the request is accepted
     Then a "Create(Article)" activity is in the Outbox

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@opentelemetry/resources": "1.29.0",
     "@opentelemetry/sdk-trace-base": "1.29.0",
     "@sentry/node": "8.43.0",
+    "es-toolkit": "^1.31.0",
     "hono": "4.6.10",
     "jsonwebtoken": "9.0.2",
     "knex": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1969,6 +1969,11 @@ es-module-lexer@^1.5.4:
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.5.4.tgz#a8efec3a3da991e60efa6b633a7cad6ab8d26b78"
   integrity sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==
 
+es-toolkit@^1.31.0:
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/es-toolkit/-/es-toolkit-1.31.0.tgz#f4fc1382aea09cb239afa38f3c724a5658ff3163"
+  integrity sha512-vwS0lv/tzjM2/t4aZZRAgN9I9TP0MSkWuvt6By+hEXfG/uLs8yg2S1/ayRXH/x3pinbLgVJYT+eppueg3cM6tg==
+
 es6-promise@^4.2.8:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
@@ -3508,16 +3513,7 @@ string-argv@0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3542,14 +3538,7 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3892,16 +3881,7 @@ wiremock-captain@3.5.0:
   dependencies:
     axios "1.7.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
no refs

Refactored cucumber webhook scenarios:

- Tweaked wording slightly - Removed `valid` as it is superfluous
- Added the ability to define the webhook payload in the scenario (gherkin)
- Added helper to wait for an activity type in the outbox (similar to existing logic for waiting for a known activity in the outbox)
- Made webhook fixture dynamic to avoid unexpected test results