### PR TITLE
Ensured that tests run in series

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "test:types": "tsc --noEmit",
     "test:unit": "vitest run --dir src --coverage '.unit.test.ts'",
     "test:unit:dev": "vitest --dir src --coverage '.unit.test.ts'",
-    "test:integration": "vitest run --sequence.concurrent=false --dir src --coverage '.integration.test.ts'",
-    "test:code": "vitest run --sequence.concurrent=false --dir src --coverage '.test.ts'",
+    "test:integration": "vitest run --no-file-parallelism --sequence.concurrent=false --dir src --coverage '.integration.test.ts'",
+    "test:code": "vitest run --no-file-parallelism --sequence.concurrent=false --dir src --coverage '.test.ts'",
     "test:all": "yarn test:types && yarn test:code",
     "lint": "biome check"
   },


### PR DESCRIPTION
Ours tests currently do some DB teardown and intefer with each other if they're run in parallel.