### PR TITLE
Updated Account entity to use AccountSite instead of Site

### DIFF
--- a/src/account/account.entity.ts
+++ b/src/account/account.entity.ts
@@ -16,6 +16,11 @@ export interface AccountData {
     url: URL | null;
 }
 
+export type AccountSite = {
+    id: number;
+    host: string;
+};
+
 export class Account extends BaseEntity {
     public readonly uuid: string;
     public readonly url: URL;
@@ -28,7 +33,7 @@ export class Account extends BaseEntity {
         public readonly bio: string | null,
         public readonly avatarUrl: URL | null,
         public readonly bannerImageUrl: URL | null,
-        private readonly site: Site | null,
+        private readonly site: AccountSite | null,
         apId: URL | null,
         url: URL | null,
     ) {

--- a/src/account/account.repository.knex.ts
+++ b/src/account/account.repository.knex.ts
@@ -3,7 +3,7 @@ import type EventEmitter from 'node:events';
 import type { Knex } from 'knex';
 import { parseURL } from '../core/url';
 import type { Site } from '../site/site.service';
-import { Account } from './account.entity';
+import { Account, type AccountSite } from './account.entity';
 
 export class KnexAccountRepository {
     constructor(
@@ -48,7 +48,10 @@ export class KnexAccountRepository {
             account.bio,
             parseURL(account.avatar_url),
             parseURL(account.banner_image_url),
-            site,
+            {
+                id: site.id,
+                host: site.host,
+            },
             parseURL(account.ap_id),
             parseURL(account.url),
         );
@@ -70,7 +73,6 @@ export class KnexAccountRepository {
                 'accounts.url',
                 'users.site_id',
                 'sites.host',
-                'sites.webhook_secret',
             )
             .first();
 
@@ -78,12 +80,14 @@ export class KnexAccountRepository {
             return null;
         }
 
-        let site: Site | null = null;
-        if (accountRow.site_id) {
+        let site: AccountSite | null = null;
+        if (
+            typeof accountRow.site_id === 'number' &&
+            typeof accountRow.host === 'string'
+        ) {
             site = {
                 id: accountRow.site_id,
                 host: accountRow.host,
-                webhook_secret: accountRow.webhook_secret,
             };
         }
 

--- a/src/http/api/helpers/post.unit.test.ts
+++ b/src/http/api/helpers/post.unit.test.ts
@@ -17,7 +17,6 @@ describe('postToPostDTO', () => {
             {
                 id: 123,
                 host: 'foobar.com',
-                webhook_secret: 'secret',
             },
             new URL('https://foobar.com/user/123'),
             null,
@@ -46,7 +45,6 @@ describe('postToPostDTO', () => {
             {
                 id: 123,
                 host: 'foobar.com',
-                webhook_secret: 'secret',
             },
             new URL('https://foobar.com/user/123'),
             null,

--- a/src/post/post.entity.unit.test.ts
+++ b/src/post/post.entity.unit.test.ts
@@ -16,7 +16,6 @@ function mockAccount(id: number | null, internal: boolean) {
             ? {
                   id: 123,
                   host: 'foobar.com',
-                  webhook_secret: 'secret',
               }
             : null,
         new URL(`https://foobar.com/user/${id}`),


### PR DESCRIPTION
The Site object has the webhook_secret on it which is not necessary for accounts to have access to and poses a security concern if we're passing it about.