### PR TITLE
Updated repository to wait for events to process

### DIFF
--- a/src/account/account.repository.knex.integration.test.ts
+++ b/src/account/account.repository.knex.integration.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, it } from 'vitest';
 
 import assert from 'node:assert';
-import EventEmitter from 'node:events';
+import { AsyncEvents } from 'core/events';
 import type { Knex } from 'knex';
 import { createTestDb } from 'test/db';
 import { KnexAccountRepository } from '../account/account.repository.knex';
@@ -31,7 +31,7 @@ describe('KnexAccountRepository', () => {
         assert(account.uuid === null, 'Account should not have a uuid');
     };
     it('Can get by site', async () => {
-        const events = new EventEmitter();
+        const events = new AsyncEvents();
         const accountRepository = new KnexAccountRepository(client, events);
         const fedifyContextFactory = new FedifyContextFactory();
         const accountService = new AccountService(
@@ -62,7 +62,7 @@ describe('KnexAccountRepository', () => {
         );
     });
     it('Ensures an account has a uuid when retrieved for a site', async () => {
-        const events = new EventEmitter();
+        const events = new AsyncEvents();
         const accountRepository = new KnexAccountRepository(client, events);
         const fedifyContextFactory = new FedifyContextFactory();
         const accountService = new AccountService(
@@ -98,7 +98,7 @@ describe('KnexAccountRepository', () => {
         assert(account.uuid !== null, 'Account should have a uuid');
     });
     it('Can get by apId', async () => {
-        const events = new EventEmitter();
+        const events = new AsyncEvents();
         const accountRepository = new KnexAccountRepository(client, events);
         const fedifyContextFactory = new FedifyContextFactory();
         const accountService = new AccountService(
@@ -135,7 +135,7 @@ describe('KnexAccountRepository', () => {
         assert(result);
     });
     it('Ensures an account has a uuid when retrieved by apId', async () => {
-        const events = new EventEmitter();
+        const events = new AsyncEvents();
         const accountRepository = new KnexAccountRepository(client, events);
         const fedifyContextFactory = new FedifyContextFactory();
         const accountService = new AccountService(

--- a/src/account/account.repository.knex.ts
+++ b/src/account/account.repository.knex.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import type EventEmitter from 'node:events';
+import type { AsyncEvents } from 'core/events';
 import type { Knex } from 'knex';
 import { parseURL } from '../core/url';
 import type { Site } from '../site/site.service';
@@ -8,7 +8,7 @@ import { Account, type AccountSite } from './account.entity';
 export class KnexAccountRepository {
     constructor(
         private readonly db: Knex,
-        private readonly events: EventEmitter,
+        private readonly events: AsyncEvents,
     ) {}
 
     async getBySite(site: Site): Promise<Account> {

--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -1,7 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import EventEmitter from 'node:events';
-
+import { AsyncEvents } from 'core/events';
 import type { Knex } from 'knex';
 import { createTestDb } from 'test/db';
 import { FedifyContextFactory } from '../activitypub/fedify-context.factory';
@@ -40,7 +39,7 @@ vi.mock('@fedify/fedify', async () => {
 
 describe('AccountService', () => {
     let service: AccountService;
-    let events: EventEmitter;
+    let events: AsyncEvents;
     let site: Site;
     let internalAccountData: InternalAccountData;
     let externalAccountData: ExternalAccountData;
@@ -103,7 +102,7 @@ describe('AccountService', () => {
         };
 
         // Init dependencies
-        events = new EventEmitter();
+        events = new AsyncEvents();
         const accountRepository = new KnexAccountRepository(db, events);
         const fedifyContextFactory = new FedifyContextFactory();
 

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -7,7 +7,7 @@ import {
 import type { Knex } from 'knex';
 
 import { randomUUID } from 'node:crypto';
-import type EventEmitter from 'node:events';
+import type { AsyncEvents } from 'core/events';
 import type { FedifyContextFactory } from '../activitypub/fedify-context.factory';
 import {
     ACTOR_DEFAULT_ICON,
@@ -46,7 +46,7 @@ export class AccountService {
      */
     constructor(
         private readonly db: Knex,
-        private readonly events: EventEmitter,
+        private readonly events: AsyncEvents,
         private readonly accountRepository: KnexAccountRepository,
         private readonly fedifyContextFactory: FedifyContextFactory,
     ) {}
@@ -401,7 +401,7 @@ export class AccountService {
         const bioChanged = account.bio !== data.bio;
 
         if (avatarChanged || nameChanged || bioChanged) {
-            this.events.emit('account.updated', newAccount);
+            await this.events.emitAsync('account.updated', newAccount);
         }
 
         return newAccount;

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,6 @@ import './instrumentation';
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { createHmac } from 'node:crypto';
-import EventEmitter from 'node:events';
 import {
     Accept,
     Announce,
@@ -36,6 +35,7 @@ import * as Sentry from '@sentry/node';
 import { KnexAccountRepository } from 'account/account.repository.knex';
 import { CreateHandler } from 'activity-handlers/create.handler';
 import { DeleteDispatcher } from 'activitypub/object-dispatchers/delete.dispatcher';
+import { AsyncEvents } from 'core/events';
 import { Hono, type Context as HonoContext, type Next } from 'hono';
 import { cors } from 'hono/cors';
 import jwt from 'jsonwebtoken';
@@ -230,7 +230,7 @@ export type FedifyContext = Context<ContextData>;
 
 export const db = await KnexKvStore.create(client, 'key_value');
 
-const events = new EventEmitter();
+const events = new AsyncEvents();
 const fedifyContextFactory = new FedifyContextFactory();
 
 const accountRepository = new KnexAccountRepository(client, events);

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -1,0 +1,15 @@
+import EventEmitter from 'node:events';
+
+export class AsyncEvents extends EventEmitter {
+    async emitAsync(eventName: string, ...args: any[]): Promise<boolean> {
+        const handlers = this.listeners(eventName);
+        if (handlers.length === 0) {
+            return false;
+        }
+        const promises = handlers.map(async (handler) => {
+            return handler(...args);
+        });
+        await Promise.all(promises);
+        return true;
+    }
+}

--- a/src/feed/feed.service.integration.test.ts
+++ b/src/feed/feed.service.integration.test.ts
@@ -1,6 +1,6 @@
-import { EventEmitter } from 'node:events';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
+import { AsyncEvents } from 'core/events';
 import type { Knex } from 'knex';
 import { createTestDb } from 'test/db';
 import type { Account } from '../account/account.entity';
@@ -30,7 +30,7 @@ import { SiteService } from '../site/site.service';
 import { FeedService } from './feed.service';
 
 describe('FeedService', () => {
-    let events: EventEmitter;
+    let events: AsyncEvents;
     let accountRepository: KnexAccountRepository;
     let fedifyContextFactory: FedifyContextFactory;
     let accountService: AccountService;
@@ -131,7 +131,7 @@ describe('FeedService', () => {
         postCount = 0;
 
         // Init deps / support
-        events = new EventEmitter();
+        events = new AsyncEvents();
         accountRepository = new KnexAccountRepository(client, events);
         fedifyContextFactory = new FedifyContextFactory();
         accountService = new AccountService(

--- a/src/site/site.service.integration.test.ts
+++ b/src/site/site.service.integration.test.ts
@@ -1,7 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import EventEmitter from 'node:events';
-
+import { AsyncEvents } from 'core/events';
 import type { Knex } from 'knex';
 import { createTestDb } from 'test/db';
 import { KnexAccountRepository } from '../account/account.repository.knex';
@@ -44,7 +43,7 @@ describe('SiteService', () => {
         await db(TABLE_ACCOUNTS).truncate();
         await db.raw('SET FOREIGN_KEY_CHECKS = 1');
 
-        const events = new EventEmitter();
+        const events = new AsyncEvents();
         const accountRepository = new KnexAccountRepository(db, events);
         const fedifyContextFactory = new FedifyContextFactory();
         accountService = new AccountService(

--- a/src/site/site.service.ts
+++ b/src/site/site.service.ts
@@ -85,7 +85,7 @@ export class SiteService {
             avatar_url: settings?.site?.icon,
         };
 
-        const internalAccount = await this.accountService.createInternalAccount(
+        await this.accountService.createInternalAccount(
             newSite,
             internalAccountData,
         );


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-859

We don't want to run the event handlers outside the scope of a request, because the container can be shut down once the request has finished executing. This change keeps our event handlers running within the lifetime of the request.

Long term this will be handled by using a queue for the domain event system, so they can be pushed outside of the request lifecycle and safely handled async