### PR TITLE
Updated application to use `isFollowedByDefaultSiteAccount`

### DIFF
--- a/src/http/api/follows.ts
+++ b/src/http/api/follows.ts
@@ -1,7 +1,11 @@
 import { type Actor, type CollectionPage, isActor } from '@fedify/fedify';
 
+import type { AccountService } from '../../account/account.service';
 import { type AppContext, fedify } from '../../app';
-import { isFollowing, isHandle } from '../../helpers/activitypub/actor';
+import {
+    isFollowedByDefaultSiteAccount,
+    isHandle,
+} from '../../helpers/activitypub/actor';
 import { isUri } from '../../helpers/uri';
 import { lookupObject } from '../../lookup-helpers';
 
@@ -14,115 +18,129 @@ interface FollowersResult {
 }
 
 /**
- * Handle a request for a profile's followers
+ * Create a handler for a request for a profile's followers
  *
- * @param ctx App context instance
+ * @param accountService Account service instance
  */
-export async function handleGetFollowers(ctx: AppContext) {
-    const db = ctx.get('db');
-    const logger = ctx.get('logger');
-    const apCtx = fedify.createContext(ctx.req.raw as Request, {
-        db,
-        globaldb: ctx.get('globaldb'),
-        logger,
-    });
+export function createGetFollowersHandler(accountService: AccountService) {
+    /**
+     * Handle a request for a profile's followers
+     *
+     * @param ctx App context instance
+     */
+    return async function handleGetFollowers(ctx: AppContext) {
+        const db = ctx.get('db');
+        const logger = ctx.get('logger');
+        const site = ctx.get('site');
+        const apCtx = fedify.createContext(ctx.req.raw as Request, {
+            db,
+            globaldb: ctx.get('globaldb'),
+            logger,
+        });
 
-    // Parse "handle" from request parameters
-    // /profile/:handle/followers
-    const handle = ctx.req.param('handle') || '';
+        // Parse "handle" from request parameters
+        // /profile/:handle/followers
+        const handle = ctx.req.param('handle') || '';
 
-    // If the provided handle is invalid, return early
-    if (!isHandle(handle)) {
-        return new Response(null, { status: 400 });
-    }
+        // If the provided handle is invalid, return early
+        if (!isHandle(handle)) {
+            return new Response(null, { status: 400 });
+        }
 
-    // Parse "next" from query parameters
-    // /profile/:handle/followers?next=<string>
-    const queryNext = ctx.req.query('next') || '';
-    const next = queryNext ? decodeURIComponent(queryNext) : '';
+        // Parse "next" from query parameters
+        // /profile/:handle/followers?next=<string>
+        const queryNext = ctx.req.query('next') || '';
+        const next = queryNext ? decodeURIComponent(queryNext) : '';
 
-    // If the next parameter is not a valid URI, return early
-    if (next !== '' && !isUri(next)) {
-        return new Response(null, { status: 400 });
-    }
+        // If the next parameter is not a valid URI, return early
+        if (next !== '' && !isUri(next)) {
+            return new Response(null, { status: 400 });
+        }
 
-    // Lookup actor by handle
-    const actor = await lookupObject(apCtx, handle);
+        // Lookup actor by handle
+        const actor = await lookupObject(apCtx, handle);
 
-    if (!isActor(actor)) {
-        return new Response(null, { status: 404 });
-    }
+        if (!isActor(actor)) {
+            return new Response(null, { status: 404 });
+        }
 
-    // Retrieve actor's followers
-    // If a next parameter was provided, use it to retrieve a specific page of
-    // followers. Otherwise, retrieve the first page of followers
-    const result: FollowersResult = {
-        followers: [],
-        next: null,
+        // Retrieve actor's followers
+        // If a next parameter was provided, use it to retrieve a specific page of
+        // followers. Otherwise, retrieve the first page of followers
+        const result: FollowersResult = {
+            followers: [],
+            next: null,
+        };
+
+        let page: CollectionPage | null = null;
+
+        try {
+            if (next !== '') {
+                // Ensure the next parameter is for the same host as the actor. We
+                // do this to prevent blindly passing URIs to lookupObject (i.e next
+                // param has been tampered with)
+                // @TODO: Does this provide enough security? Can the host of the
+                // actor be different to the host of the actor's followers collection?
+                const { host: actorHost } = actor?.id || new URL('');
+                const { host: nextHost } = new URL(next);
+
+                if (actorHost !== nextHost) {
+                    return new Response(null, { status: 400 });
+                }
+
+                page = (await lookupObject(
+                    apCtx,
+                    next,
+                )) as CollectionPage | null;
+
+                // Explicitly check that we have a valid page seeming though we
+                // can't be type safe due to lookupObject returning a generic object
+                if (!page?.itemIds) {
+                    page = null;
+                }
+            } else {
+                const followers = await actor.getFollowers();
+
+                if (followers) {
+                    page = await followers.getFirst();
+                }
+            }
+        } catch (err) {
+            logger.error('Error getting followers', { error: err });
+        }
+
+        if (!page) {
+            return new Response(null, { status: 404 });
+        }
+
+        // Return result
+        try {
+            for await (const item of page.getItems()) {
+                result.followers.push({
+                    actor: await item.toJsonLd({ format: 'compact' }),
+                    isFollowing: await isFollowedByDefaultSiteAccount(
+                        item as Actor,
+                        site,
+                        accountService,
+                    ),
+                });
+            }
+        } catch (err) {
+            logger.error('Error getting followers', { error: err });
+        }
+
+        result.next = page.nextId
+            ? encodeURIComponent(page.nextId.toString())
+            : null;
+
+        return new Response(JSON.stringify(result), {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            status: 200,
+        });
     };
-
-    let page: CollectionPage | null = null;
-
-    try {
-        if (next !== '') {
-            // Ensure the next parameter is for the same host as the actor. We
-            // do this to prevent blindly passing URIs to lookupObject (i.e next
-            // param has been tampered with)
-            // @TODO: Does this provide enough security? Can the host of the
-            // actor be different to the host of the actor's followers collection?
-            const { host: actorHost } = actor?.id || new URL('');
-            const { host: nextHost } = new URL(next);
-
-            if (actorHost !== nextHost) {
-                return new Response(null, { status: 400 });
-            }
-
-            page = (await lookupObject(apCtx, next)) as CollectionPage | null;
-
-            // Explicitly check that we have a valid page seeming though we
-            // can't be type safe due to lookupObject returning a generic object
-            if (!page?.itemIds) {
-                page = null;
-            }
-        } else {
-            const followers = await actor.getFollowers();
-
-            if (followers) {
-                page = await followers.getFirst();
-            }
-        }
-    } catch (err) {
-        logger.error('Error getting followers', { error: err });
-    }
-
-    if (!page) {
-        return new Response(null, { status: 404 });
-    }
-
-    // Return result
-    try {
-        for await (const item of page.getItems()) {
-            result.followers.push({
-                actor: await item.toJsonLd({ format: 'compact' }),
-                isFollowing: await isFollowing(item as Actor, { db }),
-            });
-        }
-    } catch (err) {
-        logger.error('Error getting followers', { error: err });
-    }
-
-    result.next = page.nextId
-        ? encodeURIComponent(page.nextId.toString())
-        : null;
-
-    return new Response(JSON.stringify(result), {
-        headers: {
-            'Content-Type': 'application/json',
-        },
-        status: 200,
-    });
 }
-
 interface FollowingResult {
     following: {
         actor: any;
@@ -132,112 +150,127 @@ interface FollowingResult {
 }
 
 /**
- * Handle a request for a profile's following
+ * Create a handler for a request for a profile's following
  *
- * @param ctx App context instance
+ * @param accountService Account service instance
  */
-export async function handleGetFollowing(ctx: AppContext) {
-    const db = ctx.get('db');
-    const logger = ctx.get('logger');
-    const apCtx = fedify.createContext(ctx.req.raw as Request, {
-        db,
-        globaldb: ctx.get('globaldb'),
-        logger,
-    });
+export function createGetFollowingHandler(accountService: AccountService) {
+    /**
+     * Handle a request for a profile's following
+     *
+     * @param ctx App context instance
+     */
+    return async function handleGetFollowing(ctx: AppContext) {
+        const db = ctx.get('db');
+        const logger = ctx.get('logger');
+        const site = ctx.get('site');
+        const apCtx = fedify.createContext(ctx.req.raw as Request, {
+            db,
+            globaldb: ctx.get('globaldb'),
+            logger,
+        });
 
-    // Parse "handle" from request parameters
-    // /profile/:handle/following
-    const handle = ctx.req.param('handle') || '';
+        // Parse "handle" from request parameters
+        // /profile/:handle/following
+        const handle = ctx.req.param('handle') || '';
 
-    // If the provided handle is invalid, return early
-    if (!isHandle(handle)) {
-        return new Response(null, { status: 400 });
-    }
+        // If the provided handle is invalid, return early
+        if (!isHandle(handle)) {
+            return new Response(null, { status: 400 });
+        }
 
-    // Parse "next" from query parameters
-    // /profile/:handle/following?next=<string>
-    const queryNext = ctx.req.query('next') || '';
-    const next = queryNext ? decodeURIComponent(queryNext) : '';
+        // Parse "next" from query parameters
+        // /profile/:handle/following?next=<string>
+        const queryNext = ctx.req.query('next') || '';
+        const next = queryNext ? decodeURIComponent(queryNext) : '';
 
-    // If the next parameter is not a valid URI, return early
-    if (next !== '' && !isUri(next)) {
-        return new Response(null, { status: 400 });
-    }
+        // If the next parameter is not a valid URI, return early
+        if (next !== '' && !isUri(next)) {
+            return new Response(null, { status: 400 });
+        }
 
-    // Lookup actor by handle
-    const actor = await lookupObject(apCtx, handle);
+        // Lookup actor by handle
+        const actor = await lookupObject(apCtx, handle);
 
-    if (!isActor(actor)) {
-        return new Response(null, { status: 404 });
-    }
+        if (!isActor(actor)) {
+            return new Response(null, { status: 404 });
+        }
 
-    // Retrieve actor's following
-    // If a next parameter was provided, use it to retrieve a specific page of
-    // the actor's following. Otherwise, retrieve the first page of the actor's
-    // following
-    const result: FollowingResult = {
-        following: [],
-        next: null,
+        // Retrieve actor's following
+        // If a next parameter was provided, use it to retrieve a specific page of
+        // the actor's following. Otherwise, retrieve the first page of the actor's
+        // following
+        const result: FollowingResult = {
+            following: [],
+            next: null,
+        };
+
+        let page: CollectionPage | null = null;
+
+        try {
+            if (next !== '') {
+                // Ensure the next parameter is for the same host as the actor. We
+                // do this to prevent blindly passing URIs to lookupObject (i.e next
+                // param has been tampered with)
+                // @TODO: Does this provide enough security? Can the host of the
+                // actor be different to the host of the actor's following collection?
+                const { host: actorHost } = actor?.id || new URL('');
+                const { host: nextHost } = new URL(next);
+
+                if (actorHost !== nextHost) {
+                    return new Response(null, { status: 400 });
+                }
+
+                page = (await lookupObject(
+                    apCtx,
+                    next,
+                )) as CollectionPage | null;
+
+                // Explicitly check that we have a valid page seeming though we
+                // can't be type safe due to lookupObject returning a generic object
+                if (!page?.itemIds) {
+                    page = null;
+                }
+            } else {
+                const following = await actor.getFollowing();
+
+                if (following) {
+                    page = await following.getFirst();
+                }
+            }
+        } catch (err) {
+            logger.error('Error getting following', { error: err });
+        }
+
+        if (!page) {
+            return new Response(null, { status: 404 });
+        }
+
+        // Return result
+        try {
+            for await (const item of page.getItems()) {
+                result.following.push({
+                    actor: await item.toJsonLd({ format: 'compact' }),
+                    isFollowing: await isFollowedByDefaultSiteAccount(
+                        item as Actor,
+                        site,
+                        accountService,
+                    ),
+                });
+            }
+        } catch (err) {
+            logger.error('Error getting following', { error: err });
+        }
+
+        result.next = page.nextId
+            ? encodeURIComponent(page.nextId.toString())
+            : null;
+
+        return new Response(JSON.stringify(result), {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            status: 200,
+        });
     };
-
-    let page: CollectionPage | null = null;
-
-    try {
-        if (next !== '') {
-            // Ensure the next parameter is for the same host as the actor. We
-            // do this to prevent blindly passing URIs to lookupObject (i.e next
-            // param has been tampered with)
-            // @TODO: Does this provide enough security? Can the host of the
-            // actor be different to the host of the actor's following collection?
-            const { host: actorHost } = actor?.id || new URL('');
-            const { host: nextHost } = new URL(next);
-
-            if (actorHost !== nextHost) {
-                return new Response(null, { status: 400 });
-            }
-
-            page = (await lookupObject(apCtx, next)) as CollectionPage | null;
-
-            // Explicitly check that we have a valid page seeming though we
-            // can't be type safe due to lookupObject returning a generic object
-            if (!page?.itemIds) {
-                page = null;
-            }
-        } else {
-            const following = await actor.getFollowing();
-
-            if (following) {
-                page = await following.getFirst();
-            }
-        }
-    } catch (err) {
-        logger.error('Error getting following', { error: err });
-    }
-
-    if (!page) {
-        return new Response(null, { status: 404 });
-    }
-
-    // Return result
-    try {
-        for await (const item of page.getItems()) {
-            result.following.push({
-                actor: await item.toJsonLd({ format: 'compact' }),
-                isFollowing: await isFollowing(item as Actor, { db }),
-            });
-        }
-    } catch (err) {
-        logger.error('Error getting following', { error: err });
-    }
-
-    result.next = page.nextId
-        ? encodeURIComponent(page.nextId.toString())
-        : null;
-
-    return new Response(JSON.stringify(result), {
-        headers: {
-            'Content-Type': 'application/json',
-        },
-        status: 200,
-    });
 }

--- a/src/http/api/profiles.ts
+++ b/src/http/api/profiles.ts
@@ -1,12 +1,13 @@
 import { isActor } from '@fedify/fedify';
 
+import type { AccountService } from '../../account/account.service';
 import { type AppContext, fedify } from '../../app';
 import {
     getAttachments,
     getFollowerCount,
     getFollowingCount,
     getHandle,
-    isFollowing,
+    isFollowedByDefaultSiteAccount,
     isHandle,
 } from '../../helpers/activitypub/actor';
 import { sanitizeHtml } from '../../helpers/html';
@@ -21,76 +22,88 @@ interface Profile {
 }
 
 /**
- * Handle a request for a profile
+ * Create a handler for a request for a profile
  *
- * @param ctx App context instance
+ * @param accountService Account service instance
  */
-export async function handleGetProfile(ctx: AppContext) {
-    const db = ctx.get('db');
-    const logger = ctx.get('logger');
-    const apCtx = fedify.createContext(ctx.req.raw as Request, {
-        db,
-        globaldb: ctx.get('globaldb'),
-        logger,
-    });
+export function createGetProfileHandler(accountService: AccountService) {
+    /**
+     * Handle a request for a profile
+     *
+     * @param ctx App context instance
+     */
+    return async function handleGetProfile(ctx: AppContext) {
+        const db = ctx.get('db');
+        const logger = ctx.get('logger');
+        const site = ctx.get('site');
+        const apCtx = fedify.createContext(ctx.req.raw as Request, {
+            db,
+            globaldb: ctx.get('globaldb'),
+            logger,
+        });
 
-    // Parse "handle" from request parameters
-    // /profile/:handle
-    const handle = ctx.req.param('handle') || '';
+        // Parse "handle" from request parameters
+        // /profile/:handle
+        const handle = ctx.req.param('handle') || '';
 
-    // If the provided handle is invalid, return early
-    if (isHandle(handle) === false) {
-        return new Response(null, { status: 400 });
-    }
-
-    // Lookup actor by handle
-    const result: Profile = {
-        actor: {},
-        handle: '',
-        followerCount: 0,
-        followingCount: 0,
-        isFollowing: false,
-    };
-
-    try {
-        const actor = await lookupObject(apCtx, handle);
-
-        if (!isActor(actor)) {
-            return new Response(null, { status: 404 });
+        // If the provided handle is invalid, return early
+        if (isHandle(handle) === false) {
+            return new Response(null, { status: 400 });
         }
 
-        result.actor = await actor.toJsonLd();
-        result.actor.summary = sanitizeHtml(result.actor.summary);
-        result.handle = getHandle(actor);
+        // Lookup actor by handle
+        const result: Profile = {
+            actor: {},
+            handle: '',
+            followerCount: 0,
+            followingCount: 0,
+            isFollowing: false,
+        };
 
-        const [followerCount, followingCount, isFollowingResult, attachments] =
-            await Promise.all([
+        try {
+            const actor = await lookupObject(apCtx, handle);
+
+            if (!isActor(actor)) {
+                return new Response(null, { status: 404 });
+            }
+
+            result.actor = await actor.toJsonLd();
+            result.actor.summary = sanitizeHtml(result.actor.summary);
+            result.handle = getHandle(actor);
+
+            const [
+                followerCount,
+                followingCount,
+                isFollowingResult,
+                attachments,
+            ] = await Promise.all([
                 getFollowerCount(actor),
                 getFollowingCount(actor),
-                isFollowing(actor, { db }),
+                isFollowedByDefaultSiteAccount(actor, site, accountService),
                 getAttachments(actor, {
                     sanitizeValue: (value: string) => sanitizeHtml(value),
                 }),
             ]);
 
-        result.followerCount = followerCount;
-        result.followingCount = followingCount;
-        result.isFollowing = isFollowingResult;
-        result.actor.attachment = attachments;
-    } catch (err) {
-        logger.error('Profile retrieval failed ({handle}): {error}', {
-            handle,
-            error: err,
+            result.followerCount = followerCount;
+            result.followingCount = followingCount;
+            result.isFollowing = isFollowingResult;
+            result.actor.attachment = attachments;
+        } catch (err) {
+            logger.error('Profile retrieval failed ({handle}): {error}', {
+                handle,
+                error: err,
+            });
+
+            return new Response(null, { status: 500 });
+        }
+
+        // Return results
+        return new Response(JSON.stringify(result), {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            status: 200,
         });
-
-        return new Response(null, { status: 500 });
-    }
-
-    // Return results
-    return new Response(JSON.stringify(result), {
-        headers: {
-            'Content-Type': 'application/json',
-        },
-        status: 200,
-    });
+    };
 }


### PR DESCRIPTION
no refs

Updated application to use `isFollowedByDefaultSiteAccount` to determine if an actor is followed by the default site account. This should replace the old `isFollowing` helper function that reads from the old KV store.

Affected areas:

- Search results to indicate if a search result account is followed by the
  default site account
- Profile result to indicate if a profile is followed by the default
  site account
- Follows result to indicate if a profile follow result is followed by the
  default site account
- `Create` handler when checking if an item should be added to the inbox
- `Announce` handler when checking if an item should be added to the inbox
- `AnnouncedCreate` handler when checking if an item should processed

This change also ensures that `site` on the `AppContext` is typed correctly so that request handlers do not have to manually resolve the site via the site service