### PR TITLE
Refactor webhook post published handling into a more modular structure

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "ignore": []
+    "ignore": ["**/__snapshots__/**"]
   },
   "formatter": {
     "enabled": true,

--- a/src/activitypub/activity.ts
+++ b/src/activitypub/activity.ts
@@ -1,0 +1,40 @@
+import type { Activity, Actor } from '@fedify/fedify';
+
+import type { FedifyRequestContext } from '../app';
+
+/**
+ * Sends an ActivityPub activity to other Fediverse actors
+ *
+ * @template TActivity Type of activity to send
+ * @template TActor Type of actor to utilise when sending an activity
+ */
+export interface ActivitySender<TActivity, TActor> {
+    /**
+     * Send an activity to the followers of an actor
+     *
+     * @param activity Activity to send
+     * @param actor Actor whose followers will receive the activity
+     */
+    sendActivityToActorFollowers(
+        activity: TActivity,
+        actor: TActor,
+    ): Promise<void>;
+}
+
+/**
+ * ActivitySender implementation using Fedify's RequestContext
+ */
+export class FedifyActivitySender implements ActivitySender<Activity, Actor> {
+    constructor(private readonly fedifyCtx: FedifyRequestContext) {}
+
+    async sendActivityToActorFollowers(activity: Activity, actor: Actor) {
+        await this.fedifyCtx.sendActivity(
+            { handle: String(actor.preferredUsername) },
+            'followers',
+            activity,
+            {
+                preferSharedInbox: true,
+            },
+        );
+    }
+}

--- a/src/activitypub/activity.unit.test.ts
+++ b/src/activitypub/activity.unit.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Activity, Actor } from '@fedify/fedify';
+
+import type { FedifyRequestContext } from '../app';
+
+import { FedifyActivitySender } from './activity';
+
+describe('FedifyActivitySender', () => {
+    describe('sendActivityToActorFollowers', () => {
+        it('should send an Activity to the followers of an Actor', async () => {
+            const handle = 'foo';
+
+            const mockActor = {
+                preferredUsername: handle,
+            } as Actor;
+            const mockActivity = {} as Activity;
+            const mockFedifyCtx = {
+                sendActivity: vi.fn(),
+            } as unknown as FedifyRequestContext;
+
+            const sender = new FedifyActivitySender(mockFedifyCtx);
+
+            await sender.sendActivityToActorFollowers(mockActivity, mockActor);
+
+            expect(mockFedifyCtx.sendActivity).toHaveBeenCalledWith(
+                { handle },
+                'followers',
+                mockActivity,
+                {
+                    preferSharedInbox: true,
+                },
+            );
+        });
+    });
+});

--- a/src/activitypub/actor.ts
+++ b/src/activitypub/actor.ts
@@ -1,0 +1,28 @@
+import type { Actor } from '@fedify/fedify';
+
+import type { FedifyRequestContext } from '../app';
+
+/**
+ * Resolves an ActivityPub actor
+ *
+ * @template TActor Type of actor to resolve
+ */
+export interface ActorResolver<TActor> {
+    /**
+     * Resolve an ActivityPub actor by their handle
+     *
+     * @param handle Handle of the actor to resolve
+     */
+    resolveActorByHandle(handle: string): Promise<TActor | null>;
+}
+
+/**
+ * ActorResolver implementation using Fedify's RequestContext
+ */
+export class FedifyActorResolver implements ActorResolver<Actor> {
+    constructor(private readonly fedifyCtx: FedifyRequestContext) {}
+
+    async resolveActorByHandle(handle: string) {
+        return this.fedifyCtx.getActor(handle);
+    }
+}

