### PR TITLE
Wired up like action to the new db tables

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -837,7 +837,9 @@ app.post(
 app.post(
     '/.ghost/activitypub/actions/like/:id',
     requireRole(GhostRole.Owner),
-    spanWrapper(createLikeAction()),
+    spanWrapper(
+        createLikeAction(accountRepository, postService, postRepository),
+    ),
 );
 app.post(
     '/.ghost/activitypub/actions/unlike/:id',

--- a/src/app.ts
+++ b/src/app.ts
@@ -81,12 +81,12 @@ import { FeedService } from './feed/feed.service';
 import {
     createDerepostActionHandler,
     createFollowActionHandler,
+    createLikeAction,
     createReplyActionHandler,
     createRepostActionHandler,
     createUnfollowActionHandler,
     getSiteDataHandler,
     inboxHandler,
-    likeAction,
     unlikeAction,
 } from './handlers';
 import { getTraceContext } from './helpers/context-header';
@@ -837,7 +837,7 @@ app.post(
 app.post(
     '/.ghost/activitypub/actions/like/:id',
     requireRole(GhostRole.Owner),
-    spanWrapper(likeAction),
+    spanWrapper(createLikeAction()),
 );
 app.post(
     '/.ghost/activitypub/actions/unlike/:id',


### PR DESCRIPTION
For outgoing likes, we want to store the like in our `likes` table immediately,
this is so that we can track the likes of posts outside of our system, as well
as not relying on the incoming activity to store likes for posts inside out
system. This will allow us to eventually optimise and not send outgoing
activities to ourself, instead updating state immediately, as we do here.