### PR TITLE
Fixed the Post entity url type

### DIFF
--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -56,6 +56,7 @@ export function isFollowersOnlyPost(post: Post): post is FollowersOnlyPost {
 export class Post extends BaseEntity {
     public readonly uuid: string;
     public readonly apId: URL;
+    public readonly url: URL;
     private likesToRemove: Set<number> = new Set();
     private likesToAdd: Set<number> = new Set();
     private repostsToAdd: Set<number> = new Set();
@@ -70,7 +71,7 @@ export class Post extends BaseEntity {
         public readonly title: string | null,
         public readonly excerpt: string | null,
         public readonly content: string | null,
-        public readonly url: URL | null,
+        url: URL | null,
         public readonly imageUrl: URL | null,
         public readonly publishedAt: Date,
         private likeCount = 0,


### PR DESCRIPTION
Due to how we defined the `url` property in the constructor, instantiated Post entities had a nullable url property, but this is not possible. I've fixed the constructor here to make sure that the type is always URL.