### PR TITLE
Added content cleaning to Post

### DIFF
--- a/src/http/api/webhook.ts
+++ b/src/http/api/webhook.ts
@@ -51,9 +51,14 @@ export function createPostPublishedWebhookHandler(
 
         const account = await accountRepository.getBySite(ctx.get('site'));
 
-        const post = Post.createArticleFromGhostPost(account, data);
-
-        await postRepository.save(post);
+        try {
+            const post = Post.createArticleFromGhostPost(account, data);
+            await postRepository.save(post);
+        } catch (err) {
+            ctx.get('logger').error('Failed to store post: {error}', {
+                error: err,
+            });
+        }
 
         try {
             await publishPost(ctx, {

--- a/src/post/post.entity.unit.test.ts
+++ b/src/post/post.entity.unit.test.ts
@@ -38,12 +38,50 @@ describe('Post', () => {
             feature_image: 'https://ghost.org/feature-image.jpeg',
             published_at: '2020-01-01',
             url: 'https://ghost.org/post',
+            visibility: 'public',
         };
 
         const post = Post.createArticleFromGhostPost(account, ghostPost);
 
         expect(post.uuid).toEqual(ghostPost.uuid);
         expect(post.content).toEqual(ghostPost.html);
+    });
+
+    it('should refuse to create an article from a private Ghost Post with no public content', () => {
+        const account = internalAccount();
+        const ghostPost = {
+            uuid: '550e8400-e29b-41d4-a716-446655440000',
+            title: 'Title of my post',
+            html: '<!--members-only--><p> This is such a great post </p>',
+            excerpt: 'This is such a great...',
+            feature_image: 'https://ghost.org/feature-image.jpeg',
+            published_at: '2020-01-01',
+            url: 'https://ghost.org/post',
+            visibility: 'members',
+        };
+
+        expect(() =>
+            Post.createArticleFromGhostPost(account, ghostPost),
+        ).toThrow();
+    });
+
+    it('should create an article with restricted content from a private Ghost Post', () => {
+        const account = internalAccount();
+        const ghostPost = {
+            uuid: '550e8400-e29b-41d4-a716-446655440000',
+            title: 'Title of my post',
+            html: '<p>Welcome!</p><!--members-only--><p> This is such a great post </p>',
+            excerpt: 'This is such a great...',
+            feature_image: 'https://ghost.org/feature-image.jpeg',
+            published_at: '2020-01-01',
+            url: 'https://ghost.org/post',
+            visibility: 'members',
+        };
+
+        const post = Post.createArticleFromGhostPost(account, ghostPost);
+
+        expect(post.uuid).toEqual(ghostPost.uuid);
+        expect(post.content).toEqual('<p>Welcome!</p>');
     });
 
     it('should handle adding and removing reposts', () => {

--- a/src/post/post.repository.knex.integration.test.ts
+++ b/src/post/post.repository.knex.integration.test.ts
@@ -76,6 +76,7 @@ describe('KnexPostRepository', () => {
             feature_image: null,
             url: 'https://testing.com/hello-world',
             published_at: '2025-01-01',
+            visibility: 'public',
         });
 
         await postRepository.save(post);
@@ -103,6 +104,7 @@ describe('KnexPostRepository', () => {
             feature_image: null,
             url: 'https://testing.com/hello-world',
             published_at: '2025-01-01',
+            visibility: 'public',
         });
 
         await postRepository.save(post);
@@ -126,6 +128,7 @@ describe('KnexPostRepository', () => {
             feature_image: null,
             url: 'https://testing.com/hello-world',
             published_at: '2025-01-01',
+            visibility: 'public',
         });
 
         await postRepository.save(post);
@@ -145,6 +148,7 @@ describe('KnexPostRepository', () => {
             feature_image: null,
             url: 'https://testing.com/hello-world',
             published_at: '2025-01-01',
+            visibility: 'public',
         });
 
         await postRepository.save(post);
@@ -180,6 +184,7 @@ describe('KnexPostRepository', () => {
             feature_image: null,
             url: 'https://testing.com/hello-world',
             published_at: '2025-01-01',
+            visibility: 'public',
         });
 
         await postRepository.save(post);
@@ -210,6 +215,7 @@ describe('KnexPostRepository', () => {
             feature_image: null,
             url: 'https://testing.com/hello-world',
             published_at: '2025-01-01',
+            visibility: 'public',
         });
 
         post.addLike(accounts[0]);
@@ -252,6 +258,7 @@ describe('KnexPostRepository', () => {
             feature_image: null,
             url: 'https://testing.com/hello-world',
             published_at: '2025-01-01',
+            visibility: 'public',
         });
 
         post.addLike(accounts[1]);
@@ -295,6 +302,7 @@ describe('KnexPostRepository', () => {
             feature_image: null,
             url: 'https://testing.com/hello-world',
             published_at: '2025-01-01',
+            visibility: 'public',
         });
 
         post.addRepost(accounts[1]);
@@ -353,6 +361,7 @@ describe('KnexPostRepository', () => {
             feature_image: null,
             url: 'https://testing.com/hello-world',
             published_at: '2025-01-01',
+            visibility: 'public',
         });
 
         post.addRepost(accounts[1]);
@@ -417,6 +426,7 @@ describe('KnexPostRepository', () => {
             feature_image: null,
             url: 'https://testing.com/original-post',
             published_at: '2025-01-01',
+            visibility: 'public',
         });
 
         await postRepository.save(originalPost);

--- a/src/publishing/content.ts
+++ b/src/publishing/content.ts
@@ -28,6 +28,20 @@ interface PrepareContentOptions {
 }
 
 export class ContentPreparer {
+    static instance = new ContentPreparer();
+
+    static prepare(
+        content: string,
+        options: PrepareContentOptions = {
+            removeMemberContent: false,
+            escapeHtml: false,
+            convertLineBreaks: false,
+            wrapInParagraph: false,
+        },
+    ) {
+        return ContentPreparer.instance.prepare(content, options);
+    }
+
     /**
      * Prepare the content
      *


### PR DESCRIPTION
We were storing posts without cleaning their html first, which meant we were
storing the wrong content, as that was not what is in the activity.

The cleaning of content is business logic and so belong in the entity. Whilst
the publishing is not hooked up to the entity we've had to duplicate this logic
for now, but eventually ti will be removed from the publishing service, which
will hook into our events to create an Article when the post is persisted.