### PR TITLE
Added missing isFollowing property to follows API

### DIFF
--- a/src/http/api/accounts.ts
+++ b/src/http/api/accounts.ts
@@ -13,7 +13,10 @@ const FOLLOWS_LIMIT = 20;
 /**
  * Follow account shape - Used when returning a list of follow accounts
  */
-type FollowAccount = Pick<AccountDTO, 'id' | 'name' | 'handle' | 'avatarUrl'>;
+type FollowAccount = Pick<
+    AccountDTO,
+    'id' | 'name' | 'handle' | 'avatarUrl'
+> & { isFollowing: boolean };
 
 /**
  * Compute the handle for an account from the provided host and username
@@ -194,6 +197,13 @@ export function createGetAccountFollowsHandler(accountService: AccountService) {
                 name: result.name || '',
                 handle: getHandle(new URL(result.ap_id).host, result.username),
                 avatarUrl: result.avatar_url || '',
+                isFollowing:
+                    type === 'following'
+                        ? true
+                        : await accountService.checkIfAccountIsFollowing(
+                              siteDefaultAccount,
+                              result,
+                          ),
             });
         }
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-690

Pretty much whenever we return external accounts we need to know whether or not we're following them so that we can correctly render follow/unfollow buttons