### PR TITLE
Wired up SiteService

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "test:types": "tsc --noEmit",
     "test:unit": "vitest run --dir src --coverage '.unit.test.ts'",
     "test:unit:dev": "vitest --dir src --coverage '.unit.test.ts'",
-    "test:integration": "vitest run --dir src --coverage '.integration.test.ts'",
-    "test:code": "vitest run --dir src --coverage '.test.ts'",
+    "test:integration": "vitest run --sequence.concurrent=false --dir src --coverage '.integration.test.ts'",
+    "test:code": "vitest run --sequence.concurrent=false --dir src --coverage '.test.ts'",
     "test:all": "yarn test:types && yarn test:code",
     "lint": "biome check"
   },

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto';
 import Knex from 'knex';
 
 export const client = Knex({
@@ -37,32 +36,6 @@ type getActivityMetaQueryResult = {
 
 interface ActivityJsonLd {
     [key: string]: any;
-}
-
-export async function getSite(host: string, createIfMissing = false) {
-    const rows = await client.select('*').from('sites').where({ host });
-
-    if (!rows || !rows.length) {
-        if (!createIfMissing) {
-            return null;
-        }
-        const webhook_secret = crypto.randomBytes(32).toString('hex');
-        await client.insert({ host, webhook_secret }).into('sites');
-
-        return {
-            host,
-            webhook_secret,
-        };
-    }
-
-    if (rows.length > 1) {
-        throw new Error(`More than one row found for site ${host}`);
-    }
-
-    return {
-        host: rows[0].host,
-        webhook_secret: rows[0].webhook_secret,
-    };
 }
 
 // Helper function to get the meta data for an array of activity URIs

--- a/src/site/site.service.integration.test.ts
+++ b/src/site/site.service.integration.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { TABLE_SITES } from '../constants';
+import { client as db } from '../db';
+
+import { type Site, SiteService } from './site.service';
+
+describe('SiteService', () => {
+    let service: SiteService;
+    let site: Site;
+
+    beforeEach(async () => {
+        // Clean up the database
+        await db.raw('SET FOREIGN_KEY_CHECKS = 0');
+        await db(TABLE_SITES).truncate();
+        await db.raw('SET FOREIGN_KEY_CHECKS = 1');
+
+        // Create the service
+        service = new SiteService(db);
+    });
+
+    it('Can initialise a site multiple times and retrieve it', async () => {
+        const existingSite = await service.getSiteByHost('hostname.tld');
+
+        expect(existingSite).toBeNull();
+
+        const site = await service.initialiseSiteForHost('hostname.tld');
+
+        expect(site.host).toBe('hostname.tld');
+        expect(site.webhook_secret).toBeDefined();
+        expect(site.id).toBeDefined();
+
+        const siteRows = await db(TABLE_SITES).select('*');
+
+        expect(siteRows).toHaveLength(1);
+
+        const siteRow = siteRows[0];
+
+        expect(siteRow.id).toBe(site.id);
+        expect(siteRow.webhook_secret).toBe(site.webhook_secret);
+        expect(siteRow.host).toBe(site.host);
+
+        const siteTwo = await service.initialiseSiteForHost('hostname.tld');
+
+        expect(siteTwo).toMatchObject(site);
+
+        const siteRowsAfterSecondInit = await db(TABLE_SITES).select('*');
+
+        expect(siteRowsAfterSecondInit).toHaveLength(1);
+
+        const retrievedSite = await service.getSiteByHost('hostname.tld');
+
+        expect(retrievedSite).toMatchObject(site);
+    });
+});

--- a/src/site/site.service.ts
+++ b/src/site/site.service.ts
@@ -51,7 +51,7 @@ export class SiteService {
         };
     }
 
-    public async initialiseSiteForHost(host: string) {
+    public async initialiseSiteForHost(host: string): Promise<Site> {
         const existingSite = await this.getSiteByHost(host);
         if (existingSite !== null) {
             return existingSite;
@@ -60,6 +60,10 @@ export class SiteService {
         await this.createSite(host);
 
         const newSite = await this.getSiteByHost(host);
+
+        if (newSite === null) {
+            throw new Error(`Site initialisation failed for ${host}`);
+        }
 
         return newSite;
     }


### PR DESCRIPTION
This replaces the use of the `getSite` helper and moves towards our new structure, paving the way for the initialisation of users and accounts for sites upon init.