### PR TITLE
Fixed persisting of `Announce` activities

### DIFF
--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -581,8 +581,16 @@ export function createAnnounceHandler(
         }
 
         // Persist announce
-        const announceJson = await announce.toJsonLd();
-        ctx.data.globaldb.set([announce.id.href], announceJson);
+        const announceJson = (await announce.toJsonLd()) as {
+            object: object | string;
+            [key: string]: unknown;
+        };
+
+        if (existing) {
+            // If the announced object already exists in globalDb, set it on
+            // the activity
+            announceJson.object = existing;
+        }
 
         // Persist object if not already persisted
         if (!existing && object && object.id) {
@@ -604,7 +612,12 @@ export function createAnnounceHandler(
             }
 
             ctx.data.globaldb.set([object.id.href], objectJson);
+
+            // Set the full object on the activity
+            announceJson.object = objectJson as object;
         }
+
+        ctx.data.globaldb.set([announce.id.href], announceJson);
 
         let shouldAddToInbox = false;
 


### PR DESCRIPTION
refs [AP-698](https://linear.app/ghost/issue/AP-698/announced-activities-not-showing-up-in-the-inbox-feed)

When persisting `Announce` objects we sometimes don't persist the object being announced ON the activity itself. This breaks any queries that rely on the `object` field of the `Announce` activity (i.e retrieving activities). This fix ensures that the object being announced is always persisted on the `Announce` activity