### PR TITLE
Added endpoint to undo a Repost

### DIFF
--- a/features/repost-activity.feature
+++ b/features/repost-activity.feature
@@ -1,9 +1,9 @@
-Feature: Reposting a post
+Feature: Reposting a post/note
   In order to share content with my followers
   As a user
   I want to be able to repost a post in my feed
 
-  Scenario: Reposting a post that has not been reposted before
+  Scenario: Reposting a post/note
     Given an Actor "Person(Alice)"
     And we follow "Alice"
     And the request is accepted
@@ -18,7 +18,7 @@ Feature: Reposting a post
     And the object "Note" should be reposted
     And a "Announce(Note)" activity is sent to "Alice"
 
-  Scenario: Reposting an post that has been reposted before
+  Scenario: Trying to repost a post/note that has already been reposted
     Given an Actor "Person(Alice)"
     And we follow "Alice"
     And the request is accepted
@@ -29,6 +29,36 @@ Feature: Reposting a post
     And "Alice" sends "Note" to the Inbox
     And "Note" is in our Inbox
     And we repost the object "Note"
+    And the request is accepted
+    When we repost the object "Note"
+    Then the request is rejected with a 409
+
+  Scenario: Undoing a repost
+    Given an Actor "Person(Alice)"
+    And we follow "Alice"
+    And the request is accepted
+    And a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
+    And "Alice" sends "Accept" to the Inbox
+    And "Accept" is in our Inbox
+    And a "Create(Note)" Activity "Note" by "Alice"
+    And "Alice" sends "Note" to the Inbox
+    And "Note" is in our Inbox
+    And we repost the object "Note"
+    And the request is accepted
+    When we undo the repost of the object "Note"
     Then the request is accepted
-    Then we repost the object "Note"
+    And the object "Note" should not be reposted
+    And a "Undo(Announce)" activity is sent to "Alice"
+
+  Scenario: Trying to undo a repost on a post/note that has not been reposted
+    Given an Actor "Person(Alice)"
+    And we follow "Alice"
+    And the request is accepted
+    And a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
+    And "Alice" sends "Accept" to the Inbox
+    And "Accept" is in our Inbox
+    And a "Create(Note)" Activity "Note" by "Alice"
+    And "Alice" sends "Note" to the Inbox
+    And "Note" is in our Inbox
+    When we undo the repost of the object "Note"
     Then the request is rejected with a 409

--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -800,6 +800,32 @@ Then('the object {string} should be reposted', async function (name) {
     assert(found.object.reposted === true);
 });
 
