### PR TITLE
Added API endpoint to repost a post

### DIFF
--- a/features/repost-activity.feature
+++ b/features/repost-activity.feature
@@ -1,4 +1,3 @@
-@only
 Feature: Reposting a post
   In order to share content with my followers
   As a user

--- a/features/repost-activity.feature
+++ b/features/repost-activity.feature
@@ -1,30 +1,31 @@
-Feature: Reposting an object
+@only
+Feature: Reposting a post
+  In order to share content with my followers
   As a user
-  I want to repost an object in my feed
-  So that I can share the content with my followers
+  I want to be able to repost a post in my feed
 
-  Scenario: Reposting an object that has not been reposted before
+  Scenario: Reposting a post that has not been reposted before
     Given an Actor "Person(Alice)"
-    Given we follow "Alice"
-    Then the request is accepted
-    Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
+    And we follow "Alice"
+    And the request is accepted
+    And a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
     And "Alice" sends "Accept" to the Inbox
     And "Accept" is in our Inbox
-    Given a "Create(Note)" Activity "Note" by "Alice"
-    When "Alice" sends "Note" to the Inbox
+    And a "Create(Note)" Activity "Note" by "Alice"
+    And "Alice" sends "Note" to the Inbox
     And "Note" is in our Inbox
-    And we repost the object "Note"
+    When we repost the object "Note"
     Then a "Announce(Note)" activity is sent to "Alice"
 
-  Scenario: Reposting an object that has been reposted before
+  Scenario: Reposting an post that has been reposted before
     Given an Actor "Person(Alice)"
-    Given we follow "Alice"
-    Then the request is accepted
-    Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
+    And we follow "Alice"
+    And the request is accepted
+    And a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
     And "Alice" sends "Accept" to the Inbox
     And "Accept" is in our Inbox
-    Given a "Create(Note)" Activity "Note" by "Alice"
-    When "Alice" sends "Note" to the Inbox
+    And a "Create(Note)" Activity "Note" by "Alice"
+    And "Alice" sends "Note" to the Inbox
     And "Note" is in our Inbox
     And we repost the object "Note"
     Then the request is accepted

--- a/features/repost-activity.feature
+++ b/features/repost-activity.feature
@@ -1,0 +1,32 @@
+Feature: Reposting an object
+  As a user
+  I want to repost an object in my feed
+  So that I can share the content with my followers
+
+  Scenario: Reposting an object that has not been reposted before
+    Given an Actor "Person(Alice)"
+    Given we follow "Alice"
+    Then the request is accepted
+    Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
+    And "Alice" sends "Accept" to the Inbox
+    And "Accept" is in our Inbox
+    Given a "Create(Note)" Activity "Note" by "Alice"
+    When "Alice" sends "Note" to the Inbox
+    And "Note" is in our Inbox
+    And we repost the object "Note"
+    Then a "Announce(Note)" activity is sent to "Alice"
+
+  Scenario: Reposting an object that has been reposted before
+    Given an Actor "Person(Alice)"
+    Given we follow "Alice"
+    Then the request is accepted
+    Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
+    And "Alice" sends "Accept" to the Inbox
+    And "Accept" is in our Inbox
+    Given a "Create(Note)" Activity "Note" by "Alice"
+    When "Alice" sends "Note" to the Inbox
+    And "Note" is in our Inbox
+    And we repost the object "Note"
+    Then the request is accepted
+    Then we repost the object "Note"
+    Then the request is rejected with a 409

--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -747,6 +747,16 @@ Then('the object {string} should not be liked', async function (name) {
     assert(found.object.liked !== true);
 });
 
