### PR TITLE
Added delete method to Post entity

### DIFF
--- a/src/account/account.entity.ts
+++ b/src/account/account.entity.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { BaseEntity } from '../core/base.entity';
-import { type Post, PostType } from '../post/post.entity';
+import { type CreatePostType, PostType } from '../post/post.entity';
 import type { Site } from '../site/site.service';
 
 export interface AccountData {
@@ -65,7 +65,7 @@ export class Account extends BaseEntity {
         );
     }
 
-    getApIdForPost(post: Post) {
+    getApIdForPost(post: { type: CreatePostType; uuid: string }) {
         if (!this.isInternal) {
             throw new Error('Cannot get AP ID for External Accounts');
         }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -367,15 +367,13 @@ export function createReplyActionHandler(
             });
         }
 
-        const replyData = {
+        const newReply = Post.createFromData(account, {
             content: data.content,
             type: PostType.Note,
             audience: Audience.Public,
             apId: replyId,
             inReplyTo: parentPost,
-        };
-
-        const newReply = Post.createFromData(account, replyData);
+        });
         await postRepository.save(newReply);
 
         apCtx.sendActivity(

--- a/src/http/api/note.ts
+++ b/src/http/api/note.ts
@@ -27,12 +27,11 @@ export async function handleCreateNote(
 
     // Save to posts table when a note is created
     const account = await accountRepository.getBySite(ctx.get('site'));
-    const postData = {
+    const post = Post.createFromData(account, {
         content: data.content,
         type: PostType.Note,
         audience: Audience.Public,
-    };
-    const post = Post.createFromData(account, postData);
+    });
     await postRepository.save(post);
 
     let result: PublishResult | null = null;

--- a/src/post/post.entity.unit.test.ts
+++ b/src/post/post.entity.unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { Account } from '../account/account.entity';
-import { Post, PostType } from './post.entity';
+import { Audience, Post, PostType } from './post.entity';
 
 function mockAccount(id: number | null, internal: boolean) {
     return new Account(
@@ -28,6 +28,119 @@ const externalAccount = (id: number | null = 456) => mockAccount(id, false);
 const internalAccount = (id: number | null = 123) => mockAccount(id, true);
 
 describe('Post', () => {
+    describe('delete', () => {
+        it('Should be possible to delete posts authored by the account', () => {
+            const author = internalAccount();
+            const ghostPost = {
+                uuid: '550e8400-e29b-41d4-a716-446655440000',
+                title: 'Title of my post',
+                html: '<p> This is such a great post </p>',
+                excerpt: 'This is such a great...',
+                feature_image: 'https://ghost.org/feature-image.jpeg',
+                published_at: '2020-01-01',
+                url: 'https://ghost.org/post',
+                visibility: 'public',
+            };
+
+            const post = Post.createArticleFromGhostPost(author, ghostPost);
+
+            post.delete(author);
+
+            expect(Post.isDeleted(post)).toBe(true);
+        });
+
+        it('Should not be possible to delete posts from other authors', () => {
+            const author = internalAccount();
+            const notAuthor = externalAccount();
+            const ghostPost = {
+                uuid: '550e8400-e29b-41d4-a716-446655440000',
+                title: 'Title of my post',
+                html: '<p> This is such a great post </p>',
+                excerpt: 'This is such a great...',
+                feature_image: 'https://ghost.org/feature-image.jpeg',
+                published_at: '2020-01-01',
+                url: 'https://ghost.org/post',
+                visibility: 'public',
+            };
+
+            const post = Post.createArticleFromGhostPost(author, ghostPost);
+
+            expect(() => {
+                post.delete(notAuthor);
+            }).toThrow();
+
+            expect(Post.isDeleted(post)).toBe(false);
+        });
+
+        it('Should set all content to null for deleted posts', () => {
+            const author = internalAccount();
+            const ghostPost = {
+                uuid: '550e8400-e29b-41d4-a716-446655440000',
+                title: 'Title of my post',
+                html: '<p> This is such a great post </p>',
+                excerpt: 'This is such a great...',
+                feature_image: 'https://ghost.org/feature-image.jpeg',
+                published_at: '2020-01-01',
+                url: 'https://ghost.org/post',
+                visibility: 'public',
+            };
+
+            const post = Post.createArticleFromGhostPost(author, ghostPost);
+
+            post.delete(author);
+
+            expect(Post.isDeleted(post)).toBe(true);
+            expect(post.type).toBe(PostType.Tombstone);
+            expect(post.title).toBeNull();
+            expect(post.content).toBeNull();
+            expect(post.excerpt).toBeNull();
+            expect(post.imageUrl).toBeNull();
+            expect(post.attachments).toEqual([]);
+        });
+
+        it('Should set all content to null for already deleted posts', () => {
+            const author = internalAccount();
+
+            const post = new Post(
+                1,
+                '550e8400-e29b-41d4-a716-446655440000',
+                author,
+                PostType.Note,
+                Audience.Public,
+                'Title of my post',
+                'This is such a great...',
+                '<p> This is such a great post </p>',
+                new URL('https://ghost.org/ap/note/123'),
+                new URL('https://ghost.org/feature-image.jpeg'),
+                new Date('2020-01-01'),
+                5,
+                10,
+                15,
+                null,
+                null,
+                null,
+                [
+                    {
+                        type: 'Image',
+                        mediaType: 'image/jpeg',
+                        name: 'Cat Pic',
+                        url: new URL('https://ghost.org/cat.jpg'),
+                    },
+                ],
+                new URL('https://ghost.org/ap/note/123'),
+                true,
+            );
+
+            expect(Post.isDeleted(post)).toBe(true);
+            expect(post.type).toBe(PostType.Tombstone);
+            expect(post.title).toBeNull();
+            expect(post.content).toBeNull();
+            expect(post.excerpt).toBeNull();
+            expect(post.imageUrl).toBeNull();
+            expect(post.attachments).toEqual([]);
+        });
+    });
+
     it('should correctly create an article from a Ghost Post', () => {
         const account = internalAccount();
         const ghostPost = {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-812

We've kept the `deleted` property private for now, and expose access via a static `isDeleted` method on the class. The idea here is that the soft deletition is an implementation detail which we're not sure we want to leak to consumers right now.

When a Post is deleted, we make sure that none of the content is available from the entity - this means we can be sure that we never serve deleted content to the client. Generally we shouldn't be dealing with instances of deleted entities - but there are a few cases we might:

1. When we've just called `delete` on it
2. When we're working with reply threads and a post in the chain is deleted, we may want to indicate that there _was_ a parent, case a Tombstone post with no content gives us the flexibility to do that.

The addition of the Tombstone type to PostType meant that we had a few issues when working with the PostType because we don't want to allow creating posts as a Tombstone, and when we call for example the `getApIdForPost` method we don't want to be dealing with Tombstones either so we've introduced a new CreatePostType which is everything in PostType *except* the Tombstone