### PR TITLE
Added UNIQUE constaint to feeds

### DIFF
--- a/migrate/migrations/000011_add-unique-constraint-to-feeds.down.sql
+++ b/migrate/migrations/000011_add-unique-constraint-to-feeds.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE feeds DROP CONSTRAINT uniq_feeds_user_post;

--- a/migrate/migrations/000011_add-unique-constraint-to-feeds.up.sql
+++ b/migrate/migrations/000011_add-unique-constraint-to-feeds.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE feeds ADD CONSTRAINT uniq_feeds_user_post UNIQUE (user_id, post_id, reposted_by_id);


### PR DESCRIPTION
closes https://linear.app/ghost/issue/AP-765

We don't want to allow for multiple entries of the same item in the feeds table
so we have added a UNIQUE constraint. It needs to include the `reposted_by_id`
because the same post can be in the feed multiple times due to reposts.

With the new UNIQUE constraint on the feeds table, we need to make sure we
handle conflicts when inserting. The `batchInsert` method in knex is just a for
loop like this, but doesn't allow using the `onConflict` method. We've pulled
that out and ensured everything is still run inside of a transaction