### PR TITLE
Added `post.deleted` event

### DIFF
--- a/src/post/post-deleted.event.ts
+++ b/src/post/post-deleted.event.ts
@@ -1,0 +1,20 @@
+import type { Post } from './post.entity';
+
+export class PostDeletedEvent {
+    constructor(
+        private readonly post: Post,
+        private readonly accountId: number,
+    ) {}
+
+    getPost(): Post {
+        return this.post;
+    }
+
+    getAccountId(): number {
+        return this.accountId;
+    }
+
+    static getName(): string {
+        return 'post.deleted';
+    }
+}


### PR DESCRIPTION
refs [AP-811](https://linear.app/ghost/issue/AP-811/decouple-backend-work-with-a-shared-postdeletedevent)

Added `post.deleted` event that can be used to notify services that a post has been deleted