### PR TITLE
Added url and apId to Account entity

### DIFF
--- a/src/account/account.entity.ts
+++ b/src/account/account.entity.ts
@@ -12,11 +12,14 @@ export interface AccountData {
     avatarUrl: URL | null;
     bannerImageUrl: URL | null;
     site: Site | null;
+    apId: URL | null;
+    url: URL | null;
 }
 
 export class Account extends BaseEntity {
     public readonly uuid: string;
-
+    public readonly url: URL;
+    public readonly apId: URL;
     constructor(
         public readonly id: number | null,
         uuid: string | null,
@@ -26,6 +29,8 @@ export class Account extends BaseEntity {
         public readonly avatarUrl: URL | null,
         public readonly bannerImageUrl: URL | null,
         private readonly site: Site | null,
+        apId: URL | null,
+        url: URL | null,
     ) {
         super(id);
         if (uuid === null) {
@@ -33,10 +38,31 @@ export class Account extends BaseEntity {
         } else {
             this.uuid = uuid;
         }
+        if (apId === null) {
+            this.apId = this.getApId();
+        } else {
+            this.apId = apId;
+        }
+        if (url === null) {
+            this.url = this.apId;
+        } else {
+            this.url = url;
+        }
     }
 
     get isInternal() {
         return this.site !== null;
+    }
+
+    getApId() {
+        if (!this.isInternal) {
+            throw new Error('Cannot get AP ID for External Accounts');
+        }
+
+        return new URL(
+            `.ghost/activitypub/users/${this.username}`,
+            `https://${this.site!.host}`,
+        );
     }
 
     getApIdForPost(post: Post) {
@@ -74,6 +100,8 @@ export class Account extends BaseEntity {
             data.avatarUrl,
             data.bannerImageUrl,
             data.site,
+            data.apId,
+            data.url,
         );
     }
 }

--- a/src/account/account.entity.unit.test.ts
+++ b/src/account/account.entity.unit.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { Account } from 'account/account.entity';
+
+describe('Account', () => {
+    it('Uses the apId if the url is missing', () => {
+        const account = new Account(
+            1243,
+            null,
+            'foobar',
+            'Foo Bar',
+            'Just a foobar',
+            new URL('https://foobar.com/avatar/foobar.png'),
+            new URL('https://foobar.com/banner/foobar.png'),
+            null,
+            new URL('https://foobar.com/user/1234'),
+            null,
+        );
+
+        expect(account.url).toEqual(account.apId);
+    });
+});

--- a/src/account/account.repository.knex.ts
+++ b/src/account/account.repository.knex.ts
@@ -49,6 +49,8 @@ export class KnexAccountRepository {
             parseURL(account.avatar_url),
             parseURL(account.banner_image_url),
             site,
+            parseURL(account.ap_id),
+            parseURL(account.url),
         );
     }
 
@@ -64,6 +66,8 @@ export class KnexAccountRepository {
                 'accounts.bio',
                 'accounts.avatar_url',
                 'accounts.banner_image_url',
+                'accounts.ap_id',
+                'accounts.url',
                 'users.site_id',
                 'sites.host',
                 'sites.webhook_secret',
@@ -99,6 +103,8 @@ export class KnexAccountRepository {
             parseURL(accountRow.avatar_url),
             parseURL(accountRow.banner_image_url),
             site,
+            parseURL(accountRow.ap_id),
+            parseURL(accountRow.url),
         );
 
         return account;

--- a/src/feed/feed-update.service.unit.test.ts
+++ b/src/feed/feed-update.service.unit.test.ts
@@ -50,6 +50,8 @@ describe('FeedUpdateService', () => {
             avatarUrl: new URL('https://example.com/avatars/foobar.png'),
             bannerImageUrl: new URL('https://example.com/banners/foobar.png'),
             site,
+            apId: new URL('https://example.com/users/456'),
+            url: new URL('https://example.com/users/456'),
         });
         post = Post.createFromData(account, {
             type: PostType.Article,

--- a/src/http/api/feed.unit.test.ts
+++ b/src/http/api/feed.unit.test.ts
@@ -31,6 +31,8 @@ describe('Feed API', () => {
             avatarUrl: new URL('https://example.com/avatars/foobar.png'),
             bannerImageUrl: new URL('https://example.com/banners/foobar.png'),
             site,
+            apId: new URL('https://example.com/users/456'),
+            url: new URL('https://example.com/users/456'),
         });
         accountService = {
             getDefaultAccountForSite: async (_site: Site) => {

--- a/src/post/post.entity.unit.test.ts
+++ b/src/post/post.entity.unit.test.ts
@@ -19,6 +19,8 @@ function mockAccount(id: number | null, internal: boolean) {
                   webhook_secret: 'secret',
               }
             : null,
+        new URL(`https://foobar.com/user/${id}`),
+        null,
     );
 }
 

--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -45,6 +45,8 @@ export class KnexPostRepository {
                 'accounts.bio',
                 'accounts.avatar_url',
                 'accounts.banner_image_url',
+                'accounts.ap_id as author_ap_id',
+                'accounts.url as author_url',
             )
             .first();
 
@@ -68,6 +70,8 @@ export class KnexPostRepository {
             parseURL(row.avatar_url),
             parseURL(row.banner_image_url),
             null,
+            parseURL(row.author_ap_id),
+            parseURL(row.author_url),
         );
 
         const post = new Post(


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-723
ref https://linear.app/ghost/issue/AP-722

In order to create an AccountDTO from an Account entity, we need a `url` property, and the `url` property depends on `apId` as a fallback. We've implemented this in the same way as the Post entity.