### PR TITLE
Misc notification perf improvements

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -663,6 +663,11 @@ export async function inboxHandler(
                     liked,
                     reposted,
                     outbox,
+                    {
+                        expandInReplyTo: false,
+                        showReplyCount: true,
+                        showRepostCount: true,
+                    },
                 );
             } catch (err) {
                 ctx.get('logger').error('Inbox handler failed: {error}', {

--- a/src/helpers/activitypub/activity.ts
+++ b/src/helpers/activitypub/activity.ts
@@ -33,7 +33,15 @@ export async function buildActivity(
     liked: string[] = [],
     reposted: string[] = [],
     authored: string[] = [],
-    expandInReplyTo = false,
+    options: {
+        expandInReplyTo?: boolean;
+        showReplyCount?: boolean;
+        showRepostCount?: boolean;
+    } = {
+        expandInReplyTo: false,
+        showReplyCount: false,
+        showRepostCount: false,
+    },
 ): Promise<Activity | null> {
     const item = await db.get<Activity>([uri]);
 
@@ -127,7 +135,7 @@ export async function buildActivity(
 
     // Expand the inReplyTo object if it is a string and we are expanding inReplyTo
     if (
-        expandInReplyTo &&
+        options.expandInReplyTo &&
         typeof item.object !== 'string' &&
         item.object.inReplyTo
     ) {
@@ -139,9 +147,14 @@ export async function buildActivity(
     }
 
     // Add reply count and repost count to the object, if it is an object
+    // and they have been requested
     if (typeof item.object !== 'string') {
-        item.object.replyCount = await getActivityChildrenCount(item);
-        item.object.repostCount = await getRepostCount(item);
+        if (options.showReplyCount) {
+            item.object.replyCount = await getActivityChildrenCount(item);
+        }
+        if (options.showRepostCount) {
+            item.object.repostCount = await getRepostCount(item);
+        }
     }
 
     // Return the built item

--- a/src/helpers/activitypub/activity.ts
+++ b/src/helpers/activitypub/activity.ts
@@ -99,8 +99,6 @@ export async function buildActivity(
         item.object.content = sanitizeHtml(item.object.content);
     }
 
-    // If the associated object is a Like, we should check if it's in the provided
-    // liked list and add a liked property to the item if it is
     let objectId = '';
 
     if (typeof item.object === 'string') {
@@ -109,7 +107,7 @@ export async function buildActivity(
         objectId = item.object.id;
     }
 
-    if (objectId) {
+    if (objectId && liked.length > 0) {
         const likeId = apCtx.getObjectUri(Like, {
             id: createHash('sha256').update(objectId).digest('hex'),
         });
@@ -118,6 +116,9 @@ export async function buildActivity(
                 item.object.liked = true;
             }
         }
+    }
+
+    if (objectId && reposted.length > 0) {
         const repostId = apCtx.getObjectUri(Announce, {
             id: createHash('sha256').update(objectId).digest('hex'),
         });
@@ -126,10 +127,11 @@ export async function buildActivity(
                 item.object.reposted = true;
             }
         }
-        if (authored.includes(item.id)) {
-            if (typeof item.object !== 'string') {
-                item.object.authored = true;
-            }
+    }
+
+    if (authored.includes(item.id)) {
+        if (typeof item.object !== 'string') {
+            item.object.authored = true;
         }
     }
 

--- a/src/http/api/activities.ts
+++ b/src/http/api/activities.ts
@@ -71,18 +71,6 @@ export async function handleGetActivities(ctx: AppContext) {
     // Fetch required data from the database
     // -------------------------------------------------------------------------
 
-    // Fetch the liked object refs from the database:
-    //   - Data is structured as an array of strings
-    //   - Each string is a URI to an object in the database
-    // This is used to add a "liked" property to the item if the user has liked it
-    const likedRefs = (await db.get<string[]>(['liked'])) || [];
-
-    // Fetch the reposted object refs from the database:
-    //   - Data is structured as an array of strings
-    //   - Each string is a URI to an object in the database
-    // This is used to add a "reposted" property to the item if the user has reposted it
-    const repostedRefs = (await db.get<string[]>(['reposted'])) || [];
-
     // Fetch the refs of the activities in the inbox from the database:
     //   - Data is structured as an array of strings
     //   - Each string is a URI to an object in the database
@@ -183,8 +171,8 @@ export async function handleGetActivities(ctx: AppContext) {
                     ref,
                     globaldb,
                     apCtx,
-                    likedRefs,
-                    repostedRefs,
+                    [],
+                    [],
                     outboxRefs,
                     {
                         expandInReplyTo: true,

--- a/src/http/api/activities.ts
+++ b/src/http/api/activities.ts
@@ -42,7 +42,7 @@ export async function handleGetActivities(ctx: AppContext) {
 
     // Parse "filter" from query parameters
     // This is used to filter the activities by various criteria
-    // ?filter={type: ['<activityType>', '<activityType>:<objectType>', '<activityType>:<objectType>:<criteria>']}
+    // ?filter={type: ['<activityType>', '<activityType>:<objectType>']}
     const queryFilters = ctx.req.query('filter') || '[]';
     const filters = JSON.parse(decodeURIComponent(queryFilters));
 
@@ -57,11 +57,6 @@ export async function handleGetActivities(ctx: AppContext) {
         };
     });
 
-    // Parse "excludeNonFollowers" from query parameters
-    // This is used to exclude activities from non-followers
-    // ?excludeNonFollowers=<boolean>
-    const excludeNonFollowers = ctx.req.query('excludeNonFollowers') === 'true';
-
     logger.info('Request query = {query}', { query: ctx.req.query() });
     logger.info('Processed query params = {params}', {
         params: JSON.stringify({
@@ -69,7 +64,6 @@ export async function handleGetActivities(ctx: AppContext) {
             limit,
             includeOwn,
             typeFilters,
-            excludeNonFollowers,
         }),
     });
 
@@ -147,47 +141,10 @@ export async function handleGetActivities(ctx: AppContext) {
                         return false;
                     }
 
-                    // ?filter={type: ['<activityType>:<objectType>:isReplyToOwn']}
-                    if (filter.criteria?.startsWith('isReplyToOwn')) {
-                        // If the activity does not have a reply object url or name,
-                        // we can't determine if it's a reply to an own object so
-                        // we skip it
-                        if (!meta.reply_object_url || !meta.reply_object_name) {
-                            return false;
-                        }
-
-                        // Verify that the reply is to an object created by the user by
-                        // checking that the hostname associated with the reply object
-                        // is the same as the hostname of the site. This is not a bullet
-                        // proof check, but it's a good enough for now (i think 😅)
-                        const siteHost = ctx.get('site').host;
-                        const { hostname: replyHost } = new URL(
-                            meta.reply_object_url,
-                        );
-
-                        return siteHost === replyHost;
-                    }
-
-                    // ?filter={type: ['<activityType>:<objectType>:notReply']}
-                    if (filter.criteria?.startsWith('notReply')) {
-                        if (meta.reply_object_url) {
-                            return false;
-                        }
-                    }
-
                     return true;
                 },
             );
         });
-    }
-
-    // Filter the activity refs by excluding non-followers if the query parameter is set
-    if (excludeNonFollowers) {
-        // const followers = await db.get<string[]>(['following']) || [];
-        // activityRefs = activityRefs.filter(ref => {
-        //     const meta = activityMeta.get(ref)!;
-        //     return followers.includes(meta.actor_id);
-        // });
     }
 
     // Sort the activity refs by the id of the activity (newest first).
@@ -229,7 +186,11 @@ export async function handleGetActivities(ctx: AppContext) {
                     likedRefs,
                     repostedRefs,
                     outboxRefs,
-                    true,
+                    {
+                        expandInReplyTo: true,
+                        showReplyCount: true,
+                        showRepostCount: true,
+                    },
                 );
             } catch (err) {
                 logger.error('Error building activity ({ref}): {error}', {


### PR DESCRIPTION
no refs

Improved notifications perf by:

- Making queries for counts optional (not needed for notifications)
- Removing queries for likes & reposts when retrieving activities (not needed for notifications)
- Only doing lookups for likes & reposts when data is provided (not needed for notifications)