### PR TITLE
Enabled ActivityPub to be run as just a MessageQueue handler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,15 @@ jobs:
           job: migrations
           flags: '--wait --execute-now --set-cloudsql-instances=ghost-activitypub:europe-west4:activitypub-db'
 
-      - name: "Deploy ActivityPub to Cloud Run"
+      - name: "Deploy ActivityPub Queue to Cloud Run"
+        if: github.ref == 'refs/heads/main'
+        uses: 'google-github-actions/deploy-cloudrun@v2'
+        with:
+          image: europe-west4-docker.pkg.dev/ghost-activitypub/main/activitypub:${{ steps.activitypub-docker-metadata.outputs.version }}
+          region: europe-west4
+          service: activitypub-sub
+
+      - name: "Deploy ActivityPub API to Cloud Run"
         if: github.ref == 'refs/heads/main'
         uses: 'google-github-actions/deploy-cloudrun@v2'
         with:

--- a/src/app.ts
+++ b/src/app.ts
@@ -212,6 +212,7 @@ if (process.env.USE_MQ === 'true') {
 export const fedify = createFederation<ContextData>({
     kv: fedifyKv,
     queue,
+    manuallyStartQueue: process.env.MANUALLY_START_QUEUE === 'true',
     skipSignatureVerification:
         process.env.SKIP_SIGNATURE_VERIFICATION === 'true' &&
         ['development', 'testing'].includes(process.env.NODE_ENV || ''),
@@ -229,6 +230,14 @@ export type FedifyRequestContext = RequestContext<ContextData>;
 export type FedifyContext = Context<ContextData>;
 
 export const db = await KnexKvStore.create(client, 'key_value');
+
+if (process.env.MANUALLY_START_QUEUE === 'true') {
+    fedify.startQueue({
+        db: scopeKvStore(db, ['UNUSED_HOST']),
+        globaldb: db,
+        logger: logging,
+    });
+}
 
 const events = new AsyncEvents();
 const fedifyContextFactory = new FedifyContextFactory();
@@ -548,6 +557,15 @@ app.use(async (ctx, next) => {
     });
 });
 
+// This needs to go before the middleware which loads the site
+// because this endpoint does not require the site to exist
+if (queue instanceof GCloudPubSubPushMessageQueue) {
+    app.post(
+        '/.ghost/activitypub/mq',
+        spanWrapper(createPushMessageHandler(queue, logging)),
+    );
+}
+
 app.use(
     cors({
         origin: (_origin, ctx) => {
@@ -703,15 +721,6 @@ app.use(async (ctx, next) => {
 
     await next();
 });
-
-// This needs to go before the middleware which loads the site
-// because this endpoint does not require the site to exist
-if (queue instanceof GCloudPubSubPushMessageQueue) {
-    app.post(
-        '/.ghost/activitypub/mq',
-        spanWrapper(createPushMessageHandler(queue, logging)),
-    );
-}
 
 app.use(async (ctx, next) => {
     const request = ctx.req;


### PR DESCRIPTION
We move the `/mq` endpoint a lot earlier in the HTTP stack so we skip unnecessary middleware like auth.

We also add a new `MANUALLY_START_QUEUE` option for the env, when this is set we will force Fedify to start the queue when the application boots.

The `startQueue` method requires that we pass a valid `ContextData` to it, and we've had to pass a KV store scoped to `"UNUSED_HOST"` in this case. However this store is never used, due to the `ensureCorrectContext` function which wraps all `fedify` handlers. 

This function will override the `db` property on the context data, scoping the store to the `host`. This `host` is captured in the message on the queue and will be set by Fedify on the context