### PR TITLE
Removed duplicate method for fetching default account

### DIFF
--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -255,6 +255,20 @@ describe('AccountService', () => {
                 service.getDefaultAccountForSite(site),
             ).rejects.toThrow(`No user found for site: ${site.id}`);
         });
+
+        it('should throw an error if no account is found for a site user', async () => {
+            await service.createInternalAccount(site, 'account1');
+
+            const rows = await db('users')
+                .select('account_id')
+                .where({ site_id: site.id });
+
+            await db('accounts').where({ id: rows[0].account_id }).del();
+
+            await expect(
+                service.getDefaultAccountForSite(site),
+            ).rejects.toThrow();
+        });
     });
 
     describe('getFollowingAccounts', () => {

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -138,7 +138,7 @@ export class AccountService {
      *
      * @param site Site
      */
-    async getDefaultAccountForSite(site: Site): Promise<Account | null> {
+    async getDefaultAccountForSite(site: Site): Promise<Account> {
         const users = await this.db(TABLE_USERS).where('site_id', site.id);
 
         if (users.length === 0) {
@@ -153,9 +153,15 @@ export class AccountService {
 
         // We can safely assume that there is an account for the user due to
         // the foreign key constraint on the users table
-        return await this.db(TABLE_ACCOUNTS)
+        const account = await this.db(TABLE_ACCOUNTS)
             .where('id', user.account_id)
             .first();
+
+        if (!account) {
+            throw new Error(`Default account not found for site ${site.id}`);
+        }
+
+        return account;
     }
 
     /**

--- a/src/app.ts
+++ b/src/app.ts
@@ -257,10 +257,12 @@ fedify
     // actorDispatcher uses RequestContext so doesn't need the ensureCorrectContext wrapper
     .setActorDispatcher(
         '/.ghost/activitypub/users/{handle}',
-        spanWrapper(actorDispatcher(siteService)),
+        spanWrapper(actorDispatcher(siteService, accountService)),
     )
     .setKeyPairsDispatcher(
-        ensureCorrectContext(spanWrapper(keypairDispatcher(siteService))),
+        ensureCorrectContext(
+            spanWrapper(keypairDispatcher(siteService, accountService)),
+        ),
     );
 
 const inboxListener = fedify.setInboxListeners(

--- a/src/dispatchers.unit.test.ts
+++ b/src/dispatchers.unit.test.ts
@@ -16,9 +16,10 @@ import {
     outboxDispatcher,
 } from './dispatchers';
 
-import type { SiteService } from 'site/site.service';
+import type { AccountService } from './account/account.service';
 import { ACTOR_DEFAULT_HANDLE } from './constants';
 import * as lookupHelpers from './lookup-helpers';
+import type { SiteService } from './site/site.service';
 
 vi.mock('./app', () => ({
     fedify: {
@@ -32,10 +33,10 @@ describe('dispatchers', () => {
             const ctx = {} as RequestContext<any>;
             const handle = 'anything';
 
-            const actual = await actorDispatcher({} as unknown as SiteService)(
-                ctx,
-                handle,
-            );
+            const actual = await actorDispatcher(
+                {} as unknown as SiteService,
+                {} as unknown as AccountService,
+            )(ctx, handle);
             const expected = null;
 
             expect(actual).toEqual(expected);

--- a/src/http/api/accounts.ts
+++ b/src/http/api/accounts.ts
@@ -81,7 +81,7 @@ export function createGetAccountHandler(
             return new Response(null, { status: 404 });
         }
 
-        const account = await siteService.getDefaultAccountForSite(site);
+        const account = await accountService.getDefaultAccountForSite(site);
 
         try {
             accountDto = {
@@ -188,14 +188,6 @@ export function createGetAccountFollowsHandler(
         // @TODO: Get account by provided handle instead of default account?
         const siteDefaultAccount =
             await accountService.getDefaultAccountForSite(site);
-
-        if (!siteDefaultAccount) {
-            logger.error('Default account not found for site: {siteHost}', {
-                siteHost,
-            });
-
-            return new Response(null, { status: 404 });
-        }
 
         // Get follows accounts and paginate
         const queryNext = ctx.req.query('next') || '0';

--- a/src/site/site.service.integration.test.ts
+++ b/src/site/site.service.integration.test.ts
@@ -100,7 +100,7 @@ describe('SiteService', () => {
             .mockResolvedValue({} as unknown as Account);
 
         const site = await service.initialiseSiteForHost('updating.tld');
-        const account = await service.getDefaultAccountForSite(site);
+        const account = await accountService.getDefaultAccountForSite(site);
 
         await service.refreshSiteDataForHost('updating.tld');
 

--- a/src/site/site.service.ts
+++ b/src/site/site.service.ts
@@ -1,7 +1,6 @@
 import crypto from 'node:crypto';
 import type { Knex } from 'knex';
 import type { AccountService } from '../account/account.service';
-import type { Account } from '../account/types';
 import type { getSiteSettings } from '../helpers/ghost';
 
 export type Site = {
@@ -84,37 +83,14 @@ export class SiteService {
         return newSite;
     }
 
-    public async getDefaultAccountForSite(site: Site): Promise<Account> {
-        const rows = await this.client('users')
-            .select('account_id')
-            .where({ site_id: site.id });
-
-        if (!rows || !rows.length) {
-            throw new Error(`User not found for site ${site.id}`);
-        }
-
-        if (rows.length !== 1) {
-            throw new Error(`Multiple users found for site ${site.id}`);
-        }
-
-        const account = await this.accountService.getByInternalId(
-            rows[0].account_id,
-        );
-
-        if (account === null) {
-            throw new Error(`Default Account not found for site ${site.id}`);
-        }
-
-        return account;
-    }
-
     public async refreshSiteDataForHost(host: string): Promise<void> {
         const site = await this.getSiteByHost(host);
         if (!site) {
             throw new Error(`Could not find site for ${host}`);
         }
 
-        const account = await this.getDefaultAccountForSite(site);
+        const account =
+            await this.accountService.getDefaultAccountForSite(site);
 
         const settings = await this.ghostService.getSiteSettings(site.host);
 


### PR DESCRIPTION
Whilst we were building out the infrastructure for accounts and sites we ended up with some duplicate code, this consolidates it into the account service, slightly updating the signature to never resolve with null, throwing if an account is not found instead. We also clean up all the call sites and tests.