### PR TITLE
Added reposted post to post & feeds table when announce handler executed

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -328,7 +328,12 @@ inboxListener
         Announce,
         ensureCorrectContext(
             spanWrapper(
-                createAnnounceHandler(siteService, accountService, postService),
+                createAnnounceHandler(
+                    siteService,
+                    accountService,
+                    postService,
+                    postRepository,
+                ),
             ),
         ),
     )

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -439,6 +439,7 @@ export function createAnnounceHandler(
     siteService: SiteService,
     accountService: AccountService,
     postService: PostService,
+    postRepository: KnexPostRepository,
 ) {
     return async function handleAnnounce(
         ctx: Context<ContextData>,
@@ -552,6 +553,15 @@ export function createAnnounceHandler(
         if (!site) {
             throw new Error(`Site not found for host: ${ctx.host}`);
         }
+
+        // This will save the account if it doesn't already exist
+        const senderAccount = await accountService.getByApId(sender.id);
+
+        // This will save the post if it doesn't already exist
+        const post = await postService.getByApId(announce.objectId);
+
+        post.addRepost(senderAccount);
+        await postRepository.save(post);
 
         shouldAddToInbox = await isFollowedByDefaultSiteAccount(
             sender,

--- a/src/feed/feed.service.integration.test.ts
+++ b/src/feed/feed.service.integration.test.ts
@@ -196,8 +196,9 @@ describe('FeedService', () => {
             await postRepository.save(bazAccountReply);
             await waitForPostAddedToFeeds(bazAccountReply);
 
-            // fooAccount should have 2 posts in their feed - Their own and barAccount's
-            // (because fooAccount follows barAccount)
+            // fooAccount should have 3 posts in their feed - Their own, barAccount's
+            //  post (because fooAccount follows barAccount) & bazAccount's reply
+            //  (because fooAccount's post was replied to in bazAccount's reply post)
             const fooFeed = await client('feeds')
                 .join('users', 'users.id', 'feeds.user_id')
                 .join('accounts', 'accounts.id', 'users.account_id')


### PR DESCRIPTION
refs [AP-719](https://linear.app/ghost/issue/AP-719/add-to-posts-feeds-reposts-table-when-announce-inbox-handler-is)

When the `Announce` handler is executed we now add the reposted post to the `posts` table as well as inserting into the correct user feeds in the `feeds` tables