--- a/src/activitypub/actor.unit.test.ts
+++ b/src/activitypub/actor.unit.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Actor } from '@fedify/fedify';
+
+import type { FedifyRequestContext } from '../app';
+
+import { FedifyActorResolver } from './actor';
+
+describe('FedifyActorResolver', () => {
+    describe('resolveActorByHandle', () => {
+        it('should resolve an actor by handle', async () => {
+            const handle = 'foo';
+
+            const mockActor = {} as Actor;
+
+            const mockFedifyCtx = {
+                getActor: vi.fn().mockImplementation((identifier) => {
+                    if (identifier === handle) {
+                        return mockActor;
+                    }
+
+                    return null;
+                }),
+            } as unknown as FedifyRequestContext;
+
+            const resolver = new FedifyActorResolver(mockFedifyCtx);
+
+            const result = await resolver.resolveActorByHandle(handle);
+
+            expect(mockFedifyCtx.getActor).toHaveBeenCalledWith(handle);
+            expect(result).toBe(mockActor);
+        });
+
+        it('should return null if the actor can not be resolved', async () => {
+            const handle = 'foo';
+
+            const mockFedifyCtx = {
+                getActor: vi.fn().mockImplementation(() => {
+                    return null;
+                }),
+            } as unknown as FedifyRequestContext;
+
+            const resolver = new FedifyActorResolver(mockFedifyCtx);
+
+            const result = await resolver.resolveActorByHandle(handle);
+
+            expect(mockFedifyCtx.getActor).toHaveBeenCalledWith(handle);
+            expect(result).toBeNull();
+        });
+    });
+});

--- a/src/activitypub/index.ts
+++ b/src/activitypub/index.ts
@@ -1,0 +1,5 @@
+export * from './actor';
+export * from './activity';
+export * from './object';
+export * from './outbox';
+export * from './uri';

--- a/src/activitypub/object.ts
+++ b/src/activitypub/object.ts
@@ -1,0 +1,30 @@
+import type { Object as FedifyObject, KvStore } from '@fedify/fedify';
+
+/**
+ * Stores ActivityPub objects
+ *
+ * @template TObject Type of the object to store
+ */
+export interface ObjectStore<TObject> {
+    /**
+     * Store an ActivityPub object
+     *
+     * @param object Object to store
+     */
+    store(object: TObject): Promise<void>;
+}
+
+/**
+ * ObjectStore implementation using Fedify's KvStore
+ */
+export class FedifyKvStoreObjectStore implements ObjectStore<FedifyObject> {
+    constructor(private readonly db: KvStore) {}
+
+    async store(object: FedifyObject) {
+        if (object.id === null) {
+            throw new Error('Object can not be stored without an ID');
+        }
+
+        await this.db.set([object.id.href], await object.toJsonLd());
+    }
+}

--- a/src/activitypub/object.unit.test.ts
+++ b/src/activitypub/object.unit.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Article, KvStore } from '@fedify/fedify';
+
+import { FedifyKvStoreObjectStore } from './object';
+
+describe('FedifyKvStoreObjectStore', () => {
+    describe('store', () => {
+        it('should store an object', async () => {
+            const mockArticleId = new URL(
+                'https://example.com/article/abc-123',
+            );
+            const mockKvStore = {
+                set: vi.fn(),
+            } as unknown as KvStore;
+            const mockArticleJsonLd = {
+                id: mockArticleId,
+                type: 'Article',
+            };
+            const mockArticle = {
+                id: mockArticleId,
+                toJsonLd: vi.fn().mockResolvedValue(mockArticleJsonLd),
+            } as unknown as Article;
+
+            const store = new FedifyKvStoreObjectStore(mockKvStore);
+
+            await store.store(mockArticle);
+
+            expect(mockKvStore.set).toHaveBeenCalledWith(
+                [mockArticleId.href],
+                mockArticleJsonLd,
+            );
+        });
+
+        it('should throw an error if the object has no ID', async () => {
+            const mockKvStore = {
+                set: vi.fn(),
+            } as unknown as KvStore;
+            const mockArticle = {
+                id: null,
+                toJsonLd: vi.fn().mockResolvedValue({}),
+            } as unknown as Article;
+
+            const store = new FedifyKvStoreObjectStore(mockKvStore);
+
+            await expect(store.store(mockArticle)).rejects.toThrow(
+                'Object can not be stored without an ID',
+            );
+        });
+    });
+});

--- a/src/activitypub/outbox.ts
+++ b/src/activitypub/outbox.ts
@@ -1,0 +1,34 @@
+import type { Activity, KvStore } from '@fedify/fedify';
+
+import { addToList } from '../kv-helpers';
+
+/**
+ * ActivityPub outbox collection
+ *
+ * @template TActivity Type of activity in the outbox
+ */
+export interface Outbox<TActivity> {
+    /**
+     * Add an activity to the outbox
+     *
+     * @param activity Activity to add
+     */
+    add(activity: TActivity): Promise<void>;
+}
+
+/**
+ * Outbox implementation using Fedify's KvStore
+ */
+export class FedifyKvStoreOutbox implements Outbox<Activity> {
+    constructor(private readonly db: KvStore) {}
+
+    async add(activity: Activity) {
+        if (activity.id === null) {
+            throw new Error(
+                'Activity can not be added to outbox without an ID',
+            );
+        }
+
+        await addToList(this.db, ['outbox'], activity.id.href);
+    }
+}

