### PR TITLE
Misc feed service updates

### DIFF
--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -283,6 +283,10 @@ export class FeedService {
         // Add the post to the feeds
         const userIds = Array.from(targetUserIds).map(Number);
 
+        if (userIds.length === 0) {
+            return;
+        }
+
         const feedEntries = userIds.map((userId) => ({
             post_type: post.type,
             audience: post.audience,

--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -24,7 +24,7 @@ interface GhostPost {
     url: string;
 }
 
-interface PostData {
+export interface PostData {
     type: PostType;
     audience?: Audience;
     title?: string | null;

--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -235,7 +235,7 @@ export class KnexPostRepository {
     }
 
     /**
-     * Insert likes associated with a post into the database
+     * Insert likes of a post into the database
      *
      * @param post Post to insert likes for
      * @param likeAccountIds Account IDs to insert likes for
@@ -255,7 +255,7 @@ export class KnexPostRepository {
     }
 
     /**
-     * Insert likes associated with a post into the database, ignoring
+     * Insert likes of a post into the database, ignoring
      * duplicates
      *
      * @param post Post to insert likes for
@@ -286,7 +286,7 @@ export class KnexPostRepository {
     }
 
     /**
-     * Insert reposts associated with a post into the database
+     * Insert reposts of a post into the database
      *
      * @param post Post to insert reposts for
      * @param repostAccountIds Account IDs to insert reposts for
@@ -306,7 +306,7 @@ export class KnexPostRepository {
     }
 
     /**
-     * Insert reposts associated with a post into the database, ignoring
+     * Insert reposts of a post into the database, ignoring
      * duplicates
      *
      * @param post Post to insert reposts for
@@ -333,6 +333,13 @@ export class KnexPostRepository {
         const newRepostAccountIds = repostAccountIds.filter(
             (accountId) => !currentRepostAccountIds.includes(accountId),
         );
+
+        if (newRepostAccountIds.length === 0) {
+            return {
+                count: 0,
+                accountIds: [],
+            };
+        }
 
         const repostsToInsert = newRepostAccountIds.map((accountId) => ({
             account_id: accountId,


### PR DESCRIPTION
no refs

Changes include:

- Bailing early if there are no reposts - This is required to prevent an unhandled error (passing empty array to query)
- Bailing early if no feeds where updated - Same as above
- Moved `feed.updated` event emission in to the event handler to keep related event logic together
- Only emit `feed.updated` event if a user's feed was actually updated 
- Refactored feed service test:
    - Added helpers for common operations across tests
    - Renamed account variables to better reflect what they are