### PR TITLE
Updated `following` and `followers` collection to only return URLs

### DIFF
--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -1038,7 +1038,8 @@ Then(
         // Check that the activity was sent to all followers
         const activity = this.activities[activityName];
 
-        for (const follower of followers) {
+        for (const followerUrl of followers) {
+            const follower = await (await fetchActivityPub(followerUrl)).json();
             const inbox = new URL(follower.inbox);
 
             const found = await waitForRequest(
@@ -1253,7 +1254,7 @@ Then('{string} is in our Followers', async function (actorName) {
     const actor = this.actors[actorName];
 
     const found = (followers.orderedItems || []).find(
-        (item) => item.id === actor.id,
+        (item) => item === actor.id,
     );
 
     assert(found);
@@ -1280,7 +1281,7 @@ Then('{string} is in our Followers once only', async function (actorName) {
     const followers = await firstPageResponse.json();
     const actor = this.actors[actorName];
     const found = (followers.orderedItems || []).filter(
-        (item) => item.id === actor.id,
+        (item) => item === actor.id,
     );
 
     assert.equal(found.length, 1);

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -532,7 +532,14 @@ export async function followersDispatcher(
     return {
         items: (
             await Promise.all(items.map((item) => APObject.fromJsonLd(item)))
-        ).filter((item): item is Actor => isActor(item)),
+        )
+            .filter((item): item is Actor => isActor(item))
+            .map((item) => {
+                return {
+                    id: item.id,
+                    inboxId: item.inboxId,
+                };
+            }),
         nextCursor,
     };
 }
@@ -592,7 +599,11 @@ export async function followingDispatcher(
                 });
             }
         }),
-    ).then((results) => results.filter((r): r is Actor => isActor(r)));
+    ).then((results) =>
+        results
+            .filter((r): r is Actor => isActor(r) && r.id !== null)
+            .map((r) => new URL(r.id!)),
+    );
 
     return {
         items,

--- a/src/dispatchers.unit.test.ts
+++ b/src/dispatchers.unit.test.ts
@@ -99,15 +99,11 @@ describe('dispatchers', () => {
 
             // Check correct items are returned in the correct order
             expect(result.items.length).toEqual(2);
-            expect(result.items[0] instanceof Person).toBeTruthy();
-            expect(result.items[1] instanceof Person).toBeTruthy();
-            // @ts-ignore: We know that this is the correct type because of the above assertions
-            expect(result.items[0].id.toString()).toEqual(
-                'https://example.com/person/123',
+            expect(result.items[0]).toEqual(
+                new URL('https://example.com/person/123'),
             );
-            // @ts-ignore: We know that this is the correct type because of the above assertions
-            expect(result.items[1].id.toString()).toEqual(
-                'https://example.com/person/456',
+            expect(result.items[1]).toEqual(
+                new URL('https://example.com/person/456'),
             );
         });
 
@@ -123,10 +119,8 @@ describe('dispatchers', () => {
 
             // Check correct items are returned
             expect(result.items.length).toEqual(1);
-            expect(result.items[0] instanceof Person).toBeTruthy();
-            // @ts-ignore: We know that this is the correct type because of the above assertions
-            expect(result.items[0].id.toString()).toEqual(
-                'https://example.com/person/456',
+            expect(result.items[0]).toEqual(
+                new URL('https://example.com/person/456'),
             );
         });
     });


### PR DESCRIPTION
refs [AP-649](https://linear.app/ghost/issue/AP-649/update-activitypub-follows-and-following-collections-to-only-return)

Updated `following` and `followers` collection to only return URLs in preparation for the upcoming changes around storing `accounts`. We return just the minimal information required for the `following` and `followers` collections so we can reduce the amount of data we need to store