### PR TITLE
Ensure only public content is posted

### DIFF
--- a/src/http/api/webhooks.ts
+++ b/src/http/api/webhooks.ts
@@ -6,6 +6,7 @@ import { ACTOR_DEFAULT_HANDLE } from '../../constants';
 import { updateSiteActor } from '../../helpers/activitypub/actor';
 import { getSiteSettings } from '../../helpers/ghost';
 import { publishPost } from '../../publishing/helpers';
+import { PostVisibility } from '../../publishing/types';
 
 const PostSchema = z.object({
     uuid: z.string().uuid(),
@@ -15,6 +16,7 @@ const PostSchema = z.object({
     feature_image: z.string().url().nullable(),
     published_at: z.string().datetime(),
     url: z.string().url(),
+    visibility: z.nativeEnum(PostVisibility),
 });
 
 type Post = z.infer<typeof PostSchema>;
@@ -55,6 +57,7 @@ export async function handleWebhookPostPublished(ctx: AppContext) {
             author: {
                 handle: ACTOR_DEFAULT_HANDLE,
             },
+            visibility: data.visibility,
         });
     } catch (err) {
         ctx.get('logger').error('Failed to publish post: {error}', {

--- a/src/publishing/helpers.ts
+++ b/src/publishing/helpers.ts
@@ -6,10 +6,11 @@ import {
     FedifyUriBuilder,
 } from '../activitypub';
 import { type AppContext, fedify } from '../app';
-import { FedifyPublishingService, type Post } from './service';
+import { FedifyPublishingService } from './service';
+import type { Post } from './types';
 
 /**
- * Publishes a post to the Fediverse
+ * Publish a post to the Fediverse
  *
  * @param ctx App context instance
  * @param post Post to publish

--- a/src/publishing/helpers.ts
+++ b/src/publishing/helpers.ts
@@ -18,6 +18,7 @@ import type { Post } from './types';
 export async function publishPost(ctx: AppContext, post: Post) {
     const scopedDb = ctx.get('db');
     const globalDb = ctx.get('globaldb');
+    const logger = ctx.get('logger');
 
     const fedifyCtx = fedify.createContext(ctx.req.raw, {
         db: scopedDb,
@@ -28,6 +29,7 @@ export async function publishPost(ctx: AppContext, post: Post) {
     const publishingService = new FedifyPublishingService(
         new FedifyActivitySender(fedifyCtx),
         new FedifyActorResolver(fedifyCtx),
+        logger,
         new FedifyKvStoreObjectStore(globalDb),
         new FedifyUriBuilder(fedifyCtx),
     );

--- a/src/publishing/service.ts
+++ b/src/publishing/service.ts
@@ -7,7 +7,6 @@ import {
     Note,
     PUBLIC_COLLECTION,
 } from '@fedify/fedify';
-import type { Temporal } from '@js-temporal/polyfill';
 import { v4 as uuidv4 } from 'uuid';
 
 import type {
@@ -17,56 +16,14 @@ import type {
     Outbox,
     UriBuilder,
 } from '../activitypub';
-
-/**
- * Post to be published to the Fediverse
- */
-export interface Post {
-    /**
-     * Unique identifier of the post
-     */
-    id: string;
-    /**
-     * Title of the post
-     */
-    title: string;
-    /**
-     * Content of the post
-     */
-    content: string | null;
-    /**
-     * Excerpt of the post
-     */
-    excerpt: string | null;
-    /**
-     * URL to the post's feature image
-     */
-    featureImageUrl: URL | null;
-    /**
-     * Published date of the post
-     */
-    publishedAt: Temporal.Instant;
-    /**
-     * URL to the post
-     */
-    url: URL;
-    /**
-     * Information about the post's author
-     */
-    author: {
-        /**
-         * The author's Fediverse handle
-         */
-        handle: string;
-    };
-}
+import type { Post } from './types';
 
 /**
  * Publishes content to the Fediverse
  */
 export interface PublishingService {
     /**
-     * Publishes a post to the Fediverse
+     * Publish a post to the Fediverse
      *
      * @param post Post to publish
      * @param outbox Outbox to record the published post in

--- a/src/publishing/service.ts
+++ b/src/publishing/service.ts
@@ -7,6 +7,7 @@ import {
     Note,
     PUBLIC_COLLECTION,
 } from '@fedify/fedify';
+import type { Logger } from '@logtape/logtape';
 import { v4 as uuidv4 } from 'uuid';
 
 import type {
@@ -43,6 +44,7 @@ export class FedifyPublishingService implements PublishingService {
     constructor(
         private readonly activitySender: ActivitySender<Activity, Actor>,
         private readonly actorResolver: ActorResolver<Actor>,
+        private readonly logger: Logger,
         private readonly objectStore: ObjectStore<FedifyObject>,
         private readonly uriBuilder: UriBuilder<FedifyObject>,
     ) {}
@@ -78,6 +80,13 @@ export class FedifyPublishingService implements PublishingService {
 
             // If there is no public content, do not publish the post
             if (articleContent === '') {
+                this.logger.info(
+                    'Skipping publishing post: No public content found for post: {post}',
+                    {
+                        post,
+                    },
+                );
+
                 return;
             }
         }

--- a/src/publishing/service.unit.test.ts
+++ b/src/publishing/service.unit.test.ts
@@ -10,6 +10,7 @@ import {
     Person,
 } from '@fedify/fedify';
 import { Temporal } from '@js-temporal/polyfill';
+import type { Logger } from '@logtape/logtape';
 
 import type {
     ActivitySender,
@@ -18,7 +19,6 @@ import type {
     Outbox,
     UriBuilder,
 } from '../activitypub';
-
 import {
     FedifyPublishingService,
     POST_CONTENT_NON_PUBLIC_MARKER,
@@ -35,6 +35,7 @@ describe('FedifyPublishingService', () => {
         let mockActivitySender: ActivitySender<Activity, Actor>;
         let actor: Actor;
         let mockActorResolver: ActorResolver<Actor>;
+        let mockLogger: Logger;
         let mockObjectStore: ObjectStore<FedifyObject>;
         let mockUriBuilder: UriBuilder<FedifyObject>;
         let mockOutbox: Outbox<Activity>;
@@ -53,6 +54,10 @@ describe('FedifyPublishingService', () => {
             mockActorResolver = {
                 resolveActorByHandle: vi.fn().mockResolvedValue(actor),
             } as ActorResolver<Actor>;
+
+            mockLogger = {
+                info: vi.fn().mockResolvedValue(void 0),
+            } as unknown as Logger;
 
             mockObjectStore = {
                 store: vi.fn().mockResolvedValue(void 0),
@@ -104,6 +109,7 @@ describe('FedifyPublishingService', () => {
             const service = new FedifyPublishingService(
                 mockActivitySender,
                 mockActorResolver,
+                mockLogger,
                 mockObjectStore,
                 mockUriBuilder,
             );
@@ -117,6 +123,7 @@ describe('FedifyPublishingService', () => {
             const service = new FedifyPublishingService(
                 mockActivitySender,
                 mockActorResolver,
+                mockLogger,
                 mockObjectStore,
                 mockUriBuilder,
             );
@@ -142,6 +149,7 @@ describe('FedifyPublishingService', () => {
             const service = new FedifyPublishingService(
                 mockActivitySender,
                 mockActorResolver,
+                mockLogger,
                 mockObjectStore,
                 mockUriBuilder,
             );
@@ -159,6 +167,7 @@ describe('FedifyPublishingService', () => {
             const service = new FedifyPublishingService(
                 mockActivitySender,
                 mockActorResolver,
+                mockLogger,
                 mockObjectStore,
                 mockUriBuilder,
             );
@@ -188,6 +197,7 @@ describe('FedifyPublishingService', () => {
             const service = new FedifyPublishingService(
                 mockActivitySender,
                 mockActorResolver,
+                mockLogger,
                 mockObjectStore,
                 mockUriBuilder,
             );
@@ -214,6 +224,7 @@ describe('FedifyPublishingService', () => {
             const service = new FedifyPublishingService(
                 mockActivitySender,
                 mockActorResolver,
+                mockLogger,
                 mockObjectStore,
                 mockUriBuilder,
             );
@@ -232,6 +243,7 @@ describe('FedifyPublishingService', () => {
             const service = new FedifyPublishingService(
                 mockActivitySender,
                 mockActorResolver,
+                mockLogger,
                 mockObjectStore,
                 mockUriBuilder,
             );

--- a/src/publishing/service.unit.test.ts
+++ b/src/publishing/service.unit.test.ts
@@ -19,7 +19,8 @@ import type {
     UriBuilder,
 } from '../activitypub';
 
-import { FedifyPublishingService, type Post } from './service';
+import { FedifyPublishingService } from './service';
+import { type Post, PostVisibility } from './types';
 
 vi.mock('uuid', () => ({
     // Return a fixed UUID for deterministic testing
@@ -85,6 +86,7 @@ describe('FedifyPublishingService', () => {
                 ),
                 publishedAt: Temporal.Instant.from('2025-01-12T10:30:00.000Z'),
                 url: new URL(`https://example.com/post/${postId}`),
+                visibility: PostVisibility.Public,
                 author: {
                     handle,
                 },

--- a/src/publishing/types.ts
+++ b/src/publishing/types.ts
@@ -1,0 +1,70 @@
+import type { Temporal } from '@js-temporal/polyfill';
+
+/**
+ * Visibility of a post
+ */
+export enum PostVisibility {
+    /**
+     * Public post
+     */
+    Public = 'public',
+    /**
+     * Members-only post
+     */
+    Members = 'members',
+    /**
+     * Paid post
+     */
+    Paid = 'paid',
+    /**
+     * Tiers post
+     */
+    Tiers = 'tiers',
+}
+
+/**
+ * Post to be published to the Fediverse
+ */
+export interface Post {
+    /**
+     * Unique identifier of the post
+     */
+    id: string;
+    /**
+     * Title of the post
+     */
+    title: string;
+    /**
+     * Content of the post
+     */
+    content: string | null;
+    /**
+     * Excerpt of the post
+     */
+    excerpt: string | null;
+    /**
+     * URL to the post's feature image
+     */
+    featureImageUrl: URL | null;
+    /**
+     * Published date of the post
+     */
+    publishedAt: Temporal.Instant;
+    /**
+     * URL to the post
+     */
+    url: URL;
+    /**
+     * Visibility of the post
+     */
+    visibility: PostVisibility;
+    /**
+     * Information about the post's author
+     */
+    author: {
+        /**
+         * The author's Fediverse handle
+         */
+        handle: string;
+    };
+}


### PR DESCRIPTION
refs [AP-641](https://linear.app/ghost/issue/AP-641/only-public-posts-should-be-sent-to-the-fediverse)

Ensured that only public content is posted when the visibility of an incoming post is not `public`