### PR TITLE
Handle reading deleted posts

### DIFF
--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -1781,3 +1781,18 @@ Then('the thread contains {string} posts', async function (string) {
         `Expected thread to contain ${string} posts, but got ${responseJson.posts.length}`,
     );
 });
+
+Then(
+    'post {string} has {string} set to {string}',
+    async function (postNumber, key, value) {
+        const responseJson = await this.response.clone().json();
+        const post = responseJson.posts[Number(postNumber) - 1];
+
+        assert(post, `Expected to find post ${postNumber} in thread`);
+
+        assert(
+            String(post[key]) === String(value),
+            `Expected post ${postNumber} to have ${key} ${value}`,
+        );
+    },
+);

--- a/features/thread.feature
+++ b/features/thread.feature
@@ -63,3 +63,33 @@ Feature: Thread
     And post "1" in the thread is "Article"
     And post "2" in the thread is "Reply1"
     And post "3" in the thread is "Reply3"
+
+  Scenario: Retrieving the thread for a top level post that has replies that have been deleted
+    Given we reply "Reply1" to "Article" with the content
+        """
+        This is a great article!
+        """
+    And "Reply1" is in our Outbox
+    And we reply "Reply2" to "Article" with the content
+        """
+        This is still a great article!
+        """
+    And "Reply2" is in our Outbox
+    And we reply "Reply3" to "Article" with the content
+        """
+        This is probably the best article I have ever read!
+        """
+    And "Reply3" is in our Outbox
+    And we reply "Reply4" to "Article" with the content
+        """
+        Maybe its just an ok article after all!
+        """
+    And "Reply4" is in our Outbox
+    And an authenticated "delete" request is made to "/.ghost/activitypub/post/Reply2"
+    And an authenticated "delete" request is made to "/.ghost/activitypub/post/Reply4"
+    When an authenticated request is made to "/.ghost/activitypub/thread/Article"
+    Then the request is accepted
+    And the thread contains "3" posts
+    And post "1" in the thread is "Article"
+    And post "2" in the thread is "Reply1"
+    And post "3" in the thread is "Reply3"

--- a/features/thread.feature
+++ b/features/thread.feature
@@ -86,10 +86,40 @@ Feature: Thread
         """
     And "Reply4" is in our Outbox
     And an authenticated "delete" request is made to "/.ghost/activitypub/post/Reply2"
+    And the request is accepted
     And an authenticated "delete" request is made to "/.ghost/activitypub/post/Reply4"
+    And the request is accepted
     When an authenticated request is made to "/.ghost/activitypub/thread/Article"
     Then the request is accepted
     And the thread contains "3" posts
     And post "1" in the thread is "Article"
     And post "2" in the thread is "Reply1"
     And post "3" in the thread is "Reply3"
+
+  Scenario: Retrieving the thread for a reply to a post that has been deleted
+     Given we reply "Reply1" to "Article" with the content
+        """
+        This is a great article!
+        """
+    And "Reply1" is in our Outbox
+    And we reply "Reply2" to "Article" with the content
+        """
+        This is still a great article!
+        """
+    And "Reply2" is in our Outbox
+    And we reply "Reply3" to "Reply1" with the content
+        """
+        This is a great reply!
+        """
+    And "Reply3" is in our Outbox
+    And an authenticated "delete" request is made to "/.ghost/activitypub/post/Reply1"
+    And the request is accepted
+    When an authenticated request is made to "/.ghost/activitypub/thread/Reply3"
+    Then the request is accepted
+    And the thread contains "3" posts
+    And post "1" in the thread is "Article"
+    And post "2" in the thread is "Reply1"
+    And post "3" in the thread is "Reply3"
+    And post "2" has "type" set to "2"
+    And post "2" has "title" set to ""
+    And post "2" has "content" set to ""

--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -204,9 +204,11 @@ export class KnexPostRepository {
         postIdsForThread.push(post.id);
 
         // Find all the posts that are immediate children of the resolved post
+        // and have not been deleted
         for (const row of await this.db('posts')
             .select('id')
-            .where('in_reply_to', post.id)) {
+            .where('in_reply_to', post.id)
+            .andWhere('deleted_at', null)) {
             postIdsForThread.push(row.id);
         }
 
@@ -233,6 +235,7 @@ export class KnexPostRepository {
                 'posts.ap_id',
                 'posts.in_reply_to',
                 'posts.thread_root',
+                'posts.deleted_at',
                 // Author account fields
                 'accounts.username',
                 'accounts.uuid as author_uuid',

--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -111,11 +111,8 @@ export class KnexPostRepository {
             row.reading_time_minutes,
             attachments,
             new URL(row.ap_id),
+            row.deleted_at !== null,
         );
-
-        if (row.deleted_at !== null) {
-            post.delete(author);
-        }
 
         return post;
     }
@@ -332,11 +329,8 @@ export class KnexPostRepository {
                 row.reading_time_minutes,
                 attachments,
                 new URL(row.ap_id),
+                row.deleted_at !== null,
             );
-
-            if (row.deleted_at !== null) {
-                post.delete(author);
-            }
 
             posts.push({
                 post,

--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -47,6 +47,7 @@ export class KnexPostRepository {
                 'posts.ap_id',
                 'posts.in_reply_to',
                 'posts.thread_root',
+                'posts.deleted_at',
                 'accounts.username',
                 'accounts.uuid as author_uuid',
                 'accounts.name',
@@ -111,6 +112,10 @@ export class KnexPostRepository {
             attachments,
             new URL(row.ap_id),
         );
+
+        if (row.deleted_at !== null) {
+            post.delete(author);
+        }
 
         return post;
     }
@@ -328,6 +333,10 @@ export class KnexPostRepository {
                 attachments,
                 new URL(row.ap_id),
             );
+
+            if (row.deleted_at !== null) {
+                post.delete(author);
+            }
 
             posts.push({
                 post,


### PR DESCRIPTION
refs [AP-801](https://linear.app/ghost/issue/AP-801/handle-reading-deleted-posts)

Added handling for reading deleted posts:

- When a deleted post is retrieved from the db, we set its type to `Tombstone`
- When we serialise a post with type `Tombstone` we remove the posts content so we are not leaking deleted post data
- When returning a thread we don't return deleted children