### PR TITLE
Added dummy delete post API endpoint

### DIFF
--- a/features/delete-post.feature
+++ b/features/delete-post.feature
@@ -1,0 +1,5 @@
+Feature: Delete a post
+
+  Scenario: Correct response code is returned
+    When an authenticated "delete" request is made to "/.ghost/activitypub/post/123"
+    Then the request is accepted with a 204

--- a/src/app.ts
+++ b/src/app.ts
@@ -93,6 +93,7 @@ import { getTraceContext } from './helpers/context-header';
 import { getSiteSettings } from './helpers/ghost';
 import { getRequestData } from './helpers/request-data';
 import {
+    createDeletePostHandler,
     createGetAccountFollowsHandler,
     createGetAccountHandler,
     createGetFeedHandler,
@@ -938,6 +939,11 @@ app.get(
     '/.ghost/activitypub/inbox',
     requireRole(GhostRole.Owner),
     spanWrapper(createGetFeedHandler(feedService, accountService, 'Inbox')),
+);
+app.delete(
+    '/.ghost/activitypub/post/:uuid',
+    requireRole(GhostRole.Owner),
+    spanWrapper(createDeletePostHandler()),
 );
 /** Federation wire up */
 

--- a/src/http/api/index.ts
+++ b/src/http/api/index.ts
@@ -2,6 +2,7 @@ export * from './activities';
 export * from './account';
 export * from './feed';
 export * from './note';
+export * from './post';
 export * from './profile';
 export * from './search';
 export * from './thread';

--- a/src/http/api/post.ts
+++ b/src/http/api/post.ts
@@ -1,0 +1,13 @@
+/**
+ * Create a handler for a request to delete a post
+ */
+export function createDeletePostHandler() {
+    /**
+     * Handle a request to delete a post
+     */
+    return async function handleDeletePost() {
+        return new Response(null, {
+            status: 204,
+        });
+    };
+}


### PR DESCRIPTION
refs [AP-810](https://linear.app/ghost/issue/AP-810/unblock-frontend-work-with-a-mock-deleteid-http-api)

Added a dummy delete post API endpoint that returns a 204 response for the purpose of enabling the frontend to simulate a delete post action. This logic to be implemented in this endpoint will be fleshed out at a later time