### PR TITLE
Improved error handling for getByApId methods

### DIFF
--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -557,11 +557,15 @@ export function createAnnounceHandler(
         // This will save the account if it doesn't already exist
         const senderAccount = await accountService.getByApId(sender.id);
 
-        // This will save the post if it doesn't already exist
-        const post = await postService.getByApId(announce.objectId);
+        if (senderAccount !== null) {
+            // This will save the post if it doesn't already exist
+            const post = await postService.getByApId(announce.objectId);
 
-        post.addRepost(senderAccount);
-        await postRepository.save(post);
+            if (post !== null) {
+                post.addRepost(senderAccount);
+                await postRepository.save(post);
+            }
+        }
 
         shouldAddToInbox = await isFollowedByDefaultSiteAccount(
             sender,
@@ -601,11 +605,15 @@ export function createLikeHandler(
         }
 
         const account = await accountService.getByApId(like.actorId);
-        const post = await postService.getByApId(like.objectId);
+        if (account !== null) {
+            const post = await postService.getByApId(like.objectId);
 
-        post.addLike(account);
+            if (post !== null) {
+                post.addLike(account);
 
-        await postRepository.save(post);
+                await postRepository.save(post);
+            }
+        }
 
         // Validate sender
         const sender = await like.getActor(ctx);

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -624,11 +624,13 @@ export function createRepostActionHandler(
         }
 
         const account = await accountRepository.getBySite(ctx.get('site'));
-        const originalPost = await postService.getByApId(post.id);
-
-        originalPost.addRepost(account);
-
-        await postRepository.save(originalPost);
+        if (account !== null) {
+            const originalPost = await postService.getByApId(post.id);
+            if (originalPost !== null) {
+                originalPost.addRepost(account);
+                await postRepository.save(originalPost);
+            }
+        }
 
         const announce = new Announce({
             id: announceId,


### PR DESCRIPTION
closes https://linear.app/ghost/issue/AP-774
closes https://linear.app/ghost/issue/AP-771

We were incorrectly throwing a URL instead of an Error when the Actor wasn't found. This has been fixed, as well as the error message improved so that we can see exactly what the problem was.

We were throwing when recieving invalid posts, but this is not an error, it's an expected path - so instead we're returning null. We've also improved the error message for when the post isn't found at all.