### PR TITLE
Added `sharedInboxUrl` to followers dispatcher output

### DIFF
--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -538,6 +538,7 @@ export async function followersDispatcher(
                 return {
                     id: item.id,
                     inboxId: item.inboxId,
+                    sharedInboxId: item.endpoints?.sharedInbox,
                 };
             }),
         nextCursor,


### PR DESCRIPTION
no refs

Added `sharedInboxUrl` to followers dispatcher output so that the Fedify can send an activity to the shared inbox of a follower