### PR TITLE
Fixed database generated columns and indexes

### DIFF
--- a/migrate/migrations/000020_add_generated_columns_and_indexes_to_key_value.down.sql
+++ b/migrate/migrations/000020_add_generated_columns_and_indexes_to_key_value.down.sql
@@ -1,0 +1,27 @@
+DROP INDEX idx_object_id ON key_value;
+ALTER TABLE key_value DROP COLUMN object_id;
+
+DROP INDEX idx_object_in_reply_to ON key_value;
+ALTER TABLE key_value DROP COLUMN object_in_reply_to;
+
+ALTER TABLE key_value
+    ADD COLUMN object_id VARCHAR(150)
+    GENERATED ALWAYS AS (
+        CASE
+            WHEN REGEXP_LIKE(JSON_UNQUOTE(value->>"$.object.id"), '^https')
+            THEN JSON_UNQUOTE(value->>"$.object.id")
+            ELSE ''
+        END) STORED;
+
+CREATE INDEX idx_object_id ON key_value(object_id);
+
+ALTER TABLE key_value
+    ADD COLUMN object_in_reply_to VARCHAR(150)
+    GENERATED ALWAYS AS (
+        CASE
+            WHEN REGEXP_LIKE(JSON_UNQUOTE(value->>"$.object.inReplyTo"), '^https')
+            THEN JSON_UNQUOTE(value->>"$.object.inReplyTo")
+        ELSE ''
+        END) STORED;
+
+CREATE INDEX idx_object_in_reply_to ON key_value(object_in_reply_to);

--- a/migrate/migrations/000020_add_generated_columns_and_indexes_to_key_value.up.sql
+++ b/migrate/migrations/000020_add_generated_columns_and_indexes_to_key_value.up.sql
@@ -1,0 +1,17 @@
+DROP INDEX idx_object_id ON key_value;
+ALTER TABLE key_value DROP COLUMN object_id;
+
+DROP INDEX idx_object_in_reply_to ON key_value;
+ALTER TABLE key_value DROP COLUMN object_in_reply_to;
+
+ALTER TABLE key_value
+    ADD COLUMN object_id VARCHAR(255)
+    GENERATED ALWAYS AS (LEFT(JSON_UNQUOTE(value->>"$.object.id"), 255)) STORED;
+
+CREATE INDEX idx_object_id ON key_value(object_id);
+
+ALTER TABLE key_value
+    ADD COLUMN object_in_reply_to VARCHAR(255)
+    GENERATED ALWAYS AS (LEFT(JSON_UNQUOTE(value->>"$.object.inReplyTo"), 255)) STORED;
+
+CREATE INDEX idx_object_in_reply_to ON key_value(object_in_reply_to);


### PR DESCRIPTION
closes https://linear.app/ghost/issue/AP-844

- Changed the generated columns to truncate the ids. The old code had '', which caused rows on the left and right join to match and return data that it wasn't supposed.