### PR TITLE
Added wipe-db command

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "db": "docker compose exec mysql mysql -uroot -proot activitypub",
     "fix": "docker compose down --rmi all activitypub activitypub-testing cucumber-tests nginx",
     "logs": "docker compose logs activitypub -f",
+    "wipe-db": "docker compose down -v mysql && docker compose up -d activitypub nginx && echo 'ActivityPub DB wiped. You must restart Ghost'",
     "test:cucumber": "./docker/cucumber-tests",
     "test": "docker compose run --rm migrate-testing up && docker compose run --rm activitypub-testing yarn _test:all && yarn test:cucumber",
     "_test:types": "tsc --noEmit",


### PR DESCRIPTION
This command resets the local state so we can test the empty states easier, we wipe the database and then restart the services. The only thing needed to do is to restart Ghost which we can't easily do from here so has to be done manually