### PR TITLE
Updated follow action to use `follows` table when checking if already following

### DIFF
--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -611,12 +611,10 @@ Given('we follow {string}', async function (name) {
         },
     );
     if (this.response.ok) {
-        const actor = await this.response.clone().json();
-
         this.activities[`Follow(${name})`] = await createActivity(
             'Follow',
-            actor,
-            actor,
+            this.actors[name],
+            this.actors.Us,
         );
     }
 });

--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -453,6 +453,39 @@ describe('AccountService', () => {
         });
     });
 
+    describe('checkIfAccountIsFollowing', () => {
+        it('should check if an account is following another account', async () => {
+            const account = await service.createInternalAccount(
+                site,
+                'account',
+            );
+            const followee = await service.createInternalAccount(
+                site,
+                'followee',
+            );
+            const nonFollowee = await service.createInternalAccount(
+                site,
+                'non-followee',
+            );
+
+            await service.recordAccountFollow(followee, account);
+
+            const isFollowing = await service.checkIfAccountIsFollowing(
+                account,
+                followee,
+            );
+
+            expect(isFollowing).toBe(true);
+
+            const isNotFollowing = await service.checkIfAccountIsFollowing(
+                account,
+                nonFollowee,
+            );
+
+            expect(isNotFollowing).toBe(false);
+        });
+    });
+
     it('should update accounts and emit an account.updated event if they have changed', async () => {
         const account = await service.createInternalAccount(
             site,

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -246,6 +246,25 @@ export class AccountService {
         return Number(result[0].count);
     }
 
+    /**
+     * Check if an account is following another account
+     *
+     * @param account Account to check
+     * @param followee Followee account
+     */
+    async checkIfAccountIsFollowing(
+        account: Account,
+        followee: Account,
+    ): Promise<boolean> {
+        const result = await this.db(TABLE_FOLLOWS)
+            .where('follower_id', account.id)
+            .where('following_id', followee.id)
+            .select(1)
+            .first();
+
+        return result !== undefined;
+    }
+
     async getByInternalId(id: number): Promise<Account | null> {
         const rows = await this.db(TABLE_ACCOUNTS).select('*').where({ id });
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -73,7 +73,7 @@ import {
     updateDispatcher,
 } from './dispatchers';
 import {
-    followAction,
+    createFollowActionHandler,
     getSiteDataHandler,
     inboxHandler,
     likeAction,
@@ -755,7 +755,7 @@ app.get(
 app.post(
     '/.ghost/activitypub/actions/follow/:handle',
     requireRole(GhostRole.Owner),
-    spanWrapper(followAction),
+    spanWrapper(createFollowActionHandler(accountService)),
 );
 app.post(
     '/.ghost/activitypub/actions/like/:id',


### PR DESCRIPTION
refs [AP-655](https://linear.app/ghost/issue/AP-664/update-api-follow-action-to-record-data-in-the-new-follows-table)

Updated follow action to use `follows` table when checking if already following