### PR TITLE
Removed likes from deleted posts

### DIFF
--- a/migrate/migrations/000021_remove-likes-of-deleted-posts.down.sql
+++ b/migrate/migrations/000021_remove-likes-of-deleted-posts.down.sql
@@ -1,0 +1,1 @@
+-- This migration cannot be rolled back

--- a/migrate/migrations/000021_remove-likes-of-deleted-posts.up.sql
+++ b/migrate/migrations/000021_remove-likes-of-deleted-posts.up.sql
@@ -1,0 +1,3 @@
+DELETE likes FROM likes
+INNER JOIN posts ON likes.post_id = posts.id
+WHERE posts.deleted_at IS NOT NULL;

--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -456,6 +456,11 @@ export class KnexPostRepository {
                             .where({ id: post.inReplyTo });
                     }
 
+                    // Delete likes associated with the deleted post
+                    await transaction('likes')
+                        .where({ post_id: post.id })
+                        .del();
+
                     wasDeleted = true;
                 }
             } else {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-864

When posts are deleted their likes are kept in the `likes` table, which means that we fetch deleted posts when looking up a users liked posts as well as we counts including likes for deleted posts.

In order to get liked posts for a user which don't include the deleted ones we need to filter on the joined posts table - which is inefficient.

This also includes a migration to remove existing likes for deleted posts. This migration is not reversible.