+When('we undo the repost of the object {string}', async function (name) {
+    const id = this.objects[name].id;
+    this.response = await fetchActivityPub(
+        `http://fake-ghost-activitypub/.ghost/activitypub/actions/depost/${encodeURIComponent(id)}`,
+        {
+            method: 'POST',
+        },
+    );
+});
+
+Then('the object {string} should not be reposted', async function (name) {
+    const response = await fetchActivityPub(
+        'http://fake-ghost-activitypub/.ghost/activitypub/inbox/index',
+        {
+            headers: {
+                Accept: 'application/ld+json',
+            },
+        },
+    );
+    const inbox = await response.json();
+    const object = this.objects[name];
+    const found = inbox.items.find((item) => item.object.id === object.id);
+
+    assert(found.object.reposted !== true);
+});
+
 async function getObjectInCollection(objectName, collectionType) {
     const initialResponse = await fetchActivityPub(
         `http://fake-ghost-activitypub/.ghost/activitypub/${collectionType}/index`,

--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -803,7 +803,7 @@ Then('the object {string} should be reposted', async function (name) {
 When('we undo the repost of the object {string}', async function (name) {
     const id = this.objects[name].id;
     this.response = await fetchActivityPub(
-        `http://fake-ghost-activitypub/.ghost/activitypub/actions/depost/${encodeURIComponent(id)}`,
+        `http://fake-ghost-activitypub/.ghost/activitypub/actions/derepost/${encodeURIComponent(id)}`,
         {
             method: 'POST',
         },

--- a/src/app.ts
+++ b/src/app.ts
@@ -76,7 +76,7 @@ import {
 } from './dispatchers';
 import { FeedService } from './feed/feed.service';
 import {
-    createDepostActionHandler,
+    createDerepostActionHandler,
     createFollowActionHandler,
     createRepostActionHandler,
     createUnfollowActionHandler,
@@ -811,9 +811,9 @@ app.post(
     spanWrapper(createRepostActionHandler(accountService)),
 );
 app.post(
-    '/.ghost/activitypub/actions/depost/:id',
+    '/.ghost/activitypub/actions/derepost/:id',
     requireRole(GhostRole.Owner),
-    spanWrapper(createDepostActionHandler(accountService)),
+    spanWrapper(createDerepostActionHandler(accountService)),
 );
 app.post(
     '/.ghost/activitypub/actions/note',

--- a/src/app.ts
+++ b/src/app.ts
@@ -76,6 +76,7 @@ import {
 } from './dispatchers';
 import { FeedService } from './feed/feed.service';
 import {
+    createDepostActionHandler,
     createFollowActionHandler,
     createRepostActionHandler,
     createUnfollowActionHandler,
@@ -808,6 +809,11 @@ app.post(
     '/.ghost/activitypub/actions/repost/:id',
     requireRole(GhostRole.Owner),
     spanWrapper(createRepostActionHandler(accountService)),
+);
+app.post(
+    '/.ghost/activitypub/actions/depost/:id',
+    requireRole(GhostRole.Owner),
+    spanWrapper(createDepostActionHandler(accountService)),
 );
 app.post(
     '/.ghost/activitypub/actions/note',

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -596,17 +596,15 @@ export function createRepostActionHandler(accountService: AccountService) {
             logger: ctx.get('logger'),
         });
 
-        const objectToRepost = await lookupObject(apCtx, id);
-        if (!objectToRepost) {
+        const post = await lookupObject(apCtx, id);
+        if (!post) {
             return new Response(null, {
                 status: 404,
             });
         }
 
         const announceId = apCtx.getObjectUri(Announce, {
-            id: createHash('sha256')
-                .update(objectToRepost.id!.href)
-                .digest('hex'),
+            id: createHash('sha256').update(post.id!.href).digest('hex'),
         });
 
         if (await ctx.get('globaldb').get([announceId.href])) {
@@ -620,25 +618,26 @@ export function createRepostActionHandler(accountService: AccountService) {
         const announce = new Announce({
             id: announceId,
             actor: actor,
-            object: objectToRepost,
+            object: post,
             to: PUBLIC_COLLECTION,
             cc: apCtx.getFollowersUri(ACTOR_DEFAULT_HANDLE),
         });
 
         const announceJson = await announce.toJsonLd();
 
+        // Add announce activity to the database
         await ctx.get('globaldb').set([announce.id!.href], announceJson);
         await addToList(ctx.get('db'), ['reposted'], announce.id!.href);
 
-        // Add to the actor's outbox
+        // Add announce activity to the actor's outbox
         await addToList(ctx.get('db'), ['outbox'], announce.id!.href);
 
         // Send the announce activity
         let attributionActor: Actor | null = null;
-        if (objectToRepost.attributionId) {
+        if (post.attributionId) {
             attributionActor = await lookupActor(
                 apCtx,
-                objectToRepost.attributionId.href,
+                post.attributionId.href,
             );
         }
         if (attributionActor) {
@@ -662,6 +661,102 @@ export function createRepostActionHandler(accountService: AccountService) {
         );
 
         return new Response(JSON.stringify(announceJson), {
+            headers: {
+                'Content-Type': 'application/activity+json',
+            },
+            status: 200,
+        });
+    };
+}
+
+export function createDepostActionHandler(accountService: AccountService) {
+    return async function depostAction(
+        ctx: Context<{ Variables: HonoContextVariables }>,
+    ) {
+        const id = ctx.req.param('id');
+        const apCtx = fedify.createContext(ctx.req.raw as Request, {
+            db: ctx.get('db'),
+            globaldb: ctx.get('globaldb'),
+            logger: ctx.get('logger'),
+        });
+
+        const post = await lookupObject(apCtx, id);
+        if (!post) {
+            return new Response(null, {
+                status: 404,
+            });
+        }
+
+        const announceId = apCtx.getObjectUri(Announce, {
+            id: createHash('sha256').update(post.id!.href).digest('hex'),
+        });
+
+        const undoId = apCtx.getObjectUri(Undo, {
+            id: createHash('sha256').update(announceId.href).digest('hex'),
+        });
+
+        const announceToUndoJson = await ctx
+            .get('globaldb')
+            .get([announceId.href]);
+
+        if (!announceToUndoJson) {
+            return new Response(null, {
+                status: 409,
+            });
+        }
+
+        const announceToUndo = await Announce.fromJsonLd(announceToUndoJson);
+
+        const actor = await apCtx.getActor(ACTOR_DEFAULT_HANDLE); // TODO This should be the actor making the request
+
+        const undo = new Undo({
+            id: undoId,
+            actor: actor,
+            object: announceToUndo,
+            to: PUBLIC_COLLECTION,
+            cc: apCtx.getFollowersUri(ACTOR_DEFAULT_HANDLE),
+        });
+
+        // Add the undo activity to the database
+        const undoJson = await undo.toJsonLd();
+        await ctx.get('globaldb').set([undo.id!.href], undoJson);
+
+        // Remove announce activity from database
+        await removeFromList(ctx.get('db'), ['reposted'], announceId.href);
+        await ctx.get('globaldb').delete([announceId.href]);
+
+        // Remove announce activity from the actor's outbox
+        await removeFromList(ctx.get('db'), ['outbox'], announceId.href);
+
+        // Send the undo activity
+        let attributionActor: Actor | null = null;
+        if (post.attributionId) {
+            attributionActor = await lookupActor(
+                apCtx,
+                post.attributionId.href,
+            );
+        }
+        if (attributionActor) {
+            apCtx.sendActivity(
+                { handle: ACTOR_DEFAULT_HANDLE },
+                attributionActor,
+                undo,
+                {
+                    preferSharedInbox: true,
+                },
+            );
+        }
+
+        apCtx.sendActivity(
+            { handle: ACTOR_DEFAULT_HANDLE },
+            'followers',
+            undo,
+            {
+                preferSharedInbox: true,
+            },
+        );
+
+        return new Response(JSON.stringify(undoJson), {
             headers: {
                 'Content-Type': 'application/activity+json',
             },

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -669,8 +669,8 @@ export function createRepostActionHandler(accountService: AccountService) {
     };
 }
 
-export function createDepostActionHandler(accountService: AccountService) {
-    return async function depostAction(
+export function createDerepostActionHandler(accountService: AccountService) {
+    return async function derepostAction(
         ctx: Context<{ Variables: HonoContextVariables }>,
     ) {
         const id = ctx.req.param('id');


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-707

- when undoing a Repost, we:
    - create a new Undo activity containing the corresponding Repost/Announce activity to undo
    - send the Undo activity to all followers of the acting user
    - remove the original Announce from the database
    - remove the Announce item from the user's outbox
    - remove the Announce item from the user's reposted collection