### PR TITLE
Simplified setting up follow relations in cucumber tests

### DIFF
--- a/features/create-note.feature
+++ b/features/create-note.feature
@@ -37,17 +37,12 @@ Feature: Creating a note
     And "Note" has the content "<p>&lt;p&gt;Hello, world!&lt;&#x2F;p&gt;<br />&lt;script&gt;alert(&quot;Hello, world!&quot;);&lt;&#x2F;script&gt;</p>"
 
   Scenario: Created note is sent to followers
-    Given an Actor "Person(Alice)"
-    And an Actor "Person(Bob)"
-    And a "Follow(Us)" Activity "F1" by "Alice"
-    And a "Follow(Us)" Activity "F2" by "Bob"
-    And "Alice" sends "F1" to the Inbox
-    And "F1" is in our Inbox
-    And "Bob" sends "F2" to the Inbox
-    And "F2" is in our Inbox
+    Given we are followed by:
+      | name    | type   |
+      | Alice   | Person |
+      | Bob     | Person |
     When we create a note "Note" with the content
       """
       Hello, world!
       """
-    Then Activity "Note" is sent to "Alice"
-    And Activity "Note" is sent to "Bob"
+    Then Activity "Note" is sent to all followers

--- a/features/create-reply.feature
+++ b/features/create-reply.feature
@@ -1,18 +1,8 @@
 Feature: Creating a reply
   Background:
-    Given an Actor "Person(Alice)"
-    And a "Follow(Us)" Activity "F1" by "Alice"
-    And "Alice" sends "F1" to the Inbox
-    And "F1" is in our Inbox
-    And an Actor "Person(Bob)"
-    And a "Follow(Us)" Activity "F2" by "Bob"
-    And "Bob" sends "F2" to the Inbox
-    And "F2" is in our Inbox
-    And we follow "Alice"
-    And the request is accepted
-    And a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
-    And "Alice" sends "Accept" to the Inbox
-    And "Accept" is in our Inbox
+    Given we are following "Alice"
+    And we are followed by "Alice"
+    And we are followed by "Bob"
     And a "Note" Object "Article" by "Alice"
     And a "Create(Article)" Activity "Create" by "Alice"
     And "Alice" sends "Create" to the Inbox

--- a/features/delete-post.feature
+++ b/features/delete-post.feature
@@ -1,15 +1,8 @@
 Feature: Delete a post
 
   Background:
-    Given an Actor "Person(Alice)"
-    And we follow "Alice"
-    And the request is accepted
-    And a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
-    And "Alice" sends "Accept" to the Inbox
-    And "Accept" is in our Inbox
-    And a "Follow(Us)" Activity "Follow" by "Alice"
-    And "Alice" sends "Follow" to the Inbox
-    And "Follow" is in our Inbox
+    Given we are following "Alice"
+    And we are followed by "Alice"
     And a "Create(Note)" Activity "AliceNote" by "Alice"
     And "Alice" sends "AliceNote" to the Inbox
     And "AliceNote" is in our Inbox

--- a/features/feed.feature
+++ b/features/feed.feature
@@ -4,12 +4,7 @@ Feature: Feed
   I want to query my feed
 
   Background:
-    Given an Actor "Person(Alice)"
-    And we follow "Alice"
-    And the request is accepted
-    And a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
-    And "Alice" sends "Accept" to the Inbox
-    And "Accept" is in our Inbox
+    Given we are following "Alice"
 
   Scenario: Querying the feed
     Given a "Create(Note)" Activity "Note1" by "Alice"

--- a/features/follow-account.feature
+++ b/features/follow-account.feature
@@ -1,13 +1,8 @@
 Feature: Follow accounts from their handle
 
   Scenario: We can follow an account only once
-    Given an Actor "Person(Alice)"
-    Given we follow "Alice"
-    Then the request is accepted
-    Given a "Accept(Follow(Alice))" Activity "A" by "Alice"
-    And "Alice" sends "A" to the Inbox
-    And "A" is in our Inbox
-    Given we follow "Alice"
+    Given we are following "Alice"
+    When we follow "Alice"
     Then the request is rejected with a 409
 
   Scenario: We cannot follow ourselves
