### PR TITLE
Update account data using site info while creating internal account

### DIFF
--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -94,7 +94,7 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 username,
-                siteSettings
+                siteSettings,
             );
 
             // Assert the created account was returned
@@ -174,12 +174,12 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
-                siteSettings
+                siteSettings,
             );
             const follower = await service.createInternalAccount(
                 site,
                 'follower',
-                siteSettings
+                siteSettings,
             );
 
             await service.recordAccountFollow(account, follower);
@@ -207,12 +207,12 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
-                siteSettings
+                siteSettings,
             );
             const follower = await service.createInternalAccount(
                 site,
                 'follower',
-                siteSettings
+                siteSettings,
             );
 
             await service.recordAccountFollow(account, follower);
@@ -232,12 +232,12 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
-                siteSettings
+                siteSettings,
             );
             const follower = await service.createInternalAccount(
                 site,
                 'follower',
-                siteSettings
+                siteSettings,
             );
 
             await service.recordAccountFollow(account, follower);
@@ -268,7 +268,7 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
-                siteSettings
+                siteSettings,
             );
 
             const retrievedAccount = await service.getAccountByApId(
@@ -285,7 +285,7 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
-                siteSettings
+                siteSettings,
             );
 
             const defaultAccount = await service.getDefaultAccountForSite(site);
@@ -328,22 +328,22 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
-                siteSettings
+                siteSettings,
             );
             const following1 = await service.createInternalAccount(
                 site,
                 'following1',
-                siteSettings
+                siteSettings,
             );
             const following2 = await service.createInternalAccount(
                 site,
                 'following2',
-                siteSettings
+                siteSettings,
             );
             const following3 = await service.createInternalAccount(
                 site,
                 'following3',
-                siteSettings
+                siteSettings,
             );
 
             await service.recordAccountFollow(following1, account);
@@ -408,17 +408,17 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
-                siteSettings
+                siteSettings,
             );
             const following1 = await service.createInternalAccount(
                 site,
                 'following1',
-                siteSettings
+                siteSettings,
             );
             const following2 = await service.createInternalAccount(
                 site,
                 'following2',
-                siteSettings
+                siteSettings,
             );
 
             await service.recordAccountFollow(following1, account);
@@ -435,22 +435,22 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
-                siteSettings
+                siteSettings,
             );
             const follower1 = await service.createInternalAccount(
                 site,
                 'follower1',
-                siteSettings
+                siteSettings,
             );
             const follower2 = await service.createInternalAccount(
                 site,
                 'follower2',
-                siteSettings
+                siteSettings,
             );
             const follower3 = await service.createInternalAccount(
                 site,
                 'follower3',
-                siteSettings
+                siteSettings,
             );
 
             await service.recordAccountFollow(account, follower1);
@@ -511,17 +511,17 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
-                siteSettings
+                siteSettings,
             );
             const follower1 = await service.createInternalAccount(
                 site,
                 'follower1',
-                siteSettings
+                siteSettings,
             );
             const follower2 = await service.createInternalAccount(
                 site,
                 'follower2',
-                siteSettings
+                siteSettings,
             );
 
             await service.recordAccountFollow(account, follower1);
@@ -538,17 +538,17 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
-                siteSettings
+                siteSettings,
             );
             const followee = await service.createInternalAccount(
                 site,
                 'followee',
-                siteSettings
+                siteSettings,
             );
             const nonFollowee = await service.createInternalAccount(
                 site,
                 'non-followee',
-                siteSettings
+                siteSettings,
             );
 
             await service.recordAccountFollow(followee, account);