+When('we repost the object {string}', async function (name) {
+    const id = this.objects[name].id;
+    this.response = await fetchActivityPub(
+        `http://fake-ghost-activitypub/.ghost/activitypub/actions/repost/${encodeURIComponent(id)}`,
+        {
+            method: 'POST',
+        },
+    );
+});
+
 async function getObjectInCollection(objectName, collectionType) {
     const initialResponse = await fetchActivityPub(
         `http://fake-ghost-activitypub/.ghost/activitypub/${collectionType}/index`,

--- a/src/app.ts
+++ b/src/app.ts
@@ -43,6 +43,7 @@ import { FediverseBridge } from './activitypub/fediverse-bridge';
 import { client } from './db';
 import {
     acceptDispatcher,
+    announceDispatcher,
     actorDispatcher,
     articleDispatcher,
     createAcceptHandler,
@@ -81,6 +82,7 @@ import {
     inboxHandler,
     likeAction,
     replyAction,
+    repostAction,
     unlikeAction,
 } from './handlers';
 import { getTraceContext } from './helpers/context-header';
@@ -380,7 +382,11 @@ fedify.setObjectDispatcher(
     '/.ghost/activitypub/undo/{id}',
     spanWrapper(undoDispatcher),
 );
-
+fedify.setObjectDispatcher(
+    Announce,
+    '/.ghost/activitypub/announce/{id}',
+    spanWrapper(announceDispatcher),
+);
 fedify.setNodeInfoDispatcher(
     '/.ghost/activitypub/nodeinfo/2.1',
     spanWrapper(nodeInfoDispatcher),
@@ -793,6 +799,11 @@ app.post(
     '/.ghost/activitypub/actions/reply/:id',
     requireRole(GhostRole.Owner),
     spanWrapper(replyAction),
+);
+app.post(
+    '/.ghost/activitypub/actions/repost/:id',
+    requireRole(GhostRole.Owner),
+    spanWrapper(repostAction),
 );
 app.post(
     '/.ghost/activitypub/actions/note',

--- a/src/app.ts
+++ b/src/app.ts
@@ -77,12 +77,12 @@ import {
 import { FeedService } from './feed/feed.service';
 import {
     createFollowActionHandler,
+    createRepostActionHandler,
     createUnfollowActionHandler,
     getSiteDataHandler,
     inboxHandler,
     likeAction,
     replyAction,
-    repostAction,
     unlikeAction,
 } from './handlers';
 import { getTraceContext } from './helpers/context-header';
@@ -803,7 +803,7 @@ app.post(
 app.post(
     '/.ghost/activitypub/actions/repost/:id',
     requireRole(GhostRole.Owner),
-    spanWrapper(repostAction),
+    spanWrapper(createRepostActionHandler(accountService)),
 );
 app.post(
     '/.ghost/activitypub/actions/note',

--- a/src/app.ts
+++ b/src/app.ts
@@ -43,8 +43,8 @@ import { FediverseBridge } from './activitypub/fediverse-bridge';
 import { client } from './db';
 import {
     acceptDispatcher,
-    announceDispatcher,
     actorDispatcher,
+    announceDispatcher,
     articleDispatcher,
     createAcceptHandler,
     createAnnounceHandler,

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -3,7 +3,7 @@ import {
     Accept,
     Activity,
     type Actor,
-    type Announce,
+    Announce,
     Article,
     type Context,
     Create,
@@ -1298,6 +1298,18 @@ export async function likeDispatcher(
         return null;
     }
     return Like.fromJsonLd(exists);
+}
+
+export async function announceDispatcher(
+    ctx: RequestContext<ContextData>,
+    data: Record<'id', string>,
+) {
+    const id = ctx.getObjectUri(Announce, data);
+    const exists = await ctx.data.globaldb.get([id.href]);
+    if (!exists) {
+        return null;
+    }
+    return Announce.fromJsonLd(exists);
 }
 
 export async function undoDispatcher(

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -1,12 +1,12 @@
 import { createHash } from 'node:crypto';
 import {
     type Actor,
+    Announce,
     Create,
     Follow,
     Like,
     Mention,
     Note,
-    Announce,
     PUBLIC_COLLECTION,
     Undo,
     isActor,

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -575,79 +575,87 @@ export async function inboxHandler(
     );
 }
 
-export async function repostAction(
-    ctx: Context<{ Variables: HonoContextVariables }>,
-) {
-    const id = ctx.req.param('id');
-    const apCtx = fedify.createContext(ctx.req.raw as Request, {
-        db: ctx.get('db'),
-        globaldb: ctx.get('globaldb'),
-        logger: ctx.get('logger'),
-    });
-
-    const objectToRepost = await lookupObject(apCtx, id);
-    if (!objectToRepost) {
-        return new Response(null, {
-            status: 404,
+export function createRepostActionHandler(accountService: AccountService) {
+    return async function repostAction(
+        ctx: Context<{ Variables: HonoContextVariables }>,
+    ) {
+        const id = ctx.req.param('id');
+        const apCtx = fedify.createContext(ctx.req.raw as Request, {
+            db: ctx.get('db'),
+            globaldb: ctx.get('globaldb'),
+            logger: ctx.get('logger'),
         });
-    }
 
-    const announceId = apCtx.getObjectUri(Announce, {
-        id: createHash('sha256').update(objectToRepost.id!.href).digest('hex'),
-    });
+        const objectToRepost = await lookupObject(apCtx, id);
+        if (!objectToRepost) {
+            return new Response(null, {
+                status: 404,
+            });
+        }
 
-    if (await ctx.get('globaldb').get([announceId.href])) {
-        return new Response(null, {
-            status: 409,
+        const announceId = apCtx.getObjectUri(Announce, {
+            id: createHash('sha256')
+                .update(objectToRepost.id!.href)
+                .digest('hex'),
         });
-    }
 
-    const actor = await apCtx.getActor(ACTOR_DEFAULT_HANDLE); // TODO This should be the actor making the request
+        if (await ctx.get('globaldb').get([announceId.href])) {
+            return new Response(null, {
+                status: 409,
+            });
+        }
 
-    const announce = new Announce({
-        id: announceId,
-        actor: actor,
-        object: objectToRepost,
-        to: PUBLIC_COLLECTION,
-        cc: apCtx.getFollowersUri(ACTOR_DEFAULT_HANDLE),
-    });
+        const actor = await apCtx.getActor(ACTOR_DEFAULT_HANDLE); // TODO This should be the actor making the request
 
-    const announceJson = await announce.toJsonLd();
+        const announce = new Announce({
+            id: announceId,
+            actor: actor,
+            object: objectToRepost,
+            to: PUBLIC_COLLECTION,
+            cc: apCtx.getFollowersUri(ACTOR_DEFAULT_HANDLE),
+        });
 
-    await ctx.get('globaldb').set([announce.id!.href], announceJson);
-    await addToList(ctx.get('db'), ['reposted'], announce.id!.href);
+        const announceJson = await announce.toJsonLd();
 
-    let attributionActor: Actor | null = null;
-    if (objectToRepost.attributionId) {
-        attributionActor = await lookupActor(
-            apCtx,
-            objectToRepost.attributionId.href,
-        );
-    }
-    if (attributionActor) {
+        await ctx.get('globaldb').set([announce.id!.href], announceJson);
+        await addToList(ctx.get('db'), ['reposted'], announce.id!.href);
+
+        // Add to the actor's outbox
+        await addToList(ctx.get('db'), ['outbox'], announce.id!.href);
+
+        // Send the announce activity
+        let attributionActor: Actor | null = null;
+        if (objectToRepost.attributionId) {
+            attributionActor = await lookupActor(
+                apCtx,
+                objectToRepost.attributionId.href,
+            );
+        }
+        if (attributionActor) {
+            apCtx.sendActivity(
+                { handle: ACTOR_DEFAULT_HANDLE },
+                attributionActor,
+                announce,
+                {
+                    preferSharedInbox: true,
+                },
+            );
+        }
+
         apCtx.sendActivity(
             { handle: ACTOR_DEFAULT_HANDLE },
-            attributionActor,
+            'followers',
             announce,
             {
                 preferSharedInbox: true,
             },
         );
-    }
 
-    apCtx.sendActivity(
-        { handle: ACTOR_DEFAULT_HANDLE },
-        'followers',
-        announce,
-        {
-            preferSharedInbox: true,
-        },
-    );
-
-    return new Response(JSON.stringify(announceJson), {
-        headers: {
-            'Content-Type': 'application/activity+json',
-        },
-        status: 200,
-    });
+        return new Response(JSON.stringify(announceJson), {
+            headers: {
+                'Content-Type': 'application/activity+json',
+            },
+            status: 200,
+        });
+    };
 }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -596,6 +596,12 @@ export async function repostAction(
         id: createHash('sha256').update(objectToRepost.id!.href).digest('hex'),
     });
 
+    if (await ctx.get('globaldb').get([announceId.href])) {
+        return new Response(null, {
+            status: 409,
+        });
+    }
+
     const actor = await apCtx.getActor(ACTOR_DEFAULT_HANDLE); // TODO This should be the actor making the request
 
     const announce = new Announce({
@@ -608,11 +614,7 @@ export async function repostAction(
 
     const announceJson = await announce.toJsonLd();
 
-    console.log('announceJSON is', announceJson);
-
-    // TODO: Share that activity
     await ctx.get('globaldb').set([announce.id!.href], announceJson);
-
     await addToList(ctx.get('db'), ['reposted'], announce.id!.href);
 
     let attributionActor: Actor | null = null;

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -6,6 +6,7 @@ import {
     Like,
     Mention,
     Note,
+    Announce,
     PUBLIC_COLLECTION,
     Undo,
     isActor,
@@ -572,4 +573,79 @@ export async function inboxHandler(
             status: 200,
         },
     );
+}
+
+export async function repostAction(
+    ctx: Context<{ Variables: HonoContextVariables }>,
+) {
+    const id = ctx.req.param('id');
+    const apCtx = fedify.createContext(ctx.req.raw as Request, {
+        db: ctx.get('db'),
+        globaldb: ctx.get('globaldb'),
+        logger: ctx.get('logger'),
+    });
+
+    const objectToRepost = await lookupObject(apCtx, id);
+    if (!objectToRepost) {
+        return new Response(null, {
+            status: 404,
+        });
+    }
+
+    const announceId = apCtx.getObjectUri(Announce, {
+        id: createHash('sha256').update(objectToRepost.id!.href).digest('hex'),
+    });
+
+    const actor = await apCtx.getActor(ACTOR_DEFAULT_HANDLE); // TODO This should be the actor making the request
+
+    const announce = new Announce({
+        id: announceId,
+        actor: actor,
+        object: objectToRepost,
+        to: PUBLIC_COLLECTION,
+        cc: apCtx.getFollowersUri(ACTOR_DEFAULT_HANDLE),
+    });
+
+    const announceJson = await announce.toJsonLd();
+
+    console.log('announceJSON is', announceJson);
+
+    // TODO: Share that activity
+    await ctx.get('globaldb').set([announce.id!.href], announceJson);
+
+    await addToList(ctx.get('db'), ['reposted'], announce.id!.href);
+
+    let attributionActor: Actor | null = null;
+    if (objectToRepost.attributionId) {
+        attributionActor = await lookupActor(
+            apCtx,
+            objectToRepost.attributionId.href,
+        );
+    }
+    if (attributionActor) {
+        apCtx.sendActivity(
+            { handle: ACTOR_DEFAULT_HANDLE },
+            attributionActor,
+            announce,
+            {
+                preferSharedInbox: true,
+            },
+        );
+    }
+
+    apCtx.sendActivity(
+        { handle: ACTOR_DEFAULT_HANDLE },
+        'followers',
+        announce,
+        {
+            preferSharedInbox: true,
+        },
+    );
+
+    return new Response(JSON.stringify(announceJson), {
+        headers: {
+            'Content-Type': 'application/activity+json',
+        },
+        status: 200,
+    });
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-702

- added `POST /actions/reposts/:id endpoint` to create a Repost
- a Repost is the equivalent of the "Announce" activity in the ActivityPub vocabulary, or "Boost" in the Mastodon vocabulary