@@ -15,12 +10,7 @@ Feature: Follow accounts from their handle
     Then the request is rejected with a 400
 
   Scenario: We can unfollow an account
-    Given an Actor "Person(Alice)"
-    And we follow "Alice"
-    And the request is accepted
-    And a "Accept(Follow(Alice))" Activity "A" by "Alice"
-    And "Alice" sends "A" to the Inbox
-    And "A" is in our Inbox
+    Given we are following "Alice"
     And the object "Alice" should be in the "following" collection
     When we unfollow "Alice"
     Then the request is accepted

--- a/features/handle-announce.feature
+++ b/features/handle-announce.feature
@@ -2,12 +2,7 @@ Feature: Announce(Note)
   We want to handle Announce(Note) activities in the Inbox
 
   Scenario: We recieve a Announce(Note) activity from someone we follow
-    Given an Actor "Person(Alice)"
-    Given we follow "Alice"
-    Then the request is accepted
-    Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
-    And "Alice" sends "Accept" to the Inbox
-    And "Accept" is in our Inbox
+    Given we are following "Alice"
     Given a "Announce(Note)" Activity "A" by "Alice"
     When "Alice" sends "A" to the Inbox
     Then the request is accepted

--- a/features/handle-create-article.feature
+++ b/features/handle-create-article.feature
@@ -2,20 +2,15 @@ Feature: Create(Article)
   We want to handle Create(Article) activities in the Inbox
 
   Scenario: We recieve a Create(Article) activity from someone we follow
-    Given an Actor "Person(Alice)"
-    Given we follow "Alice"
-    Then the request is accepted
-    Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
-    And "Alice" sends "Accept" to the Inbox
-    And "Accept" is in our Inbox
-    Given a "Create(Article)" Activity "A" by "Alice"
+    Given we are following "Alice"
+    And a "Create(Article)" Activity "A" by "Alice"
     When "Alice" sends "A" to the Inbox
     Then the request is accepted
     Then "A" is in our Inbox
 
   Scenario: We recieve a Create(Article) activity from someone we don't follow
     Given an Actor "Person(Alice)"
-    Given a "Create(Article)" Activity "A" by "Alice"
+    And a "Create(Article)" Activity "A" by "Alice"
     When "Alice" sends "A" to the Inbox
     Then the request is accepted
     Then "A" is not in our Inbox

--- a/features/handle-group-announce.feature
+++ b/features/handle-group-announce.feature
@@ -1,12 +1,7 @@
 Feature: Handling activities announced by a Group
   Background:
     Given an Actor "Person(Alice)"
-    And an Actor "Group(Wonderland)"
-    And we follow "Wonderland"
-    And the request is accepted
-    And a "Accept(Follow(Wonderland))" Activity "Accept" by "Wonderland"
-    And "Wonderland" sends "Accept" to the Inbox
-    And "Accept" is in our Inbox
+    And we are following "Group(Wonderland)"
 
   Scenario: We recieve a Create(Article) activity announced by a Group
     Given a "Create(Article)" Activity "Create" by "Alice"

--- a/features/like-activity.feature
+++ b/features/like-activity.feature
@@ -4,12 +4,7 @@ Feature: Liking an object
   So that I can express my approval of the content
 
   Scenario: Liking an object that has not been liked before
-    Given an Actor "Person(Alice)"
-    Given we follow "Alice"
-    Then the request is accepted
-    Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
-    And "Alice" sends "Accept" to the Inbox
-    And "Accept" is in our Inbox
+    Given we are following "Alice"
     Given a "Create(Note)" Activity "Note" by "Alice"
     When "Alice" sends "Note" to the Inbox
     And "Note" is in our Inbox
@@ -20,12 +15,7 @@ Feature: Liking an object
     And a "Like(Note)" activity is sent to "Alice"
 
   Scenario: Liking an object that has been liked before