--- a/src/activitypub/outbox.unit.test.ts
+++ b/src/activitypub/outbox.unit.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Activity, KvStore } from '@fedify/fedify';
+
+import * as kvHelpers from '../kv-helpers';
+
+import { FedifyKvStoreOutbox } from './outbox';
+
+vi.mock('../kv-helpers', () => ({
+    addToList: vi.fn(),
+}));
+
+describe('FedifyKvStoreOutbox', () => {
+    describe('add', () => {
+        it('should add an activity to the outbox', async () => {
+            const mockKvStore = {} as KvStore;
+            const mockActivityId = new URL(
+                'https://example.com/activity/abc-123',
+            );
+            const mockActivity = {
+                id: mockActivityId,
+            } as Activity;
+
+            const outbox = new FedifyKvStoreOutbox(mockKvStore);
+
+            await outbox.add(mockActivity);
+
+            expect(kvHelpers.addToList).toHaveBeenCalledWith(
+                mockKvStore,
+                ['outbox'],
+                mockActivityId.href,
+            );
+        });
+
+        it('should throw an error if the activity has no ID', async () => {
+            const mockKvStore = {} as KvStore;
+            const mockActivity = {
+                id: null,
+            } as Activity;
+
+            const outbox = new FedifyKvStoreOutbox(mockKvStore);
+
+            await expect(outbox.add(mockActivity)).rejects.toThrow(
+                'Activity can not be added to outbox without an ID',
+            );
+        });
+    });
+});

--- a/src/activitypub/uri.ts
+++ b/src/activitypub/uri.ts
@@ -1,0 +1,46 @@
+import type { Object as FedifyObject } from '@fedify/fedify';
+
+import type { FedifyRequestContext } from '../app';
+
+/**
+ * Builds ActivityPub URIs
+ *
+ * @template TObject Type of object to build a URI for
+ */
+export interface UriBuilder<TObject> {
+    /**
+     * Build a URI for an object
+     *
+     * @param cls Class of the object to build a URI for
+     * @param id ID of the object to build a URI for
+     */
+    buildObjectUri(
+        cls: { new (props: Partial<TObject>): TObject; typeId: URL },
+        id: string,
+    ): URL;
+
+    /**
+     * Build a URI for an actor's followers collection
+     *
+     * @param handle Handle of the actor to build a followers collection URI for
+     */
+    buildFollowersCollectionUri(handle: string): URL;
+}
+
+/**
+ * UriBuilder implementation using Fedify's RequestContext
+ */
+export class FedifyUriBuilder implements UriBuilder<FedifyObject> {
+    constructor(private readonly fedifyCtx: FedifyRequestContext) {}
+
+    buildObjectUri(
+        cls: { new (props: Partial<FedifyObject>): FedifyObject; typeId: URL },
+        id: string,
+    ) {
+        return this.fedifyCtx.getObjectUri(cls, { id });
+    }
+
+    buildFollowersCollectionUri(handle: string) {
+        return this.fedifyCtx.getFollowersUri(handle);
+    }
+}

