### PR TITLE
Required Owner role to read site data

### DIFF
--- a/features/site-data.feature
+++ b/features/site-data.feature
@@ -1,0 +1,8 @@
+Feature: Get site data
+  Scenario: It will 403 without authentication
+    When an unauthenticated request is made to "/.ghost/activitypub/site"
+    Then the request is rejected with a 403
+
+  Scenario: It will respond with authentication
+    When an authenticated request is made to "/.ghost/activitypub/site"
+    Then the request is accepted

--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -549,7 +549,7 @@ Before(async function () {
     }
 });
 
-async function fetchActivityPub(url, options = {}) {
+async function fetchActivityPub(url, options = {}, auth = true) {
     if (!options.headers) {
         options.headers = {};
     }
@@ -570,7 +570,10 @@ async function fetchActivityPub(url, options = {}) {
         },
     );
 
-    options.headers.Authorization = `Bearer ${token}`;
+    if (auth) {
+        options.headers.Authorization = `Bearer ${token}`;
+    }
+
     return fetch(url, options);
 }
 
@@ -588,6 +591,29 @@ When('we request the outbox', async function () {
                 Accept: 'application/ld+json',
             },
         },
+    );
+});
+
+When('an authenticated request is made to {string}', async function (path) {
+    this.response = await fetchActivityPub(
+        `http://fake-ghost-activitypub${path}`,
+        {
+            headers: {
+                Accept: 'application/ld+json',
+            },
+        },
+    );
+});
+
+When('an unauthenticated request is made to {string}', async function (path) {
+    this.response = await fetchActivityPub(
+        `http://fake-ghost-activitypub${path}`,
+        {
+            headers: {
+                Accept: 'application/ld+json',
+            },
+        },
+        false,
     );
 });
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -654,7 +654,11 @@ app.use(async (ctx, next) => {
 
 // This needs to go before the middleware which loads the site
 // Because the site doesn't always exist - this is how it's created
-app.get('/.ghost/activitypub/site', getSiteDataHandler(siteService));
+app.get(
+    '/.ghost/activitypub/site',
+    requireRole(GhostRole.Owner),
+    getSiteDataHandler(siteService),
+);
 
 /**
  * Essentially Auth middleware and also handles the multitenancy

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -505,8 +505,6 @@ export const getSiteDataHandler =
 
         const site = await siteService.initialiseSiteForHost(host);
 
-        console.log(site);
-
         // This is to ensure that the actor exists - e.g. for a brand new a site
         await getUserData(apCtx, handle);
 


### PR DESCRIPTION
We don't want site data to be read by anyone but the site itself. This also cleans up an old console log in the site data handler.