-    Given an Actor "Person(Alice)"
-    Given we follow "Alice"
-    Then the request is accepted
-    Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
-    And "Alice" sends "Accept" to the Inbox
-    And "Accept" is in our Inbox
+    Given we are following "Alice"
     Given a "Create(Note)" Activity "Note" by "Alice"
     When "Alice" sends "Note" to the Inbox
     And "Note" is in our Inbox
@@ -35,12 +25,7 @@ Feature: Liking an object
     Then the request is rejected with a 409
 
   Scenario: Unliking an object that has not been liked before
-    Given an Actor "Person(Alice)"
-    Given we follow "Alice"
-    Then the request is accepted
-    Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
-    And "Alice" sends "Accept" to the Inbox
-    And "Accept" is in our Inbox
+    Given we are following "Alice"
     Given a "Create(Note)" Activity "Note" by "Alice"
     When "Alice" sends "Note" to the Inbox
     And "Note" is in our Inbox
@@ -48,12 +33,7 @@ Feature: Liking an object
     Then the request is rejected with a 409
 
   Scenario: Unliking an object that has been liked before
-    Given an Actor "Person(Alice)"
-    Given we follow "Alice"
-    Then the request is accepted
-    Given a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
-    And "Alice" sends "Accept" to the Inbox
-    And "Accept" is in our Inbox
+    Given we are following "Alice"
     Given a "Create(Note)" Activity "Note" by "Alice"
     When "Alice" sends "Note" to the Inbox
     And "Note" is in our Inbox

--- a/features/repost-activity.feature
+++ b/features/repost-activity.feature
@@ -4,12 +4,7 @@ Feature: Reposting a post/note
   I want to be able to repost a post in my feed
 
   Scenario: Reposting a post/note
-    Given an Actor "Person(Alice)"
-    And we follow "Alice"
-    And the request is accepted
-    And a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
-    And "Alice" sends "Accept" to the Inbox
-    And "Accept" is in our Inbox
+    Given we are following "Alice"
     And a "Create(Note)" Activity "Note" by "Alice"
     And "Alice" sends "Note" to the Inbox
     And "Note" is in our Inbox
@@ -22,12 +17,7 @@ Feature: Reposting a post/note
     And the found "Announce(Note)" has property "object.attributedTo" of type "object"
 
   Scenario: Trying to repost a post/note that has already been reposted
-    Given an Actor "Person(Alice)"
-    And we follow "Alice"
-    And the request is accepted
-    And a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
-    And "Alice" sends "Accept" to the Inbox
-    And "Accept" is in our Inbox
+    Given we are following "Alice"
     And a "Create(Note)" Activity "Note" by "Alice"
     And "Alice" sends "Note" to the Inbox
     And "Note" is in our Inbox
@@ -37,12 +27,7 @@ Feature: Reposting a post/note
     Then the request is rejected with a 409
 
   Scenario: Undoing a repost
-    Given an Actor "Person(Alice)"
-    And we follow "Alice"
-    And the request is accepted
-    And a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
-    And "Alice" sends "Accept" to the Inbox
-    And "Accept" is in our Inbox
+    Given we are following "Alice"
     And a "Create(Note)" Activity "Note" by "Alice"
     And "Alice" sends "Note" to the Inbox
     And "Note" is in our Inbox
@@ -54,12 +39,7 @@ Feature: Reposting a post/note
     And a "Undo(Announce)" activity is sent to "Alice"
 
   Scenario: Trying to undo a repost on a post/note that has not been reposted
-    Given an Actor "Person(Alice)"
-    And we follow "Alice"
-    And the request is accepted
-    And a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
-    And "Alice" sends "Accept" to the Inbox
-    And "Accept" is in our Inbox
+    Given we are following "Alice"
     And a "Create(Note)" Activity "Note" by "Alice"
     And "Alice" sends "Note" to the Inbox
     And "Note" is in our Inbox

--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -669,6 +669,64 @@ Given('an Actor {string}', async function (actorDef) {
     this.actors[name] = await createActor(name, { type });
 });
 
