### PR TITLE
Implemented adding a post to a feed

### DIFF
--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -289,28 +289,6 @@ describe('AccountService', () => {
         });
     });
 
-    describe('getInternalIdForAccount', () => {
-        it('should retrieve the internal ID for an account', async () => {
-            const account = await service.createInternalAccount(site, {
-                ...internalAccountData,
-                username: 'account',
-            });
-
-            const internalId = await service.getInternalIdForAccount(account);
-
-            expect(internalId).toBe(account.id);
-        });
-
-        it('should return null if no user is found for an account', async () => {
-            const account =
-                await service.createExternalAccount(externalAccountData);
-
-            const internalId = await service.getInternalIdForAccount(account);
-
-            expect(internalId).toBeNull();
-        });
-    });
-
     describe('getDefaultAccountForSite', () => {
         it('should retrieve the default account for a site', async () => {
             const account = await service.createInternalAccount(site, {

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -374,22 +374,6 @@ export class AccountService {
         };
     }
 
-    /**
-     * Get the internal ID for an account
-     *
-     * @param account Account
-     */
-    async getInternalIdForAccount(
-        account: AccountType,
-    ): Promise<number | null> {
-        const result = await this.db(TABLE_USERS)
-            .where('account_id', account.id)
-            .select('id')
-            .first();
-
-        return result?.id ?? null;
-    }
-
     async updateAccount(
         account: AccountType,
         data: Omit<Partial<AccountType>, 'id'>,

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -374,6 +374,22 @@ export class AccountService {
         };
     }
 
+    /**
+     * Get the internal ID for an account
+     *
+     * @param account Account
+     */
+    async getInternalIdForAccount(
+        account: AccountType,
+    ): Promise<number | null> {
+        const result = await this.db(TABLE_USERS)
+            .where('account_id', account.id)
+            .select('id')
+            .first();
+
+        return result?.id ?? null;
+    }
+
     async updateAccount(
         account: AccountType,
         data: Omit<Partial<AccountType>, 'id'>,

--- a/src/app.ts
+++ b/src/app.ts
@@ -247,7 +247,7 @@ const postService = new PostService(
 const siteService = new SiteService(client, accountService, {
     getSiteSettings: getSiteSettings,
 });
-const feedService = new FeedService();
+const feedService = new FeedService(client, events, accountService);
 
 const fediverseBridge = new FediverseBridge(events, fedifyContextFactory);
 fediverseBridge.init();

--- a/src/app.ts
+++ b/src/app.ts
@@ -247,7 +247,7 @@ const postService = new PostService(
 const siteService = new SiteService(client, accountService, {
     getSiteSettings: getSiteSettings,
 });
-const feedService = new FeedService(client, events, accountService);
+const feedService = new FeedService(client, events);
 
 const fediverseBridge = new FediverseBridge(events, fedifyContextFactory);
 fediverseBridge.init();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,3 +14,6 @@ export const TABLE_ACCOUNTS = 'accounts';
 export const TABLE_FOLLOWS = 'follows';
 export const TABLE_SITES = 'sites';
 export const TABLE_USERS = 'users';
+export const TABLE_POSTS = 'posts';
+export const TABLE_LIKES = 'likes';
+export const TABLE_FEEDS = 'feeds';

--- a/src/feed/feed.service.integration.test.ts
+++ b/src/feed/feed.service.integration.test.ts
@@ -14,6 +14,7 @@ import {
     TABLE_USERS,
 } from '../constants';
 import { client } from '../db';
+import { Audience, PostType } from '../post/post.entity';
 import { Post } from '../post/post.entity';
 import { KnexPostRepository } from '../post/post.repository.knex';
 import { SiteService } from '../site/site.service';
@@ -84,7 +85,7 @@ describe('FeedService', () => {
     });
 
     describe('handling a post being created', () => {
-        it("should add to the user's feed and any follower feeds if the post audience is: Public", async () => {
+        it("should add to the user's feed and any follower feeds if the post audience is: Public or FollowersOnly", async () => {
             const feedService = new FeedService(client, events);
 
             // Initialise user internal account
@@ -139,30 +140,32 @@ describe('FeedService', () => {
 
             // Create posts
             const fooAccountPost = Post.createArticleFromGhostPost(fooAccount, {
-                title: 'Title',
-                html: '<p>Hello, world!</p>',
-                excerpt: 'Hello, world!',
+                title: 'Foo Account Post',
+                html: '<p>Hello, world! (from foo.com)</p>',
+                excerpt: 'Hello, world! (from foo.com)',
                 feature_image: null,
                 url: 'https://foo.com/hello-world',
                 published_at: '2025-01-01',
             });
 
-            const barAccountPost = Post.createArticleFromGhostPost(barAccount, {
-                title: 'Title',
-                html: '<p>Hello, world!</p>',
-                excerpt: 'Hello, world!',
-                feature_image: null,
-                url: 'https://bar.com/hello-world',
-                published_at: '2025-01-01',
+            const barAccountPost = Post.createFromData(barAccount, {
+                type: PostType.Article,
+                audience: Audience.FollowersOnly,
+                title: 'Bar Account Post',
+                excerpt: 'Hello, world! (from bar.com)',
+                content: '<p>Hello, world! (from bar.com)</p>',
+                url: new URL('https://bar.com/hello-world'),
+                imageUrl: null,
+                publishedAt: new Date('2025-01-02'),
             });
 
             const bazAccountPost = Post.createArticleFromGhostPost(bazAccount, {
-                title: 'Title',
-                html: '<p>Hello, world!</p>',
-                excerpt: 'Hello, world!',
+                title: 'Baz Account Post',
+                html: '<p>Hello, world! (from baz.com)</p>',
+                excerpt: 'Hello, world! (from baz.com)',
                 feature_image: null,
                 url: 'https://baz.com/hello-world',
-                published_at: '2025-01-01',
+                published_at: '2025-01-03',
             });
 
             await postRepository.save(fooAccountPost);
@@ -223,13 +226,5 @@ describe('FeedService', () => {
                 author_id: bazAccount.id,
             });
         }, 10000);
-
-        it.skip('should only add to follower feeds if the post audience is: FollowersOnly', async () => {
-            // @TODO: Implement
-        });
-
-        it.skip('should not add to any feeds if the post audience is: Direct', async () => {
-            // @TODO: Implement
-        });
     });
 });

--- a/src/feed/feed.service.integration.test.ts
+++ b/src/feed/feed.service.integration.test.ts
@@ -139,13 +139,15 @@ describe('FeedService', () => {
             );
 
             // Create posts
-            const fooAccountPost = Post.createArticleFromGhostPost(fooAccount, {
+            const fooAccountPost = Post.createFromData(fooAccount, {
+                type: PostType.Article,
+                audience: Audience.Public,
                 title: 'Foo Account Post',
-                html: '<p>Hello, world! (from foo.com)</p>',
                 excerpt: 'Hello, world! (from foo.com)',
-                feature_image: null,
-                url: 'https://foo.com/hello-world',
-                published_at: '2025-01-01',
+                content: '<p>Hello, world! (from foo.com)</p>',
+                url: new URL('https://foo.com/hello-world'),
+                imageUrl: null,
+                publishedAt: new Date('2025-01-01'),
             });
 
             const barAccountPost = Post.createFromData(barAccount, {
@@ -159,13 +161,15 @@ describe('FeedService', () => {
                 publishedAt: new Date('2025-01-02'),
             });
 
-            const bazAccountPost = Post.createArticleFromGhostPost(bazAccount, {
+            const bazAccountPost = Post.createFromData(bazAccount, {
+                type: PostType.Article,
+                audience: Audience.Public,
                 title: 'Baz Account Post',
-                html: '<p>Hello, world! (from baz.com)</p>',
                 excerpt: 'Hello, world! (from baz.com)',
-                feature_image: null,
-                url: 'https://baz.com/hello-world',
-                published_at: '2025-01-03',
+                content: '<p>Hello, world! (from baz.com)</p>',
+                url: new URL('https://baz.com/hello-world'),
+                imageUrl: null,
+                publishedAt: new Date('2025-01-03'),
             });
 
             await postRepository.save(fooAccountPost);

--- a/src/feed/feed.service.integration.test.ts
+++ b/src/feed/feed.service.integration.test.ts
@@ -235,7 +235,7 @@ describe('FeedService', () => {
                 post_id: bazAccountPost.id,
                 author_id: bazAccount.id,
             });
-        });
+        }, 10000);
 
         it.skip('should only add to follower feeds if the post audience is: FollowersOnly', async () => {
             // @TODO: Implement

--- a/src/feed/feed.service.integration.test.ts
+++ b/src/feed/feed.service.integration.test.ts
@@ -1,0 +1,248 @@
+import { EventEmitter } from 'node:events';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { KnexAccountRepository } from '../account/account.repository.knex';
+import { AccountService } from '../account/account.service';
+import type { Account as AccountType } from '../account/types';
+import { FedifyContextFactory } from '../activitypub/fedify-context.factory';
+import {
+    TABLE_ACCOUNTS,
+    TABLE_FEEDS,
+    TABLE_FOLLOWS,
+    TABLE_POSTS,
+    TABLE_SITES,
+    TABLE_USERS,
+} from '../constants';
+import { client } from '../db';
+import { Post } from '../post/post.entity';
+import { KnexPostRepository } from '../post/post.repository.knex';
+import { SiteService } from '../site/site.service';
+import { FeedService } from './feed.service';
+import {
+    FeedsUpdatedEvent,
+    FeedsUpdatedEventUpdateOperation,
+} from './feeds-updated.event';
+
+describe('FeedService', () => {
+    let events: EventEmitter;
+    let accountRepository: KnexAccountRepository;
+    let fedifyContextFactory: FedifyContextFactory;
+    let accountService: AccountService;
+    let siteService: SiteService;
+    let postRepository: KnexPostRepository;
+
+    const waitForPostAddedToFeeds = (post: Post) => {
+        return new Promise<void>((resolve) => {
+            events.on(
+                FeedsUpdatedEvent.getName(),
+                (event: FeedsUpdatedEvent) => {
+                    if (
+                        event.post.id === post.id &&
+                        event.updateOperation ===
+                            FeedsUpdatedEventUpdateOperation.PostAdded
+                    ) {
+                        resolve();
+                    }
+                },
+            );
+        });
+    };
+
+    beforeEach(async () => {
+        // Clean up the database
+        await client.raw('SET FOREIGN_KEY_CHECKS = 0');
+        await client(TABLE_FEEDS).truncate();
+        await client(TABLE_POSTS).truncate();
+        await client(TABLE_FOLLOWS).truncate();
+        await client(TABLE_ACCOUNTS).truncate();
+        await client(TABLE_USERS).truncate();
+        await client(TABLE_SITES).truncate();
+        await client.raw('SET FOREIGN_KEY_CHECKS = 1');
+
+        // Init dependencies
+        events = new EventEmitter();
+        accountRepository = new KnexAccountRepository(client, events);
+        fedifyContextFactory = new FedifyContextFactory();
+        accountService = new AccountService(
+            client,
+            events,
+            accountRepository,
+            fedifyContextFactory,
+        );
+        siteService = new SiteService(client, accountService, {
+            async getSiteSettings(host: string) {
+                return {
+                    site: {
+                        title: `Site ${host} title`,
+                        description: `Site ${host} description`,
+                        icon: `https://${host}/favicon.ico`,
+                    },
+                };
+            },
+        });
+        postRepository = new KnexPostRepository(client, events);
+    });
+
+    describe('handling a post being created', () => {
+        it("should add to the user's feed and any follower feeds if the post audience is: Public", async () => {
+            const feedService = new FeedService(client, events, accountService);
+
+            // Initialise user internal account
+            const fooSite = await siteService.initialiseSiteForHost('foo.com');
+            const fooAccount = await accountRepository.getBySite(fooSite);
+            const fooUserId = await accountService.getInternalIdForAccount(
+                fooAccount as unknown as AccountType,
+            );
+
+            // Initialise an internal account that the user will follow
+            const barSite = await siteService.initialiseSiteForHost('bar.com');
+            const barAccount = await accountRepository.getBySite(barSite);
+            const barUserId = await accountService.getInternalIdForAccount(
+                barAccount as unknown as AccountType,
+            );
+
+            await accountService.recordAccountFollow(
+                barAccount as unknown as AccountType,
+                fooAccount as unknown as AccountType,
+            );
+
+            // Initialise an internal account that the user will not follow
+            const bazSite = await siteService.initialiseSiteForHost('baz.com');
+            const bazAccount = await accountRepository.getBySite(bazSite);
+            const bazUserId = await accountService.getInternalIdForAccount(
+                bazAccount as unknown as AccountType,
+            );
+
+            // Initialise an external account that follows the user - This account
+            // should not have a feed so we should not try and add a post to it.
+            // If we did, an error would be thrown and the test would fail.
+            // @TODO: Is there a better way to test this?
+            const quxAccount = await accountService.createExternalAccount({
+                username: 'external-account',
+                name: 'External Account',
+                bio: 'External Account Bio',
+                avatar_url: 'https://example.com/avatars/external-account.png',
+                banner_image_url:
+                    'https://example.com/banners/external-account.png',
+                url: 'https://example.com/users/external-account',
+                custom_fields: {},
+                ap_id: 'https://example.com/activitypub/users/external-account',
+                ap_inbox_url:
+                    'https://example.com/activitypub/inbox/external-account',
+                ap_outbox_url:
+                    'https://example.com/activitypub/outbox/external-account',
+                ap_following_url:
+                    'https://example.com/activitypub/following/external-account',
+                ap_followers_url:
+                    'https://example.com/activitypub/followers/external-account',
+                ap_liked_url:
+                    'https://example.com/activitypub/liked/external-account',
+                ap_shared_inbox_url: null,
+                ap_public_key: '',
+            });
+
+            await accountService.recordAccountFollow(
+                fooAccount as unknown as AccountType,
+                quxAccount as unknown as AccountType,
+            );
+
+            // Create posts
+            const fooAccountPost = Post.createArticleFromGhostPost(fooAccount, {
+                title: 'Title',
+                html: '<p>Hello, world!</p>',
+                excerpt: 'Hello, world!',
+                feature_image: null,
+                url: 'https://foo.com/hello-world',
+                published_at: '2025-01-01',
+            });
+
+            const barAccountPost = Post.createArticleFromGhostPost(barAccount, {
+                title: 'Title',
+                html: '<p>Hello, world!</p>',
+                excerpt: 'Hello, world!',
+                feature_image: null,
+                url: 'https://bar.com/hello-world',
+                published_at: '2025-01-01',
+            });
+
+            const bazAccountPost = Post.createArticleFromGhostPost(bazAccount, {
+                title: 'Title',
+                html: '<p>Hello, world!</p>',
+                excerpt: 'Hello, world!',
+                feature_image: null,
+                url: 'https://baz.com/hello-world',
+                published_at: '2025-01-01',
+            });
+
+            await postRepository.save(fooAccountPost);
+            await waitForPostAddedToFeeds(fooAccountPost);
+
+            await postRepository.save(barAccountPost);
+            await waitForPostAddedToFeeds(barAccountPost);
+
+            await postRepository.save(bazAccountPost);
+            await waitForPostAddedToFeeds(bazAccountPost);
+
+            // fooAccount should have 2 posts in their feed - Their own and barAccount's
+            // (because fooAccount follows barAccount)
+            const fooFeed = await client(TABLE_FEEDS).where(
+                'user_id',
+                fooUserId,
+            );
+
+            expect(fooFeed.length).toBe(2);
+            expect(fooFeed[0]).toMatchObject({
+                post_type: fooAccountPost.type,
+                audience: fooAccountPost.audience,
+                user_id: fooUserId,
+                post_id: fooAccountPost.id,
+                author_id: fooAccount.id,
+            });
+            expect(fooFeed[1]).toMatchObject({
+                post_type: barAccountPost.type,
+                audience: barAccountPost.audience,
+                user_id: fooUserId,
+                post_id: barAccountPost.id,
+                author_id: barAccount.id,
+            });
+
+            // barAccount should have 1 post in their feed - Their own
+            // (because they do not follow anyone)
+            const barFeed = await client(TABLE_FEEDS).where(
+                'user_id',
+                barUserId,
+            );
+            expect(barFeed.length).toBe(1);
+            expect(barFeed[0]).toMatchObject({
+                post_type: barAccountPost.type,
+                audience: barAccountPost.audience,
+                user_id: barUserId,
+                post_id: barAccountPost.id,
+                author_id: barAccount.id,
+            });
+
+            // bazAccount should have 1 posts in their feed - Their own
+            // (because they do not follow anyone)
+            const bazFeed = await client(TABLE_FEEDS).where(
+                'user_id',
+                bazUserId,
+            );
+            expect(bazFeed.length).toBe(1);
+            expect(bazFeed[0]).toMatchObject({
+                post_type: bazAccountPost.type,
+                audience: bazAccountPost.audience,
+                user_id: bazUserId,
+                post_id: bazAccountPost.id,
+                author_id: bazAccount.id,
+            });
+        });
+
+        it.skip('should only add to follower feeds if the post audience is: FollowersOnly', async () => {
+            // @TODO: Implement
+        });
+
+        it.skip('should not add to any feeds if the post audience is: Direct', async () => {
+            // @TODO: Implement
+        });
+    });
+});

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -49,9 +49,7 @@ export class FeedService {
     ) {
         this.events.on(
             PostCreatedEvent.getName(),
-            async (event: PostCreatedEvent) => {
-                await this.handlePostCreatedEvent(event);
-            },
+            this.handlePostCreatedEvent.bind(this),
         );
     }
 
@@ -196,15 +194,7 @@ export class FeedService {
     /**
      * Add a post to the feeds of the users that should see it
      *
-     * If the post audience = Public then the post should be added to:
-     * - The feed of the user that authored the post
-     * - The feeds of all users that follow the author
-     *
-     * If the post audience = FollowersOnly then the post should be added to:
-     * - The feed of the user that authored the post
-     * - The feeds of all users that follow the author
-     *
-     * @param event Post created event
+     * @param post Post to add to feeds
      */
     private async addPostToFeeds(post: PublicPost | FollowersOnlyPost) {
         // Work out which user's feeds the post should be added to

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -183,11 +183,16 @@ export class FeedService {
         };
     }
 
+    /**
+     * Handle a post created event
+     *
+     * @param event Post created event
+     */
     private async handlePostCreatedEvent(event: PostCreatedEvent) {
         const post = event.getPost();
 
         if (isPublicPost(post) || isFollowersOnlyPost(post)) {
-            this.addPostToFeeds(post);
+            await this.addPostToFeeds(post);
         }
     }
 

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -240,7 +240,7 @@ export class FeedService {
             // @TODO: Handle reposted_by_id
         }));
 
-        await this.db(TABLE_FEEDS).insert(feedEntries); // @TODO: Is there a limit on the number of rows we can insert at once?
+        await this.db.batchInsert(TABLE_FEEDS, feedEntries);
 
         // Emit event to notify listeners that multiple feeds have been updated
         this.events.emit(

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -237,7 +237,7 @@ export class FeedService {
             user_id: userId,
             post_id: post.id,
             author_id: post.author.id,
-            // @TODO: Handle reposted_by_id
+            reposted_by_id: null,
         }));
 
         await this.db.batchInsert(TABLE_FEEDS, feedEntries);

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -214,6 +214,17 @@ export class FeedService {
             targetUserIds.add(authorInternalId.id);
         }
 
+        const inReplyToAuthorId =
+            post.inReplyTo &&
+            (await this.db(TABLE_USERS)
+                .where('account_id', post.inReplyTo.id)
+                .select('id')
+                .first());
+
+        if (inReplyToAuthorId) {
+            targetUserIds.add(inReplyToAuthorId.id);
+        }
+
         const followerIds = await this.db(TABLE_FOLLOWS)
             .join(TABLE_USERS, 'follows.follower_id', 'users.id')
             .where('following_id', post.author.id)

--- a/src/feed/feeds-updated.event.ts
+++ b/src/feed/feeds-updated.event.ts
@@ -1,0 +1,18 @@
+import type { Post } from '../post/post.entity';
+
+export enum FeedsUpdatedEventUpdateOperation {
+    PostAdded = 'post.added',
+    PostRemoved = 'post.removed',
+}
+
+export class FeedsUpdatedEvent {
+    constructor(
+        public readonly userIds: number[],
+        public readonly updateOperation: FeedsUpdatedEventUpdateOperation,
+        public readonly post: Post,
+    ) {}
+
+    static getName(): string {
+        return 'feeds.updated';
+    }
+}

--- a/src/post/post-created.event.ts
+++ b/src/post/post-created.event.ts
@@ -1,0 +1,13 @@
+import type { Post } from './post.entity';
+
+export class PostCreatedEvent {
+    constructor(private readonly post: Post) {}
+
+    getPost(): Post {
+        return this.post;
+    }
+
+    static getName(): string {
+        return 'post.created';
+    }
+}

--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -33,6 +33,7 @@ interface PostData {
     url?: URL | null;
     imageUrl?: URL | null;
     publishedAt?: Date;
+    inReplyTo?: Post;
 }
 
 export type PublicPost = Post & {
@@ -144,6 +145,10 @@ export class Post extends BaseEntity {
             data.url ?? null,
             data.imageUrl ?? null,
             data.publishedAt ?? new Date(),
+            0,
+            0,
+            0,
+            data.inReplyTo ?? null,
         );
     }
 }

--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -35,6 +35,22 @@ interface PostData {
     publishedAt?: Date;
 }
 
+export type PublicPost = Post & {
+    audience: Audience.Public;
+};
+
+export type FollowersOnlyPost = Post & {
+    audience: Audience.FollowersOnly;
+};
+
+export function isPublicPost(post: Post): post is PublicPost {
+    return post.audience === Audience.Public;
+}
+
+export function isFollowersOnlyPost(post: Post): post is FollowersOnlyPost {
+    return post.audience === Audience.FollowersOnly;
+}
+
 export class Post extends BaseEntity {
     public readonly uuid: string;
     public readonly apId: URL;

--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -1,7 +1,9 @@
 import type EventEmitter from 'node:events';
 import type { Knex } from 'knex';
+
 import { Account } from '../account/account.entity';
 import { parseURL } from '../core/url';
+import { PostCreatedEvent } from './post-created.event';
 import { Post } from './post.entity';
 
 export class KnexPostRepository {
@@ -103,6 +105,11 @@ export class KnexPostRepository {
                     reading_time_minutes: post.readingTime,
                     ap_id: post.apId.href,
                 });
+
+                this.events.emit(
+                    PostCreatedEvent.getName(),
+                    new PostCreatedEvent(post),
+                );
 
                 if (potentiallyNewLikes.length > 0) {
                     const likesToInsert = potentiallyNewLikes.map(


### PR DESCRIPTION
refs [AP-753](https://linear.app/ghost/issue/AP-753/handle-adding-a-post-to-a-feed)

Implemented adding a post to a feed using the application event bus: When a post is created, a `post.created` event is emitted which gets picked up by the `FeedService`. The `FeedService` will then handle this event and add a post to the appropriate feed(s) based on the audience of the post