### PR TITLE
Fixed duplicate articles in Inbox

### DIFF
--- a/migrate/migrations/000013_remove-duplicate-articles.down.sql
+++ b/migrate/migrations/000013_remove-duplicate-articles.down.sql
@@ -1,0 +1,1 @@
+-- This migration isn't possible to roll back

--- a/migrate/migrations/000013_remove-duplicate-articles.up.sql
+++ b/migrate/migrations/000013_remove-duplicate-articles.up.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+UPDATE posts p1
+JOIN posts p2 ON p1.title = p2.title AND p1.type = 1 AND p2.type = 1
+SET p2.type = 3 -- Mark these rows for deletion
+WHERE p1.excerpt IS NULL AND p2.excerpt IS NOT NULL;
+
+UPDATE posts p1
+JOIN posts p2 ON p1.title = p2.title AND p1.type = 1 AND p2.type = 3
+SET p1.excerpt = p2.excerpt -- Copy the excerpt
+WHERE p1.excerpt IS NULL AND p2.excerpt IS NOT NULL;
+
+DELETE FROM posts WHERE type = 3; -- Delete the marked rows
+
+COMMIT;

--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -17,6 +17,7 @@ export enum Audience {
 // TODO Deduplicate this with the webhook handler
 interface GhostPost {
     title: string;
+    uuid: string;
     html: string | null;
     excerpt: string | null;
     feature_image: string | null;
@@ -165,7 +166,7 @@ export class Post extends BaseEntity {
     ): Post {
         return new Post(
             null,
-            null,
+            ghostPost.uuid,
             account,
             PostType.Article,
             Audience.Public,

--- a/src/post/post.entity.unit.test.ts
+++ b/src/post/post.entity.unit.test.ts
@@ -26,6 +26,24 @@ const externalAccount = (id: number | null = 456) => mockAccount(id, false);
 const internalAccount = (id: number | null = 123) => mockAccount(id, true);
 
 describe('Post', () => {
+    it('should correctly create an article from a Ghost Post', () => {
+        const account = internalAccount();
+        const ghostPost = {
+            uuid: '550e8400-e29b-41d4-a716-446655440000',
+            title: 'Title of my post',
+            html: '<p> This is such a great post </p>',
+            excerpt: 'This is such a great...',
+            feature_image: 'https://ghost.org/feature-image.jpeg',
+            published_at: '2020-01-01',
+            url: 'https://ghost.org/post',
+        };
+
+        const post = Post.createArticleFromGhostPost(account, ghostPost);
+
+        expect(post.uuid).toEqual(ghostPost.uuid);
+        expect(post.content).toEqual(ghostPost.html);
+    });
+
     it('should handle adding and removing reposts', () => {
         const postAuthorAccount = internalAccount(456);
         const postReposterAccount = externalAccount(789);

--- a/src/post/post.repository.knex.integration.test.ts
+++ b/src/post/post.repository.knex.integration.test.ts
@@ -70,6 +70,7 @@ describe('KnexPostRepository', () => {
         const account = await accountRepository.getBySite(site);
         const post = Post.createArticleFromGhostPost(account, {
             title: 'Title',
+            uuid: '3f1c5e84-9a2b-4d7f-8e62-1a6b9c9d4f10',
             html: '<p>Hello, world!</p>',
             excerpt: 'Hello, world!',
             feature_image: null,
@@ -96,6 +97,7 @@ describe('KnexPostRepository', () => {
 
         const post = Post.createArticleFromGhostPost(account, {
             title: 'Title',
+            uuid: '3f1c5e84-9a2b-4d7f-8e62-1a6b9c9d4f10',
             html: '<p>Hello, world!</p>',
             excerpt: 'Hello, world!',
             feature_image: null,
@@ -118,6 +120,7 @@ describe('KnexPostRepository', () => {
 
         const post = Post.createArticleFromGhostPost(account, {
             title: 'Title',
+            uuid: '3f1c5e84-9a2b-4d7f-8e62-1a6b9c9d4f10',
             html: '<p>Hello, world!</p>',
             excerpt: 'Hello, world!',
             feature_image: null,
@@ -136,6 +139,7 @@ describe('KnexPostRepository', () => {
         const account = await accountRepository.getBySite(site);
         const post = Post.createArticleFromGhostPost(account, {
             title: 'Title',
+            uuid: '3f1c5e84-9a2b-4d7f-8e62-1a6b9c9d4f10',
             html: '<p>Hello, world!</p>',
             excerpt: 'Hello, world!',
             feature_image: null,
@@ -170,6 +174,7 @@ describe('KnexPostRepository', () => {
 
         const post = Post.createArticleFromGhostPost(account, {
             title: 'Title',
+            uuid: '3f1c5e84-9a2b-4d7f-8e62-1a6b9c9d4f10',
             html: '<p>Hello, world!</p>',
             excerpt: 'Hello, world!',
             feature_image: null,
@@ -199,6 +204,7 @@ describe('KnexPostRepository', () => {
 
         const post = Post.createArticleFromGhostPost(accounts[0], {
             title: 'Title',
+            uuid: '3f1c5e84-9a2b-4d7f-8e62-1a6b9c9d4f10',
             html: '<p>Hello, world!</p>',
             excerpt: 'Hello, world!',
             feature_image: null,
@@ -240,6 +246,7 @@ describe('KnexPostRepository', () => {
 
         const post = Post.createArticleFromGhostPost(accounts[0], {
             title: 'Title',
+            uuid: '3f1c5e84-9a2b-4d7f-8e62-1a6b9c9d4f10',
             html: '<p>Hello, world!</p>',
             excerpt: 'Hello, world!',
             feature_image: null,
@@ -282,6 +289,7 @@ describe('KnexPostRepository', () => {
 
         const post = Post.createArticleFromGhostPost(accounts[0], {
             title: 'Title',
+            uuid: '3f1c5e84-9a2b-4d7f-8e62-1a6b9c9d4f10',
             html: '<p>Hello, world!</p>',
             excerpt: 'Hello, world!',
             feature_image: null,
@@ -339,6 +347,7 @@ describe('KnexPostRepository', () => {
 
         const post = Post.createArticleFromGhostPost(accounts[0], {
             title: 'Title',
+            uuid: '3f1c5e84-9a2b-4d7f-8e62-1a6b9c9d4f10',
             html: '<p>Hello, world!</p>',
             excerpt: 'Hello, world!',
             feature_image: null,
@@ -402,6 +411,7 @@ describe('KnexPostRepository', () => {
 
         const originalPost = Post.createArticleFromGhostPost(accounts[0], {
             title: 'Original Post',
+            uuid: '3f1c5e84-9a2b-4d7f-8e62-1a6b9c9d4f10',
             html: '<p>Original content</p>',
             excerpt: 'Original content',
             feature_image: null,


### PR DESCRIPTION
closes https://linear.app/ghost/issue/AP-790
closes https://linear.app/ghost/issue/AP-791

We were creating the post without using the `uuid` which resulted in the
incorrect ActivityPub ID being generated, and us creating duplicate entries.
This has been fixed by using the `uuid` given to us by ghost, so we have
consistent ids throughout the system.

Now that we've fixed newly created articles we want to clean up the old ones.
The rows that have a missing `excerpt` are the ones which have the correct
`uuid` so we want to retain these rows, and copy over the missing excerpt.

First we mark all of the rows _without_ a missing excerpt with a `type` of 3,
this is currently unused in the system and we use it as a mark to delete them.

Then we copy the excerpt from posts with an excerpt to ones without, we do this
only when the `title` is the same and the `type` is 1 (an article).

After we've copied the excerpt, we delete the previously marked posts.