### PR TITLE
Renamed types to be more specific

### DIFF
--- a/src/http/api/account.ts
+++ b/src/http/api/account.ts
@@ -4,7 +4,7 @@ import type { AccountService } from '../../account/account.service';
 import { getAccountHandle } from '../../account/utils';
 import type { AppContext } from '../../app';
 import { sanitizeHtml } from '../../helpers/html';
-import type { Account as AccountDTO } from './types';
+import type { AccountDTO } from './types';
 
 /**
  * Maximum number of follow accounts to return

--- a/src/http/api/feed.ts
+++ b/src/http/api/feed.ts
@@ -2,7 +2,7 @@ import type { AccountService } from '../../account/account.service';
 import { getAccountHandle } from '../../account/utils';
 import type { AppContext } from '../../app';
 import type { FeedService, FeedType } from '../../feed/feed.service';
-import type { Post } from './types';
+import type { PostDTO } from './types';
 
 /**
  * Default number of posts to return in a feed
@@ -57,7 +57,7 @@ export function createGetFeedHandler(
             cursor,
         });
 
-        const posts: Post[] = results.map((result) => {
+        const posts: PostDTO[] = results.map((result) => {
             return {
                 id: result.post_ap_id,
                 type: result.post_type,

--- a/src/http/api/helpers/post.ts
+++ b/src/http/api/helpers/post.ts
@@ -17,7 +17,7 @@ import type {
 } from '../../../helpers/activitypub/activity';
 import { lookupActor } from '../../../lookup-helpers';
 import { PostType } from '../../../post/post.entity';
-import type { Post } from '../types';
+import type { PostDTO } from '../types';
 
 /**
  * Get the author of a post from an activity: If the activity has attribution,
@@ -196,7 +196,7 @@ export async function mapActivityToPost(
     activity: Activity,
     accountService: AccountService,
     fedifyCtx: FedifyRequestContext,
-): Promise<Post | null> {
+): Promise<PostDTO | null> {
     const object = activity.object as ActivityObject;
 
     // At the moment it is possible that a post can be published without any
@@ -211,7 +211,7 @@ export async function mapActivityToPost(
         return null;
     }
 
-    const post: Post = {
+    const post: PostDTO = {
         id: object.id,
         type:
             object.type === ACTIVITY_OBJECT_TYPE_ARTICLE

--- a/src/http/api/search.ts
+++ b/src/http/api/search.ts
@@ -10,10 +10,10 @@ import {
 } from '../../helpers/activitypub/actor';
 import { isUri } from '../../helpers/uri';
 import { lookupObject } from '../../lookup-helpers';
-import type { Account } from './types';
+import type { AccountDTO } from './types';
 
 type AccountSearchResult = Pick<
-    Account,
+    AccountDTO,
     'id' | 'name' | 'handle' | 'avatarUrl' | 'followerCount' | 'followedByMe'
 >;
 

--- a/src/http/api/types.ts
+++ b/src/http/api/types.ts
@@ -4,7 +4,7 @@ import type { PostType } from '../../post/post.entity';
  * Account returned by the API - Anywhere an account is returned via the API,
  * it should be this shape, or a partial version of it
  */
-export interface Account {
+export interface AccountDTO {
     /**
      * Internal ID of the account
      */
@@ -67,7 +67,7 @@ export interface Account {
  * Post returned by the API - Anywhere a post is returned via the API,
  * it should be this shape, or a partial version of it
  */
-export interface Post {
+export interface PostDTO {
     /**
      * Internal ID of the post
      */
@@ -140,7 +140,7 @@ export interface Post {
     /**
      * Author of the post (partial account)
      */
-    author: Pick<Account, 'id' | 'handle' | 'avatarUrl' | 'name' | 'url'>;
+    author: Pick<AccountDTO, 'id' | 'handle' | 'avatarUrl' | 'name' | 'url'>;
     /**
      * Number of reposts of the post
      */
@@ -153,7 +153,7 @@ export interface Post {
      * Account that reposted the post
      */
     repostedBy: Pick<
-        Account,
+        AccountDTO,
         'id' | 'handle' | 'avatarUrl' | 'name' | 'url'
     > | null;
 }


### PR DESCRIPTION
The types Post and Account share a name with the Post&Account entities and this can cause confusion. Being specific about makes them easier to work with.