@@ -573,7 +573,7 @@ describe('AccountService', () => {
         const account = await service.createInternalAccount(
             site,
             'testing-update',
-            siteSettings
+            siteSettings,
         );
 
         let accountFromEvent: Account | undefined;

--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -76,10 +76,10 @@ describe('AccountService', () => {
             const username = 'foobarbaz';
 
             const expectedAccount = {
-                name: siteSettings?.site?.title || ACTOR_DEFAULT_NAME,
+                name: siteSettings.site.title || ACTOR_DEFAULT_NAME,
                 username,
-                bio: siteSettings?.site?.description || ACTOR_DEFAULT_SUMMARY,
-                avatar_url: siteSettings?.site?.icon || ACTOR_DEFAULT_ICON,
+                bio: siteSettings.site.description || ACTOR_DEFAULT_SUMMARY,
+                avatar_url: siteSettings.site.icon || ACTOR_DEFAULT_ICON,
                 url: `https://${site.host}`,
                 custom_fields: null,
                 ap_id: `https://${site.host}${AP_BASE_PATH}/users/${username}`,

--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -94,7 +94,7 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 username,
-                siteSettings,
+                siteSettings
             );
 
             // Assert the created account was returned
@@ -174,12 +174,12 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
-                siteSettings,
+                siteSettings
             );
             const follower = await service.createInternalAccount(
                 site,
                 'follower',
-                siteSettings,
+                siteSettings
             );
 
             await service.recordAccountFollow(account, follower);
@@ -207,12 +207,12 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
-                siteSettings,
+                siteSettings
             );
             const follower = await service.createInternalAccount(
                 site,
                 'follower',
-                siteSettings,
+                siteSettings
             );
 
             await service.recordAccountFollow(account, follower);
@@ -232,12 +232,12 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
-                siteSettings,
+                siteSettings
             );
             const follower = await service.createInternalAccount(
                 site,
                 'follower',
-                siteSettings,
+                siteSettings
             );
 
             await service.recordAccountFollow(account, follower);
@@ -268,7 +268,7 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
-                siteSettings,
+                siteSettings
             );
 
             const retrievedAccount = await service.getAccountByApId(
@@ -285,7 +285,7 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
-                siteSettings,
+                siteSettings
             );
 
             const defaultAccount = await service.getDefaultAccountForSite(site);
@@ -328,22 +328,22 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
-                siteSettings,
+                siteSettings
             );
             const following1 = await service.createInternalAccount(
                 site,
                 'following1',
-                siteSettings,
+                siteSettings
             );
             const following2 = await service.createInternalAccount(
                 site,
                 'following2',
-                siteSettings,
+                siteSettings
             );
             const following3 = await service.createInternalAccount(
                 site,
                 'following3',
-                siteSettings,
+                siteSettings
             );
 
             await service.recordAccountFollow(following1, account);
@@ -408,17 +408,17 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
-                siteSettings,
+                siteSettings
             );
             const following1 = await service.createInternalAccount(
                 site,
                 'following1',
-                siteSettings,
+                siteSettings
             );
             const following2 = await service.createInternalAccount(
                 site,
                 'following2',
-                siteSettings,
+                siteSettings
             );
 
             await service.recordAccountFollow(following1, account);
@@ -435,22 +435,22 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
-                siteSettings,
+                siteSettings
             );
             const follower1 = await service.createInternalAccount(
                 site,
                 'follower1',
-                siteSettings,
+                siteSettings
             );
             const follower2 = await service.createInternalAccount(
                 site,
                 'follower2',
-                siteSettings,
+                siteSettings
             );
             const follower3 = await service.createInternalAccount(
                 site,
                 'follower3',
-                siteSettings,
+                siteSettings
             );
 
             await service.recordAccountFollow(account, follower1);
@@ -511,17 +511,17 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
-                siteSettings,
+                siteSettings
             );
             const follower1 = await service.createInternalAccount(
                 site,
                 'follower1',
-                siteSettings,
+                siteSettings
             );
             const follower2 = await service.createInternalAccount(
                 site,
                 'follower2',
-                siteSettings,
+                siteSettings
             );
 
             await service.recordAccountFollow(account, follower1);
@@ -538,17 +538,17 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
-                siteSettings,
+                siteSettings
             );
             const followee = await service.createInternalAccount(
                 site,
                 'followee',
-                siteSettings,
+                siteSettings
             );
             const nonFollowee = await service.createInternalAccount(
                 site,
                 'non-followee',
-                siteSettings,
+                siteSettings
             );
 
             await service.recordAccountFollow(followee, account);