--- a/src/activitypub/uri.unit.test.ts
+++ b/src/activitypub/uri.unit.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { Article } from '@fedify/fedify';
+
+import type { FedifyRequestContext } from '../app';
+
+import { FedifyUriBuilder } from './uri';
+
+type ArticleValues = {
+    id: string;
+};
+
+describe('FedifyUriBuilder', () => {
+    describe('buildObjectUri', () => {
+        it('should build a URI for an object', async () => {
+            const object = Article;
+            const id = 'abc-123';
+            const expectedUri = new URL(`https://example.com/article/${id}`);
+            const mockFedifyCtx = {
+                getObjectUri: vi
+                    .fn()
+                    .mockImplementation((objectCls, values: ArticleValues) => {
+                        if (objectCls === object && values.id === id) {
+                            return expectedUri;
+                        }
+
+                        return new URL(
+                            'https://example.com/unexpected-object-uri',
+                        );
+                    }),
+            } as unknown as FedifyRequestContext;
+
+            const builder = new FedifyUriBuilder(mockFedifyCtx);
+
+            const result = builder.buildObjectUri(object, id);
+
+            expect(result).toEqual(expectedUri);
+        });
+
+        it('should build a URI for an actors followers collection', () => {
+            const handle = 'foo';
+            const expectedUri = new URL(
+                `https://example.com/user/${handle}/followers`,
+            );
+            const mockFedifyCtx = {
+                getFollowersUri: vi.fn().mockImplementation((value) => {
+                    if (value === handle) {
+                        return expectedUri;
+                    }
+
+                    return new URL(
+                        'https://example.com/unexpected-followers-uri',
+                    );
+                }),
+            } as unknown as FedifyRequestContext;
+
+            const builder = new FedifyUriBuilder(mockFedifyCtx);
+
+            const result = builder.buildFollowersCollectionUri(handle);
+
+            expect(result).toEqual(expectedUri);
+        });
+    });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import {
     type KvStore,
     Like,
     Note,
+    type RequestContext,
     Undo,
     Update,
     createFederation,
@@ -196,6 +197,13 @@ export const fedify = createFederation<ContextData>({
         ['development', 'testing'].includes(process.env.NODE_ENV || ''),
 });
 
+/**
+ * Fedify request context with app specific context data
+ *
+ * @see https://fedify.dev/manual/context
+ */
+export type FedifyRequestContext = RequestContext<ContextData>;
+
 export const db = await KnexKvStore.create(client, 'key_value');
 
 /** Fedify */
@@ -354,6 +362,13 @@ export type HonoContextVariables = {
 };
 
 const app = new Hono<{ Variables: HonoContextVariables }>();
+
+/**
+ * Hono context with app specific context variables
+ *
+ * @see https://hono.dev/docs/api/context
+ */
+export type AppContext = HonoContext<{ Variables: HonoContextVariables }>;
 
 app.get('/ping', (ctx) => {
     return new Response('', {

--- a/src/http/api/webhooks.ts
+++ b/src/http/api/webhooks.ts
@@ -1,22 +1,11 @@
-import {
-    type Actor,
-    Article,
-    Create,
-    Note,
-    PUBLIC_COLLECTION,
-    type RequestContext,
-} from '@fedify/fedify';
 import { Temporal } from '@js-temporal/polyfill';
-import type { Context } from 'hono';
-import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 
-import { type ContextData, type HonoContextVariables, fedify } from '../../app';
+import { type AppContext, fedify } from '../../app';
 import { ACTOR_DEFAULT_HANDLE } from '../../constants';
 import { updateSiteActor } from '../../helpers/activitypub/actor';
 import { getSiteSettings } from '../../helpers/ghost';
-import { toURL } from '../../helpers/uri';
-import { addToList } from '../../kv-helpers';
+import { publishPost } from '../../publishing/helpers';
 
 const PostSchema = z.object({
     uuid: z.string().uuid(),
@@ -30,40 +19,6 @@ const PostSchema = z.object({
 
 type Post = z.infer<typeof PostSchema>;
 
-async function postToArticle(
-    ctx: RequestContext<ContextData>,
-    post: Post,
-    author: Actor | null,
-) {
-    if (!post) {
-        return {
-            article: null,
-            preview: null,
-        };
-    }
-    const preview = new Note({
-        id: ctx.getObjectUri(Note, { id: post.uuid }),
-        content: post.excerpt,
-    });
-    const article = new Article({
-        id: ctx.getObjectUri(Article, { id: post.uuid }),
-        attribution: author,
-        name: post.title,
-        content: post.html,
-        image: toURL(post.feature_image),
-        published: Temporal.Instant.from(post.published_at),
-        preview: preview,
-        url: toURL(post.url),
-        to: PUBLIC_COLLECTION,
-        cc: ctx.getFollowersUri(ACTOR_DEFAULT_HANDLE),
-    });
-
-    return {
-        article,
-        preview,
-    };
-}
-
 const PostPublishedWebhookSchema = z.object({
     post: z.object({
         current: PostSchema,
@@ -73,59 +28,40 @@ const PostPublishedWebhookSchema = z.object({
 /**
  * Handle a post.published webhook
  *
- * @param ctx {Context<{ Variables: HonoContextVariables }>} Hono context instance
+ * @param ctx App context instance
  */
-export async function handleWebhookPostPublished(
-    ctx: Context<{ Variables: HonoContextVariables }>,
-) {
-    const data = PostPublishedWebhookSchema.parse(
-        (await ctx.req.json()) as unknown,
-    );
-    const apCtx = fedify.createContext(ctx.req.raw as Request, {
-        db: ctx.get('db'),
-        globaldb: ctx.get('globaldb'),
-        logger: ctx.get('logger'),
-    });
-    const actor = await apCtx.getActor(ACTOR_DEFAULT_HANDLE);
-    const { article, preview } = await postToArticle(
-        apCtx,
-        data.post.current,
-        actor,
-    );
-    if (article) {
-        const create = new Create({
-            actor,
-            object: article,
-            id: apCtx.getObjectUri(Create, { id: uuidv4() }),
-            to: PUBLIC_COLLECTION,
-            cc: apCtx.getFollowersUri('index'),
-        });
-        try {
-            await article.toJsonLd();
-            await ctx
-                .get('globaldb')
-                .set([preview.id!.href], await preview.toJsonLd());
-            await ctx
-                .get('globaldb')
-                .set([create.id!.href], await create.toJsonLd());
-            await ctx
-                .get('globaldb')
-                .set([article.id!.href], await article.toJsonLd());
-            await addToList(ctx.get('db'), ['outbox'], create.id!.href);
-            await apCtx.sendActivity(
-                { handle: ACTOR_DEFAULT_HANDLE },
-                'followers',
-                create,
-                {
-                    preferSharedInbox: true,
-                },
-            );
-        } catch (err) {
-            ctx.get('logger').error('Post published webhook failed: {error}', {
-                error: err,
-            });
-        }
+export async function handleWebhookPostPublished(ctx: AppContext) {
+    let data: Post;
+
+    try {
+        data = PostPublishedWebhookSchema.parse(
+            (await ctx.req.json()) as unknown,
+        ).post.current;
+    } catch (err) {
+        return new Response(JSON.stringify({}), { status: 400 });
     }
+
+    try {
+        await publishPost(ctx, {
+            id: data.uuid,
+            title: data.title,
+            content: data.html,
+            excerpt: data.excerpt,
+            featureImageUrl: data.feature_image
+                ? new URL(data.feature_image)
+                : null,
+            publishedAt: Temporal.Instant.from(data.published_at),
+            url: new URL(data.url),
+            author: {
+                handle: ACTOR_DEFAULT_HANDLE,
+            },
+        });
+    } catch (err) {
+        ctx.get('logger').error('Failed to publish post: {error}', {
+            error: err,
+        });
+    }
+
     return new Response(JSON.stringify({}), {
         headers: {
             'Content-Type': 'application/json',
@@ -137,11 +73,9 @@ export async function handleWebhookPostPublished(
 /**
  * Handle a site.changed webhook
  *
- * @param ctx {Context<{ Variables: HonoContextVariables }>} Hono context instance
+ * @param ctx App context instance
  */
-export async function handleWebhookSiteChanged(
-    ctx: Context<{ Variables: HonoContextVariables }>,
-) {
+export async function handleWebhookSiteChanged(ctx: AppContext) {
     try {
         const db = ctx.get('db');
         const globaldb = ctx.get('globaldb');

--- a/src/publishing/__snapshots__/service/create.json
+++ b/src/publishing/__snapshots__/service/create.json
@@ -1,0 +1,48 @@
+{
+  "@context": [
+    "https://w3id.org/identity/v1",
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/security/data-integrity/v1",
+    {
+      "ChatMessage": "http://litepub.social/ns#ChatMessage",
+      "Emoji": "toot:Emoji",
+      "Hashtag": "as:Hashtag",
+      "_misskey_quote": "misskey:_misskey_quote",
+      "fedibird": "http://fedibird.com/ns#",
+      "misskey": "https://misskey-hub.net/ns#",
+      "quoteUri": "fedibird:quoteUri",
+      "quoteUrl": "as:quoteUrl",
+      "sensitive": "as:sensitive",
+      "toot": "http://joinmastodon.org/ns#",
+      "votersCount": "toot:votersCount",
+    },
+  ],
+  "actor": {
+    "id": "https://example.com/user/foo",
+    "type": "Person",
+  },
+  "cc": "https://example.com/user/foo/followers",
+  "id": "https://example.com/create/cb1e7e92-5560-4ceb-9272-7e9d0e2a7da4",
+  "object": {
+    "attributedTo": {
+      "id": "https://example.com/user/foo",
+      "type": "Person",
+    },
+    "cc": "https://example.com/user/foo/followers",
+    "content": "Post content",
+    "id": "https://example.com/article/post-123",
+    "image": "https://example.com/img/post-123_feature.jpg",
+    "name": "Post title",
+    "preview": {
+      "content": "Post excerpt",
+      "id": "https://example.com/note/post-123",
+      "type": "Note",
+    },
+    "published": "2025-01-12T10:30:00Z",
+    "to": "as:Public",
+    "type": "Article",
+    "url": "https://example.com/post/post-123",
+  },
+  "to": "as:Public",
+  "type": "Create",
+}

--- a/src/publishing/helpers.ts
+++ b/src/publishing/helpers.ts
@@ -1,0 +1,37 @@
+import {
+    FedifyActivitySender,
+    FedifyActorResolver,
+    FedifyKvStoreObjectStore,
+    FedifyKvStoreOutbox,
+    FedifyUriBuilder,
+} from '../activitypub';
+import { type AppContext, fedify } from '../app';
+import { FedifyPublishingService, type Post } from './service';
+
+/**
+ * Publishes a post to the Fediverse
+ *
+ * @param ctx App context instance
+ * @param post Post to publish
+ */
+export async function publishPost(ctx: AppContext, post: Post) {
+    const scopedDb = ctx.get('db');
+    const globalDb = ctx.get('globaldb');
+
+    const fedifyCtx = fedify.createContext(ctx.req.raw, {
+        db: scopedDb,
+        globaldb: globalDb,
+        logger: ctx.get('logger'),
+    });
+
+    const publishingService = new FedifyPublishingService(
+        new FedifyActivitySender(fedifyCtx),
+        new FedifyActorResolver(fedifyCtx),
+        new FedifyKvStoreObjectStore(globalDb),
+        new FedifyUriBuilder(fedifyCtx),
+    );
+
+    const outbox = new FedifyKvStoreOutbox(scopedDb);
+
+    await publishingService.publishPost(post, outbox);
+}

--- a/src/publishing/service.ts
+++ b/src/publishing/service.ts
@@ -1,0 +1,139 @@
+import {
+    type Activity,
+    type Actor,
+    Article,
+    Create,
+    type Object as FedifyObject,
+    Note,
+    PUBLIC_COLLECTION,
+} from '@fedify/fedify';
+import type { Temporal } from '@js-temporal/polyfill';
+import { v4 as uuidv4 } from 'uuid';
+
+import type {
+    ActivitySender,
+    ActorResolver,
+    ObjectStore,
+    Outbox,
+    UriBuilder,
+} from '../activitypub';
+
+/**
+ * Post to be published to the Fediverse
+ */
+export interface Post {
+    /**
+     * Unique identifier of the post
+     */
+    id: string;
+    /**
+     * Title of the post
+     */
+    title: string;
+    /**
+     * Content of the post
+     */
+    content: string | null;
+    /**
+     * Excerpt of the post
+     */
+    excerpt: string | null;
+    /**
+     * URL to the post's feature image
+     */
+    featureImageUrl: URL | null;
+    /**
+     * Published date of the post
+     */
+    publishedAt: Temporal.Instant;
+    /**
+     * URL to the post
+     */
+    url: URL;
+    /**
+     * Information about the post's author
+     */
+    author: {
+        /**
+         * The author's Fediverse handle
+         */
+        handle: string;
+    };
+}
+
+/**
+ * Publishes content to the Fediverse
+ */
+export interface PublishingService {
+    /**
+     * Publishes a post to the Fediverse
+     *
+     * @param post Post to publish
+     * @param outbox Outbox to record the published post in
+     */
+    publishPost(post: Post, outbox: Outbox<unknown>): Promise<void>;
+}
+
+/**
+ * PublishingService implementation using Fedify
+ */
+export class FedifyPublishingService implements PublishingService {
+    constructor(
+        private readonly activitySender: ActivitySender<Activity, Actor>,
+        private readonly actorResolver: ActorResolver<Actor>,
+        private readonly objectStore: ObjectStore<FedifyObject>,
+        private readonly uriBuilder: UriBuilder<FedifyObject>,
+    ) {}
+
+    async publishPost(post: Post, outbox: Outbox<Activity>) {
+        // @TODO: Should this be a transaction and all operations rolled back if
+        // one fails?
+
+        // Resolve the actor responsible for publishing the post
+        const actor = await this.actorResolver.resolveActorByHandle(
+            post.author.handle,
+        );
+
+        if (!actor) {
+            throw new Error(
+                `Actor not resolved for handle: ${post.author.handle}`,
+            );
+        }
+
+        // Build the required objects
+        const preview = new Note({
+            id: this.uriBuilder.buildObjectUri(Note, post.id),
+            content: post.excerpt,
+        });
+        const article = new Article({
+            id: this.uriBuilder.buildObjectUri(Article, post.id),
+            attribution: actor,
+            name: post.title,
+            content: post.content,
+            image: post.featureImageUrl,
+            published: post.publishedAt,
+            preview,
+            url: post.url,
+            to: PUBLIC_COLLECTION,
+            cc: this.uriBuilder.buildFollowersCollectionUri(post.author.handle),
+        });
+        const create = new Create({
+            actor,
+            object: article,
+            id: this.uriBuilder.buildObjectUri(Create, uuidv4()),
+            to: PUBLIC_COLLECTION,
+            cc: this.uriBuilder.buildFollowersCollectionUri(post.author.handle),
+        });
+
+        // Store the built objects
+        await this.objectStore.store(preview);
+        await this.objectStore.store(article);
+        await this.objectStore.store(create);
+
+        // Add the activity to the provided outbox
+        await outbox.add(create);
+
+        // Send the create activity to the followers of the actor
+        await this.activitySender.sendActivityToActorFollowers(create, actor);
+    }
+}

--- a/src/publishing/service.unit.test.ts
+++ b/src/publishing/service.unit.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    type Activity,
+    type Actor,
+    Article,
+    Create,
+    type Object as FedifyObject,
+    Note,
+    Person,
+} from '@fedify/fedify';
+import { Temporal } from '@js-temporal/polyfill';
+
+import type {
+    ActivitySender,
+    ActorResolver,
+    ObjectStore,
+    Outbox,
+    UriBuilder,
+} from '../activitypub';
+
+import { FedifyPublishingService, type Post } from './service';
+
+vi.mock('uuid', () => ({
+    // Return a fixed UUID for deterministic testing
+    v4: vi.fn().mockReturnValue('cb1e7e92-5560-4ceb-9272-7e9d0e2a7da4'),
+}));
+
+describe('FedifyPublishingService', () => {
+    describe('publishPost', () => {
+        let mockActivitySender: ActivitySender<Activity, Actor>;
+        let actor: Actor;
+        let mockActorResolver: ActorResolver<Actor>;
+        let mockObjectStore: ObjectStore<FedifyObject>;
+        let mockUriBuilder: UriBuilder<FedifyObject>;
+        let mockOutbox: Outbox<Activity>;
+        let post: Post;
+
+        beforeEach(() => {
+            const handle = 'foo';
+            mockActivitySender = {
+                sendActivityToActorFollowers: vi.fn().mockResolvedValue(void 0),
+            } as ActivitySender<Activity, Actor>;
+
+            actor = new Person({
+                id: new URL(`https://example.com/user/${handle}`),
+            });
+
+            mockActorResolver = {
+                resolveActorByHandle: vi.fn().mockResolvedValue(actor),
+            } as ActorResolver<Actor>;
+
+            mockObjectStore = {
+                store: vi.fn().mockResolvedValue(void 0),
+            } as ObjectStore<FedifyObject>;
+
+            mockUriBuilder = {
+                buildObjectUri: vi.fn().mockImplementation((object, id) => {
+                    return new URL(
+                        `https://example.com/${object.name.toLowerCase()}/${id}`,
+                    );
+                }),
+                buildFollowersCollectionUri: vi
+                    .fn()
+                    .mockImplementation((handle) => {
+                        return new URL(
+                            `https://example.com/user/${handle}/followers`,
+                        );
+                    }),
+            } as UriBuilder<FedifyObject>;
+
+            mockOutbox = {
+                add: vi.fn().mockResolvedValue(void 0),
+            } as Outbox<Activity>;
+
+            const postId = 'post-123';
+
+            post = {
+                id: postId,
+                title: 'Post title',
+                content: 'Post content',
+                excerpt: 'Post excerpt',
+                featureImageUrl: new URL(
+                    `https://example.com/img/${postId}_feature.jpg`,
+                ),
+                publishedAt: Temporal.Instant.from('2025-01-12T10:30:00.000Z'),
+                url: new URL(`https://example.com/post/${postId}`),
+                author: {
+                    handle,
+                },
+            };
+        });
+
+        it('should throw an error if the actor can not be resolved', async () => {
+            vi.mocked(mockActorResolver.resolveActorByHandle).mockResolvedValue(
+                null,
+            );
+
+            const service = new FedifyPublishingService(
+                mockActivitySender,
+                mockActorResolver,
+                mockObjectStore,
+                mockUriBuilder,
+            );
+
+            await expect(service.publishPost(post, mockOutbox)).rejects.toThrow(
+                `Actor not resolved for handle: ${post.author.handle}`,
+            );
+        });
+
+        it('should store the created ActivityPub objects', async () => {
+            const service = new FedifyPublishingService(
+                mockActivitySender,
+                mockActorResolver,
+                mockObjectStore,
+                mockUriBuilder,
+            );
+
+            await service.publishPost(post, mockOutbox);
+
+            expect(mockObjectStore.store).toHaveBeenCalledTimes(3);
+
+            const note = vi.mocked(mockObjectStore.store).mock.calls[0][0];
+            const article = vi.mocked(mockObjectStore.store).mock.calls[1][0];
+            const create = vi.mocked(mockObjectStore.store).mock.calls[2][0];
+
+            expect(note).toBeInstanceOf(Note);
+            expect(article).toBeInstanceOf(Article);
+            expect(create).toBeInstanceOf(Create);
+
+            await expect(await create.toJsonLd()).toMatchFileSnapshot(
+                './__snapshots__/service/create.json',
+            );
+        });
+
+        it('should add the create activity to the outbox', async () => {
+            const service = new FedifyPublishingService(
+                mockActivitySender,
+                mockActorResolver,
+                mockObjectStore,
+                mockUriBuilder,
+            );
+
+            await service.publishPost(post, mockOutbox);
+
+            expect(mockOutbox.add).toHaveBeenCalledTimes(1);
+
+            const outboxActivity = vi.mocked(mockOutbox.add).mock.calls[0][0];
+
+            expect(outboxActivity).toBeInstanceOf(Create);
+        });
+
+        it('should send the create activity to the followers of the actor', async () => {
+            const service = new FedifyPublishingService(
+                mockActivitySender,
+                mockActorResolver,
+                mockObjectStore,
+                mockUriBuilder,
+            );
+
+            await service.publishPost(post, mockOutbox);
+
+            expect(
+                mockActivitySender.sendActivityToActorFollowers,
+            ).toHaveBeenCalledTimes(1);
+
+            const sentActivity = vi.mocked(
+                mockActivitySender.sendActivityToActorFollowers,
+            ).mock.calls[0][0];
+
+            expect(sentActivity).toBeInstanceOf(Create);
+
+            expect(
+                vi.mocked(mockActivitySender.sendActivityToActorFollowers).mock
+                    .calls[0][1],
+            ).toBe(actor);
+        });
+    });
+});


### PR DESCRIPTION
no refs

This is being done as a pre-requisite to handling publishing posts containing member content from Ghost

Me & @allouis discussed taking the opportunity to refactor this area of the codebase to make it more modular / testable and reducing the tight coupling between the http handler and the business logic for publishing posts

In this refactored design:

- The webhook post published http handler now only deals with only validating the incoming data & returning the appropriate response. It passes the validated data to a new service that deals with the publishing
- The new publishing service contains all the business logic for publishing a post. In the future we can move the logic for publishing a reply / note here as well to keep all the publishing logic co-located (and also cleaning up the respective http handlers for these operations in the same we have done with the webhook post published handler)
- We have introduced a bunch of interfaces to help define boundaries and allow composability / flexibility
- We have tried to reduce direct coupling to Fedify (in particular the request context ) - Whilst Fedify is the backbone of the application and unlikely to change, it can sometimes be cumbersome to test or change the tightly coupled logic