### PR TITLE
Updated `followers` and `following` counters to read data from the `follows` table

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -48,12 +48,12 @@ import {
     createAcceptHandler,
     createDispatcher,
     createFollowHandler,
+    createFollowersCounter,
     createFollowersDispatcher,
+    createFollowingCounter,
     createFollowingDispatcher,
     followDispatcher,
-    followersCounter,
     followersFirstCursor,
-    followingCounter,
     followingFirstCursor,
     handleAnnounce,
     handleCreate,
@@ -291,7 +291,7 @@ fedify
         '/.ghost/activitypub/followers/{handle}',
         spanWrapper(createFollowersDispatcher(siteService, accountService)),
     )
-    .setCounter(followersCounter)
+    .setCounter(createFollowersCounter(siteService, accountService))
     .setFirstCursor(followersFirstCursor);
 
 fedify
@@ -299,7 +299,7 @@ fedify
         '/.ghost/activitypub/following/{handle}',
         spanWrapper(createFollowingDispatcher(siteService, accountService)),
     )
-    .setCounter(followingCounter)
+    .setCounter(createFollowingCounter(siteService, accountService))
     .setFirstCursor(followingFirstCursor);
 
 fedify

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -711,13 +711,12 @@ export function createFollowersDispatcher(
             throw new Error(`Site not found for host: ${ctx.host}`);
         }
 
+        // @TODO: Get account by provided handle instead of default account?
         const siteDefaultAccount =
             await accountService.getDefaultAccountForSite(site);
 
         if (!siteDefaultAccount) {
-            throw new Error(
-                `Default account for site not found for site: ${site.id}`,
-            );
+            throw new Error(`Default account not found for site: ${site.id}`);
         }
 
         const results = await accountService.getFollowerAccounts(
@@ -751,15 +750,31 @@ export function createFollowersDispatcher(
     };
 }
 
-export async function followersCounter(
-    ctx: RequestContext<ContextData>,
-    handle: string,
+export function createFollowersCounter(
+    siteService: SiteService,
+    accountService: AccountService,
 ) {
-    const results = [
-        // Remove duplicates
-        ...new Set((await ctx.data.db.get<string[]>(['followers'])) || []),
-    ];
-    return results.length;
+    return async function countFollowers(
+        ctx: RequestContext<ContextData>,
+        handle: string,
+    ) {
+        const site = await siteService.getSiteByHost(ctx.host);
+        if (!site) {
+            throw new Error(`Site not found for host: ${ctx.host}`);
+        }
+
+        // @TODO: Get account by provided handle instead of default account?
+        const siteDefaultAccount =
+            await accountService.getDefaultAccountForSite(site);
+
+        if (!siteDefaultAccount) {
+            throw new Error(`Default account not found for site: ${site.id}`);
+        }
+
+        return await accountService.getFollowerAccountsCount(
+            siteDefaultAccount,
+        );
+    };
 }
 
 export function followersFirstCursor() {
@@ -852,13 +867,12 @@ export function createFollowingDispatcher(
             throw new Error(`Site not found for host: ${host}`);
         }
 
+        // @TODO: Get account by provided handle instead of default account?
         const siteDefaultAccount =
             await accountService.getDefaultAccountForSite(site);
 
         if (!siteDefaultAccount) {
-            throw new Error(
-                `Default account for site not found for site: ${site.id}`,
-            );
+            throw new Error(`Default account not found for site: ${site.id}`);
         }
 
         const results = await accountService.getFollowingAccounts(
@@ -886,12 +900,31 @@ export function createFollowingDispatcher(
     };
 }
 
-export async function followingCounter(
-    ctx: RequestContext<ContextData>,
-    handle: string,
+export function createFollowingCounter(
+    siteService: SiteService,
+    accountService: AccountService,
 ) {
-    const results = (await ctx.data.db.get<string[]>(['following'])) || [];
-    return results.length;
+    return async function countFollowing(
+        ctx: RequestContext<ContextData>,
+        handle: string,
+    ) {
+        const site = await siteService.getSiteByHost(ctx.host);
+        if (!site) {
+            throw new Error(`Site not found for host: ${ctx.host}`);
+        }
+
+        // @TODO: Get account by provided handle instead of default account?
+        const siteDefaultAccount =
+            await accountService.getDefaultAccountForSite(site);
+
+        if (!siteDefaultAccount) {
+            throw new Error(`Default account not found for site: ${site.id}`);
+        }
+
+        return await accountService.getFollowingAccountsCount(
+            siteDefaultAccount,
+        );
+    };
 }
 
 export function followingFirstCursor() {

--- a/src/http/api/accounts.ts
+++ b/src/http/api/accounts.ts
@@ -185,10 +185,12 @@ export function createGetAccountFollowsHandler(
             return new Response(null, { status: 404 });
         }
 
-        const account = await accountService.getDefaultAccountForSite(site); // @TODO: Get account by handle
+        // @TODO: Get account by provided handle instead of default account?
+        const siteDefaultAccount =
+            await accountService.getDefaultAccountForSite(site);
 
-        if (!account) {
-            logger.error('No default account found for site: {siteHost}', {
+        if (!siteDefaultAccount) {
+            logger.error('Default account not found for site: {siteHost}', {
                 siteHost,
             });
 
@@ -199,12 +201,12 @@ export function createGetAccountFollowsHandler(
         const queryNext = ctx.req.query('next') || '0';
         const offset = Number.parseInt(queryNext);
 
-        const results = await getAccounts(account, {
+        const results = await getAccounts(siteDefaultAccount, {
             limit: FOLLOWS_LIMIT,
             offset,
             fields: ['id', 'ap_id', 'name', 'username', 'avatar_url'],
         });
-        const total = await getAccountsCount(account);
+        const total = await getAccountsCount(siteDefaultAccount);
 
         const next =
             total > offset + FOLLOWS_LIMIT


### PR DESCRIPTION
refs [AP-681](https://linear.app/ghost/issue/AP-681/update-followers-and-following-counters-to-read-data-from-the-new)

Updated `followers` and `following` counters to read data from the `follows` table