### PR TITLE
Updated incoming `Follow` activity handler to record data in the new follows table

### DIFF
--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -44,54 +44,58 @@ describe('AccountService', () => {
         service = new AccountService(db);
     });
 
-    it('should create an internal account', async () => {
-        const username = 'foobarbaz';
+    it(
+        'should create an internal account',
+        async () => {
+            const username = 'foobarbaz';
 
-        const expectedAccount = {
-            name: ACTOR_DEFAULT_NAME,
-            username,
-            bio: ACTOR_DEFAULT_SUMMARY,
-            avatar_url: ACTOR_DEFAULT_ICON,
-            url: `https://${site.host}`,
-            custom_fields: null,
-            ap_id: `https://${site.host}${AP_BASE_PATH}/users/${username}`,
-            ap_inbox_url: `https://${site.host}${AP_BASE_PATH}/inbox/${username}`,
-            ap_outbox_url: `https://${site.host}${AP_BASE_PATH}/outbox/${username}`,
-            ap_following_url: `https://${site.host}${AP_BASE_PATH}/following/${username}`,
-            ap_followers_url: `https://${site.host}${AP_BASE_PATH}/followers/${username}`,
-            ap_liked_url: `https://${site.host}${AP_BASE_PATH}/liked/${username}`,
-            ap_shared_inbox_url: null,
-        };
+            const expectedAccount = {
+                name: ACTOR_DEFAULT_NAME,
+                username,
+                bio: ACTOR_DEFAULT_SUMMARY,
+                avatar_url: ACTOR_DEFAULT_ICON,
+                url: `https://${site.host}`,
+                custom_fields: null,
+                ap_id: `https://${site.host}${AP_BASE_PATH}/users/${username}`,
+                ap_inbox_url: `https://${site.host}${AP_BASE_PATH}/inbox/${username}`,
+                ap_outbox_url: `https://${site.host}${AP_BASE_PATH}/outbox/${username}`,
+                ap_following_url: `https://${site.host}${AP_BASE_PATH}/following/${username}`,
+                ap_followers_url: `https://${site.host}${AP_BASE_PATH}/followers/${username}`,
+                ap_liked_url: `https://${site.host}${AP_BASE_PATH}/liked/${username}`,
+                ap_shared_inbox_url: null,
+            };
 
-        const account = await service.createInternalAccount(site, username);
+            const account = await service.createInternalAccount(site, username);
 
-        // Assert the created account was returned
-        expect(account).toMatchObject(expectedAccount);
-        expect(account.id).toBeGreaterThan(0);
-        expect(account.ap_public_key).toBeDefined();
-        expect(account.ap_public_key).toContain('key_ops');
-        expect(account.ap_private_key).toBeDefined();
-        expect(account.ap_private_key).toContain('key_ops');
+            // Assert the created account was returned
+            expect(account).toMatchObject(expectedAccount);
+            expect(account.id).toBeGreaterThan(0);
+            expect(account.ap_public_key).toBeDefined();
+            expect(account.ap_public_key).toContain('key_ops');
+            expect(account.ap_private_key).toBeDefined();
+            expect(account.ap_private_key).toContain('key_ops');
 
-        // Assert the account was inserted into the database
-        const accounts = await db(TABLE_ACCOUNTS).select('*');
+            // Assert the account was inserted into the database
+            const accounts = await db(TABLE_ACCOUNTS).select('*');
 
-        expect(accounts).toHaveLength(1);
+            expect(accounts).toHaveLength(1);
 
-        const dbAccount = accounts[0];
+            const dbAccount = accounts[0];
 
-        expect(dbAccount).toMatchObject(expectedAccount);
+            expect(dbAccount).toMatchObject(expectedAccount);
 
-        // Assert the user was inserted into the database
-        const users = await db(TABLE_USERS).select('*');
+            // Assert the user was inserted into the database
+            const users = await db(TABLE_USERS).select('*');
 
-        expect(users).toHaveLength(1);
+            expect(users).toHaveLength(1);
 
-        const dbUser = users[0];
+            const dbUser = users[0];
 
-        expect(dbUser.account_id).toBe(account.id);
-        expect(dbUser.site_id).toBe(site.id);
-    });
+            expect(dbUser.account_id).toBe(account.id);
+            expect(dbUser.site_id).toBe(site.id);
+        },
+        1000 * 10, // Increase timeout to 10 seconds as 5 seconds seems to be too short on CI
+    );
 
     it('should create an external account', async () => {
         const accountData: ExternalAccountData = {

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -88,16 +88,34 @@ export class AccountService {
     /**
      * Record an account follow
      *
-     * @param account Account being followed
-     * @param follower Follower account
+     * @param followee Account to follow
+     * @param follower Following account
      */
     async recordAccountFollow(
-        account: Account,
+        followee: Account,
         follower: Account,
     ): Promise<void> {
-        await this.db(TABLE_FOLLOWS).insert({
-            following_id: account.id,
-            follower_id: follower.id,
-        });
+        await this.db(TABLE_FOLLOWS)
+            .insert({
+                following_id: followee.id,
+                follower_id: follower.id,
+            })
+            .onConflict(['following_id', 'follower_id'])
+            .ignore();
+    }
+
+    /**
+     * Get an account by it's ActivityPub ID
+     *
+     * @param apId ActivityPub ID
+     */
+    async getAccountByApId(apId: string): Promise<Account | null> {
+        if (apId === '') {
+            return null;
+        }
+
+        return (
+            (await this.db(TABLE_ACCOUNTS).where('ap_id', apId).first()) ?? null
+        );
     }
 }

--- a/src/account/utils.ts
+++ b/src/account/utils.ts
@@ -1,0 +1,66 @@
+import { type Actor, PropertyValue } from '@fedify/fedify';
+import type { ExternalAccountData } from './types';
+
+export async function mapActorToExternalAccountData(
+    actor: Actor,
+): Promise<ExternalAccountData> {
+    const customFields: Record<string, string> = {};
+
+    for await (const attachment of actor.getAttachments()) {
+        if (!(attachment instanceof PropertyValue)) {
+            continue;
+        }
+
+        const name = attachment.name?.toString() || '';
+        const value = attachment.value?.toString() || '';
+
+        if (name && value) {
+            customFields[name] = value;
+        }
+    }
+
+    let apPublicKey:
+        | {
+              id: string;
+              owner: string;
+              publicKeyPem: string;
+          }
+        | string = '';
+
+    const publicKey = await actor.getPublicKey();
+
+    if (publicKey) {
+        const jsonLd = (await publicKey.toJsonLd({ format: 'compact' })) as {
+            id: string;
+            owner: string;
+            publicKeyPem: string;
+        };
+
+        if (typeof jsonLd === 'object' && jsonLd !== null) {
+            apPublicKey = {
+                id: jsonLd.id,
+                owner: jsonLd.owner,
+                publicKeyPem: jsonLd.publicKeyPem,
+            };
+        }
+    }
+
+    return {
+        username: actor.preferredUsername?.toString() ?? '',
+        name: actor.name?.toString() ?? null,
+        bio: actor.summary?.toString() ?? null,
+        avatar_url: (await actor.getIcon())?.url?.toString() ?? null,
+        banner_image_url: (await actor.getImage())?.url?.toString() ?? null,
+        url: actor.url?.toString() ?? null,
+        custom_fields:
+            Object.keys(customFields).length > 0 ? customFields : null,
+        ap_id: actor.id?.href ?? '',
+        ap_inbox_url: actor.inboxId?.href ?? '',
+        ap_shared_inbox_url: actor.endpoints?.sharedInbox?.href ?? null,
+        ap_outbox_url: actor.outboxId?.href ?? '',
+        ap_following_url: actor.followingId?.href ?? '',
+        ap_followers_url: actor.followersId?.href ?? '',
+        ap_liked_url: actor.likedId?.href ?? '',
+        ap_public_key: JSON.stringify(apPublicKey),
+    };
+}

--- a/src/account/utils.ts
+++ b/src/account/utils.ts
@@ -1,6 +1,12 @@
 import { type Actor, PropertyValue } from '@fedify/fedify';
 import type { ExternalAccountData } from './types';
 
+interface PublicKey {
+    id: string;
+    owner: string;
+    publicKeyPem: string;
+}
+
 export async function mapActorToExternalAccountData(
     actor: Actor,
 ): Promise<ExternalAccountData> {
@@ -19,28 +25,20 @@ export async function mapActorToExternalAccountData(
         }
     }
 
-    let apPublicKey:
-        | {
-              id: string;
-              owner: string;
-              publicKeyPem: string;
-          }
-        | string = '';
+    let apPublicKey: PublicKey | null = null;
 
     const publicKey = await actor.getPublicKey();
 
     if (publicKey) {
-        const jsonLd = (await publicKey.toJsonLd({ format: 'compact' })) as {
-            id: string;
-            owner: string;
-            publicKeyPem: string;
-        };
+        const jsonLd = (await publicKey.toJsonLd({
+            format: 'compact',
+        })) as Partial<PublicKey>;
 
         if (typeof jsonLd === 'object' && jsonLd !== null) {
             apPublicKey = {
-                id: jsonLd.id,
-                owner: jsonLd.owner,
-                publicKeyPem: jsonLd.publicKeyPem,
+                id: jsonLd.id ?? '',
+                owner: jsonLd.owner ?? '',
+                publicKeyPem: jsonLd.publicKeyPem ?? '',
             };
         }
     }
@@ -61,6 +59,6 @@ export async function mapActorToExternalAccountData(
         ap_following_url: actor.followingId?.href ?? '',
         ap_followers_url: actor.followersId?.href ?? '',
         ap_liked_url: actor.likedId?.href ?? '',
-        ap_public_key: JSON.stringify(apPublicKey),
+        ap_public_key: apPublicKey ? JSON.stringify(apPublicKey) : '',
     };
 }

--- a/src/account/utils.unit.test.ts
+++ b/src/account/utils.unit.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { type Actor, PropertyValue } from '@fedify/fedify';
+
+import { mapActorToExternalAccountData } from './utils';
+
+describe('mapActorToExternalAccountData', () => {
+    it('should map actor to external account data', async () => {
+        const actor = {
+            id: new URL('https://example.com/actor/example'),
+            preferredUsername: 'example',
+            name: 'Example',
+            summary: 'This is an example',
+            getIcon: vi.fn().mockResolvedValue({
+                url: new URL('https://example.com/icon/example'),
+            }),
+            getImage: vi.fn().mockResolvedValue({
+                url: new URL('https://example.com/image/example'),
+            }),
+            url: new URL('https://example.com/actor/example'),
+            getAttachments: vi.fn().mockImplementation(async function* () {
+                yield new PropertyValue({ name: 'foo', value: 'bar' });
+                yield new PropertyValue({ name: 'baz', value: 'qux' });
+            }),
+            inboxId: new URL('https://example.com/inbox/example'),
+            endpoints: {
+                sharedInbox: new URL('https://example.com/shared-inbox'),
+            },
+            outboxId: new URL('https://example.com/outbox/example'),
+            followingId: new URL('https://example.com/following/example'),
+            followersId: new URL('https://example.com/followers/example'),
+            likedId: new URL('https://example.com/liked/example'),
+            getPublicKey: vi.fn().mockResolvedValue({
+                toJsonLd: vi.fn().mockResolvedValue({
+                    id: 'https://example.com/public-key/example',
+                    owner: 'https://example.com/actor/example',
+                    publicKeyPem: 'publicKeyPem',
+                }),
+            }),
+        } as unknown as Actor;
+
+        const result = await mapActorToExternalAccountData(actor);
+
+        expect(result).toMatchObject({
+            username: 'example',
+            name: 'Example',
+            bio: 'This is an example',
+            avatar_url: 'https://example.com/icon/example',
+            banner_image_url: 'https://example.com/image/example',
+            url: 'https://example.com/actor/example',
+            custom_fields: {
+                foo: 'bar',
+                baz: 'qux',
+            },
+            ap_id: 'https://example.com/actor/example',
+            ap_inbox_url: 'https://example.com/inbox/example',
+            ap_shared_inbox_url: 'https://example.com/shared-inbox',
+            ap_outbox_url: 'https://example.com/outbox/example',
+            ap_following_url: 'https://example.com/following/example',
+            ap_followers_url: 'https://example.com/followers/example',
+            ap_liked_url: 'https://example.com/liked/example',
+            ap_public_key: JSON.stringify({
+                id: 'https://example.com/public-key/example',
+                owner: 'https://example.com/actor/example',
+                publicKeyPem: 'publicKeyPem',
+            }),
+        });
+    });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -210,6 +210,8 @@ export type FedifyRequestContext = RequestContext<ContextData>;
 
 export const db = await KnexKvStore.create(client, 'key_value');
 
+const accountService = new AccountService(client);
+
 /** Fedify */
 
 /**
@@ -254,7 +256,7 @@ const inboxListener = fedify.setInboxListeners(
 );
 
 inboxListener
-    .on(Follow, ensureCorrectContext(spanWrapper(handleFollow)))
+    .on(Follow, ensureCorrectContext(spanWrapper(handleFollow(accountService))))
     .onError(inboxErrorHandler)
     .on(Accept, ensureCorrectContext(spanWrapper(handleAccept)))
     .onError(inboxErrorHandler)
@@ -612,7 +614,6 @@ app.use(async (ctx, next) => {
     await next();
 });
 
-const accountService = new AccountService(client);
 const siteService = new SiteService(client, accountService);
 // This needs to go before the middleware which loads the site
 // Because the site doesn't always exist - this is how it's created

--- a/src/app.ts
+++ b/src/app.ts
@@ -43,6 +43,7 @@ import {
     actorDispatcher,
     articleDispatcher,
     createDispatcher,
+    createFollowHandler,
     followDispatcher,
     followersCounter,
     followersDispatcher,
@@ -53,7 +54,6 @@ import {
     handleAccept,
     handleAnnounce,
     handleCreate,
-    handleFollow,
     handleLike,
     inboxErrorHandler,
     keypairDispatcher,
@@ -256,7 +256,10 @@ const inboxListener = fedify.setInboxListeners(
 );
 
 inboxListener
-    .on(Follow, ensureCorrectContext(spanWrapper(handleFollow(accountService))))
+    .on(
+        Follow,
+        ensureCorrectContext(spanWrapper(createFollowHandler(accountService))),
+    )
     .onError(inboxErrorHandler)
     .on(Accept, ensureCorrectContext(spanWrapper(handleAccept)))
     .onError(inboxErrorHandler)

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -57,8 +57,11 @@ export async function keypairDispatcher(
     return [data];
 }
 
-export function handleFollow(accountService: AccountService) {
-    return async (ctx: Context<ContextData>, follow: Follow) => {
+export function createFollowHandler(accountService: AccountService) {
+    return async function handleFollow(
+        ctx: Context<ContextData>,
+        follow: Follow,
+    ) {
         ctx.data.logger.info('Handling Follow');
         if (!follow.id) {
             return;


### PR DESCRIPTION
refs [AP-661](https://linear.app/ghost/issue/AP-661/update-incoming-follow-activity-handler-to-record-data-in-the-new)

Updated incoming `Follow` activity handler to record data in the new follows table. The original logic for writing to the kv store is kept in place until we have fully migrated to th e new table.