+async function getActor(input) {
+    const existingActor = this.actors[input];
+
+    let type = 'Person';
+    let name = input;
+
+    if (!existingActor) {
+        const parsed = parseActorString(input);
+        if (parsed.type && parsed.name) {
+            type = parsed.type;
+            name = parsed.name;
+        }
+        this.actors[name] = await createActor(name, { type });
+    }
+
+    return {
+        type,
+        name,
+        actor: this.actors[name],
+    };
+}
+
+Given('we are following {string}', async function (input) {
+    const { actor } = await getActor.call(this, input);
+
+    const followResponse = await fetchActivityPub(
+        `http://fake-ghost-activitypub/.ghost/activitypub/actions/follow/${actor.handle}`,
+        {
+            method: 'POST',
+        },
+    );
+
+    if (!followResponse.ok) {
+        throw new Error('Something went wrong');
+    }
+
+    const follow = await createActivity('Follow', actor, this.actors.Us);
+
+    const accept = await createActivity('Accept', follow, actor);
+
+    const acceptResponse = await fetchActivityPub(
+        'http://fake-ghost-activitypub/.ghost/activitypub/inbox/index',
+        {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/ld+json',
+            },
+            body: JSON.stringify(accept),
+        },
+    );
+
+    if (!acceptResponse.ok) {
+        throw new Error('Something went wrong');
+    }
+
+    await waitForInboxActivity(accept);
+});
+
 Given('we follow {string}', async function (name) {
     const handle = this.actors[name].handle;
     this.response = await fetchActivityPub(
@@ -701,30 +759,37 @@ Given('we unfollow {string}', async function (name) {
     }
 });
 
+async function weAreFollowedBy(actor) {
+    const object = this.actors.Us;
+    const activity = await createActivity('Follow', object, actor);
+
+    // Send the follow activity to the inbox
+    const response = await fetchActivityPub(
+        'http://fake-ghost-activitypub/.ghost/activitypub/inbox/index',
+        {
+            method: 'POST',
+            body: JSON.stringify(activity),
+        },
+    );
+
+    if (!response.ok) {
+        throw new Error('Something went wrong');
+    }
+
+    await waitForInboxActivity(activity);
+}
+
+Given('we are followed by {string}', async function (input) {
+    const { actor } = await getActor.call(this, input);
+    await weAreFollowedBy.call(this, actor);
+});
+
 Given('we are followed by:', async function (actors) {
     for (const { name, type } of actors.hashes()) {
         // Create the actor
         this.actors[name] = await createActor(name, { type });
 
-        // Create the follow activity
-        const actor = this.actors[name];
-        const object = this.actors.Us;
-        const activity = await createActivity('Follow', object, actor);
-
-        const key = `Follow(Us)_${name}`;
-        this.activities[key] = activity;
-        this.objects[key] = object;
-
-        // Send the follow activity to the inbox
-        this.response = await fetchActivityPub(
-            'http://fake-ghost-activitypub/.ghost/activitypub/inbox/index',
-            {
-                method: 'POST',
-                body: JSON.stringify(activity),
-            },
-        );
-
-        await waitForInboxActivity(activity);
+        await weAreFollowedBy.call(this, this.actors[name]);
     }
 });
 

--- a/features/thread.feature
+++ b/features/thread.feature
@@ -4,15 +4,8 @@ Feature: Thread
   I want to request the thread for a post
 
   Background:
-    Given an Actor "Person(Alice)"
-    And a "Follow(Us)" Activity "Follow" by "Alice"
-    And "Alice" sends "Follow" to the Inbox
-    And "Follow" is in our Inbox
-    And we follow "Alice"
-    And the request is accepted
-    And a "Accept(Follow(Alice))" Activity "Accept" by "Alice"
-    And "Alice" sends "Accept" to the Inbox
-    And "Accept" is in our Inbox
+    Given we are following "Alice"
+    And we are followed by "Alice"
     And a "Note" Object "Article" by "Alice"
     And a "Create(Article)" Activity "Create" by "Alice"
     And "Alice" sends "Create" to the Inbox


### PR DESCRIPTION
Rather than manually doing the whole follow dance between us/actors we can make the tests more readable by combining these into one step.