### PR TITLE
Support persistence of deleted posts

### DIFF
--- a/src/post/post.repository.knex.integration.test.ts
+++ b/src/post/post.repository.knex.integration.test.ts
@@ -165,7 +165,7 @@ describe('KnexPostRepository', () => {
 
             const postDeletedEvent = await postDeletedEventPromise;
 
-            expect(postDeletedEvent.getPost().id).toBe(post.id);
+            expect(postDeletedEvent.getPost().id).toBe(reply.id);
 
             const postRowAfterDelete = await client(TABLE_POSTS)
                 .where({

--- a/src/post/post.repository.knex.integration.test.ts
+++ b/src/post/post.repository.knex.integration.test.ts
@@ -9,6 +9,7 @@ import { TABLE_LIKES, TABLE_POSTS, TABLE_REPOSTS } from '../constants';
 import { client } from '../db';
 import { SiteService } from '../site/site.service';
 import { PostCreatedEvent } from './post-created.event';
+import { PostDeletedEvent } from './post-deleted.event';
 import { PostDerepostedEvent } from './post-dereposted.event';
 import { PostRepostedEvent } from './post-reposted.event';
 import { Post, PostType } from './post.entity';
@@ -63,6 +64,79 @@ describe('KnexPostRepository', () => {
             },
         });
         postRepository = new KnexPostRepository(client, events);
+    });
+
+    describe('Delete', () => {
+        it('Can handle a deleted post', async () => {
+            const site = await siteService.initialiseSiteForHost('testing.com');
+            const account = await accountRepository.getBySite(site);
+            const post = Post.createArticleFromGhostPost(account, {
+                title: 'Title',
+                uuid: '3f1c5e84-9a2b-4d7f-8e62-1a6b9c9d4f10',
+                html: '<p>Hello, world!</p>',
+                excerpt: 'Hello, world!',
+                feature_image: null,
+                url: 'https://testing.com/hello-world',
+                published_at: '2025-01-01',
+                visibility: 'public',
+            });
+
+            await postRepository.save(post);
+
+            post.delete(account);
+
+            const postDeletedEventPromise: Promise<PostDeletedEvent> =
+                new Promise((resolve) => {
+                    events.once(PostDeletedEvent.getName(), resolve);
+                });
+
+            await postRepository.save(post);
+
+            const rowInDb = await client(TABLE_POSTS)
+                .where({
+                    uuid: post.uuid,
+                })
+                .select('*')
+                .first();
+
+            assert(rowInDb, 'A row should have been saved in the DB');
+            expect(rowInDb.deleted_at).not.toBe(null);
+            expect(rowInDb.title).toBe('Title');
+            expect(rowInDb.content).toBe('<p>Hello, world!</p>');
+            expect(rowInDb.excerpt).toBe('Hello, world!');
+
+            const postDeletedEvent = await postDeletedEventPromise;
+
+            expect(postDeletedEvent.getPost().id).toBe(post.id);
+        });
+
+        it('Can handle a new deleted post', async () => {
+            const site = await siteService.initialiseSiteForHost('testing.com');
+            const account = await accountRepository.getBySite(site);
+            const post = Post.createArticleFromGhostPost(account, {
+                title: 'Title',
+                uuid: '3f1c5e84-9a2b-4d7f-8e62-1a6b9c9d4f10',
+                html: '<p>Hello, world!</p>',
+                excerpt: 'Hello, world!',
+                feature_image: null,
+                url: 'https://testing.com/hello-world',
+                published_at: '2025-01-01',
+                visibility: 'public',
+            });
+
+            post.delete(account);
+
+            await postRepository.save(post);
+
+            const rowInDb = await client(TABLE_POSTS)
+                .where({
+                    uuid: post.uuid,
+                })
+                .select('*')
+                .first();
+
+            expect(rowInDb).toBe(undefined);
+        });
     });
 
     it('Can save a Post', async () => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-812

We need to mark deleted posts as deleted in the DB, as well as emit a PostDeletedEvent so that other systems can react to it, for example removing the post from the feed after a deletion.

Newly created posts that are immediately deleted are not a use-case we have and it's not clear on how that should work, this implementation simply does not persist them for now, but we can change that in future if we need to support this.

When a post is deleted, the only column we write to is the deleted_at column, this ensures that the content is still available for audit, debug, undoing etc...

We also have to add a new check that the Post author Account has an id property, I would like to move this constraint to the entity layer, but that is outside the scope of this PR. Right now this check still happens, but it is implicit at the DB level with a foreign key constraint on the column - this just makes it explicit so that 1) we are all aware of it and 2) TypeScript doesn't complain about referencing author.id when instantiating the PostDeletedEvent.