@@ -573,7 +573,7 @@ describe('AccountService', () => {
         const account = await service.createInternalAccount(
             site,
             'testing-update',
-            siteSettings,
+            siteSettings
         );
 
         let accountFromEvent: Account | undefined;

--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -17,8 +17,8 @@ import { AccountService } from './account.service';
 import type {
     Account,
     ExternalAccountData,
-    Site,
     InternalAccountData,
+    Site,
 } from './types';
 
 vi.mock('@fedify/fedify', async () => {
@@ -96,7 +96,10 @@ describe('AccountService', () => {
                 ap_shared_inbox_url: null,
             };
 
-            const account = await service.createInternalAccount(site, internalAccountData);
+            const account = await service.createInternalAccount(
+                site,
+                internalAccountData,
+            );
 
             // Assert the created account was returned
             expect(account).toMatchObject(expectedAccount);

--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../constants';
 import { client as db } from '../db';
 import { AccountService } from './account.service';
-import type { Account, ExternalAccountData, Site } from './types';
+import type { Account, ExternalAccountData, Site, SiteSettings } from './types';
 
 vi.mock('@fedify/fedify', async () => {
     // generateCryptoKeyPair is a slow operation so we generate a key pair
@@ -34,6 +34,7 @@ describe('AccountService', () => {
     let service: AccountService;
     let events: EventEmitter;
     let site: Site;
+    let siteSettings: SiteSettings;
 
     beforeEach(async () => {
         // Clean up the database
@@ -56,6 +57,14 @@ describe('AccountService', () => {
             ...siteData,
         };
 
+        siteSettings = {
+            site: {
+                description: 'Test Site Description',
+                icon: 'Test Site Icon',
+                title: 'Test Site Title',
+            },
+        };
+
         events = new EventEmitter();
 
         // Create the service
@@ -67,10 +76,10 @@ describe('AccountService', () => {
             const username = 'foobarbaz';
 
             const expectedAccount = {
-                name: ACTOR_DEFAULT_NAME,
+                name: siteSettings?.site?.title || ACTOR_DEFAULT_NAME,
                 username,
-                bio: ACTOR_DEFAULT_SUMMARY,
-                avatar_url: ACTOR_DEFAULT_ICON,
+                bio: siteSettings?.site?.description || ACTOR_DEFAULT_SUMMARY,
+                avatar_url: siteSettings?.site?.icon || ACTOR_DEFAULT_ICON,
                 url: `https://${site.host}`,
                 custom_fields: null,
                 ap_id: `https://${site.host}${AP_BASE_PATH}/users/${username}`,
@@ -82,7 +91,11 @@ describe('AccountService', () => {
                 ap_shared_inbox_url: null,
             };
 
-            const account = await service.createInternalAccount(site, username);
+            const account = await service.createInternalAccount(
+                site,
+                username,
+                siteSettings,
+            );
 
             // Assert the created account was returned
             expect(account).toMatchObject(expectedAccount);
@@ -161,10 +174,12 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
+                siteSettings,
             );
             const follower = await service.createInternalAccount(
                 site,
                 'follower',
+                siteSettings,
             );
 
             await service.recordAccountFollow(account, follower);
@@ -192,10 +207,12 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
+                siteSettings,
             );
             const follower = await service.createInternalAccount(
                 site,
                 'follower',
+                siteSettings,
             );
 
             await service.recordAccountFollow(account, follower);
@@ -215,10 +232,12 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
+                siteSettings,
             );
             const follower = await service.createInternalAccount(
                 site,
                 'follower',
+                siteSettings,
             );
 
             await service.recordAccountFollow(account, follower);
@@ -249,6 +268,7 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
+                siteSettings,
             );
 
             const retrievedAccount = await service.getAccountByApId(
@@ -265,6 +285,7 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
+                siteSettings,
             );
 
             const defaultAccount = await service.getDefaultAccountForSite(site);
@@ -273,8 +294,8 @@ describe('AccountService', () => {
         });
 
         it('should throw an error if multiple users are found for a site', async () => {
-            await service.createInternalAccount(site, 'account1');
-            await service.createInternalAccount(site, 'account2');
+            await service.createInternalAccount(site, 'account1', siteSettings);
+            await service.createInternalAccount(site, 'account2', siteSettings);
 
             await expect(
                 service.getDefaultAccountForSite(site),
@@ -288,7 +309,7 @@ describe('AccountService', () => {
         });
 
         it('should throw an error if no account is found for a site user', async () => {
-            await service.createInternalAccount(site, 'account1');
+            await service.createInternalAccount(site, 'account1', siteSettings);
 
             const rows = await db('users')
                 .select('account_id')
@@ -307,18 +328,22 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
+                siteSettings,
             );
             const following1 = await service.createInternalAccount(
                 site,
                 'following1',
+                siteSettings,
             );
             const following2 = await service.createInternalAccount(
                 site,
                 'following2',
+                siteSettings,
             );
             const following3 = await service.createInternalAccount(
                 site,
                 'following3',
+                siteSettings,
             );
 
             await service.recordAccountFollow(following1, account);
@@ -383,14 +408,17 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
+                siteSettings,
             );
             const following1 = await service.createInternalAccount(
                 site,
                 'following1',
+                siteSettings,
             );
             const following2 = await service.createInternalAccount(
                 site,
                 'following2',
+                siteSettings,
             );
 
             await service.recordAccountFollow(following1, account);
@@ -407,18 +435,22 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
+                siteSettings,
             );
             const follower1 = await service.createInternalAccount(
                 site,
                 'follower1',
+                siteSettings,
             );
             const follower2 = await service.createInternalAccount(
                 site,
                 'follower2',
+                siteSettings,
             );
             const follower3 = await service.createInternalAccount(
                 site,
                 'follower3',
+                siteSettings,
             );
 
             await service.recordAccountFollow(account, follower1);
@@ -479,14 +511,17 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
+                siteSettings,
             );
             const follower1 = await service.createInternalAccount(
                 site,
                 'follower1',
+                siteSettings,
             );
             const follower2 = await service.createInternalAccount(
                 site,
                 'follower2',
+                siteSettings,
             );
 
             await service.recordAccountFollow(account, follower1);
@@ -503,14 +538,17 @@ describe('AccountService', () => {
             const account = await service.createInternalAccount(
                 site,
                 'account',
+                siteSettings,
             );
             const followee = await service.createInternalAccount(
                 site,
                 'followee',
+                siteSettings,
             );
             const nonFollowee = await service.createInternalAccount(
                 site,
                 'non-followee',
+                siteSettings,
             );
 
             await service.recordAccountFollow(followee, account);
@@ -535,6 +573,7 @@ describe('AccountService', () => {
         const account = await service.createInternalAccount(
             site,
             'testing-update',
+            siteSettings,
         );
 
         let accountFromEvent: Account | undefined;

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -11,7 +11,7 @@ import {
     TABLE_FOLLOWS,
     TABLE_USERS,
 } from '../constants';
-import type { Account, ExternalAccountData, Site } from './types';
+import type { Account, ExternalAccountData, Site, SiteSettings } from './types';
 
 interface GetFollowingAccountsOptions {
     limit: number;
@@ -45,14 +45,15 @@ export class AccountService {
     async createInternalAccount(
         site: Site,
         username: string,
+        settings: SiteSettings,
     ): Promise<Account> {
         const keyPair = await generateCryptoKeyPair();
 
         const accountData = {
-            name: ACTOR_DEFAULT_NAME,
+            name: settings?.site?.title || ACTOR_DEFAULT_NAME,
             username,
-            bio: ACTOR_DEFAULT_SUMMARY,
-            avatar_url: ACTOR_DEFAULT_ICON,
+            bio: settings?.site?.description || ACTOR_DEFAULT_SUMMARY,
+            avatar_url: settings?.site?.icon || ACTOR_DEFAULT_ICON,
             banner_image_url: null,
             url: `https://${site.host}`,
             custom_fields: null,

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -11,7 +11,7 @@ import {
     TABLE_FOLLOWS,
     TABLE_USERS,
 } from '../constants';
-import type { Account, ExternalAccountData, Site, SiteSettings } from './types';
+import type { Account, ExternalAccountData, Site, InternalAccountData } from './types';
 
 interface GetFollowingAccountsOptions {
     limit: number;
@@ -44,16 +44,16 @@ export class AccountService {
      */
     async createInternalAccount(
         site: Site,
-        username: string,
-        settings: SiteSettings,
+        internalAccountData: InternalAccountData,
     ): Promise<Account> {
         const keyPair = await generateCryptoKeyPair();
+        const username = internalAccountData.username;
 
         const accountData = {
-            name: settings?.site?.title || ACTOR_DEFAULT_NAME,
-            username,
-            bio: settings?.site?.description || ACTOR_DEFAULT_SUMMARY,
-            avatar_url: settings?.site?.icon || ACTOR_DEFAULT_ICON,
+            name: internalAccountData.name || ACTOR_DEFAULT_NAME,
+            username : username,
+            bio: internalAccountData.bio || ACTOR_DEFAULT_SUMMARY,
+            avatar_url: internalAccountData.avatar_url || ACTOR_DEFAULT_ICON,
             banner_image_url: null,
             url: `https://${site.host}`,
             custom_fields: null,

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -11,7 +11,12 @@ import {
     TABLE_FOLLOWS,
     TABLE_USERS,
 } from '../constants';
-import type { Account, ExternalAccountData, Site, InternalAccountData } from './types';
+import type {
+    Account,
+    ExternalAccountData,
+    InternalAccountData,
+    Site,
+} from './types';
 
 interface GetFollowingAccountsOptions {
     limit: number;
@@ -51,7 +56,7 @@ export class AccountService {
 
         const accountData = {
             name: internalAccountData.name || ACTOR_DEFAULT_NAME,
-            username : username,
+            username: username,
             bio: internalAccountData.bio || ACTOR_DEFAULT_SUMMARY,
             avatar_url: internalAccountData.avatar_url || ACTOR_DEFAULT_ICON,
             banner_image_url: null,

--- a/src/account/types.ts
+++ b/src/account/types.ts
@@ -7,6 +7,14 @@ export interface Site {
     webhook_secret: string;
 }
 
+export interface SiteSettings {
+    site: {
+        description: string;
+        icon: string;
+        title: string;
+    };
+}
+
 /**
  * Account
  */

--- a/src/account/types.ts
+++ b/src/account/types.ts
@@ -7,12 +7,11 @@ export interface Site {
     webhook_secret: string;
 }
 
-export interface SiteSettings {
-    site: {
-        description: string;
-        icon: string;
-        title: string;
-    };
+export interface InternalAccountData {
+    username: string;
+    name?: string;
+    bio?: string;
+    avatar_url?: string;
 }
 
 /**

--- a/src/helpers/ghost.ts
+++ b/src/helpers/ghost.ts
@@ -1,11 +1,18 @@
 import ky from 'ky';
-import type { SiteSettings } from '../account/types';
 
 import {
     ACTOR_DEFAULT_ICON,
     ACTOR_DEFAULT_NAME,
     ACTOR_DEFAULT_SUMMARY,
 } from '../constants';
+
+type SiteSettings = {
+    site: {
+        description: string;
+        icon: string;
+        title: string;
+    };
+};
 
 export async function getSiteSettings(host: string): Promise<SiteSettings> {
     const settings = await ky

--- a/src/helpers/ghost.ts
+++ b/src/helpers/ghost.ts
@@ -1,18 +1,11 @@
 import ky from 'ky';
+import type { SiteSettings } from '../account/types';
 
 import {
     ACTOR_DEFAULT_ICON,
     ACTOR_DEFAULT_NAME,
     ACTOR_DEFAULT_SUMMARY,
 } from '../constants';
-
-type SiteSettings = {
-    site: {
-        description: string;
-        icon: string;
-        title: string;
-    };
-};
 
 export async function getSiteSettings(host: string): Promise<SiteSettings> {
     const settings = await ky

--- a/src/site/site.service.ts
+++ b/src/site/site.service.ts
@@ -75,9 +75,12 @@ export class SiteService {
             throw new Error(`Site initialisation failed for ${host}`);
         }
 
+        const settings = await this.ghostService.getSiteSettings(newSite.host);
+
         const internalAccount = await this.accountService.createInternalAccount(
             newSite,
             'index',
+            settings
         );
 
         return newSite;

--- a/src/site/site.service.ts
+++ b/src/site/site.service.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 import type { Knex } from 'knex';
 import type { AccountService } from '../account/account.service';
 import type { getSiteSettings } from '../helpers/ghost';
+import type { InternalAccountData } from '../account/types';
 
 export type Site = {
     id: number;
@@ -77,10 +78,16 @@ export class SiteService {
 
         const settings = await this.ghostService.getSiteSettings(newSite.host);
 
+        const internalAccountData: InternalAccountData = {
+            username: 'index',
+            name: settings?.site?.title,
+            bio: settings?.site?.description,
+            avatar_url: settings?.site?.icon,
+        };
+
         const internalAccount = await this.accountService.createInternalAccount(
             newSite,
-            'index',
-            settings,
+            internalAccountData,
         );
 
         return newSite;

--- a/src/site/site.service.ts
+++ b/src/site/site.service.ts
@@ -1,8 +1,8 @@
 import crypto from 'node:crypto';
 import type { Knex } from 'knex';
 import type { AccountService } from '../account/account.service';
-import type { getSiteSettings } from '../helpers/ghost';
 import type { InternalAccountData } from '../account/types';
+import type { getSiteSettings } from '../helpers/ghost';
 
 export type Site = {
     id: number;

--- a/src/site/site.service.ts
+++ b/src/site/site.service.ts
@@ -80,7 +80,7 @@ export class SiteService {
         const internalAccount = await this.accountService.createInternalAccount(
             newSite,
             'index',
-            settings
+            settings,
         );
 
         return newSite;


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/AP-737/

- While creating an account we used the default name, icon and bio
- This change will use the site settings to fetch the name, icon and bio while creating the AP account and we'll use the default ones only if the info is missing in site setting. 

