### PR TITLE
Added routePath and host to spans

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -547,6 +547,9 @@ app.use(async (ctx, next) => {
                         attributes: {
                             ...extra,
                             'service.name': 'activitypub',
+                            'service.host': ctx.req.header('host'),
+                            'http.req.path': ctx.req.path,
+                            'http.route': ctx.req.path,
                         },
                     },
                     () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1002,17 +1002,19 @@ app.delete(
 /** Federation wire up */
 
 app.use(
-    federation(
-        fedify,
-        (
-            ctx: HonoContext<{ Variables: HonoContextVariables }>,
-        ): ContextData => {
-            return {
-                db: ctx.get('db'),
-                globaldb: ctx.get('globaldb'),
-                logger: ctx.get('logger'),
-            };
-        },
+    spanWrapper(
+        federation(
+            fedify,
+            (
+                ctx: HonoContext<{ Variables: HonoContextVariables }>,
+            ): ContextData => {
+                return {
+                    db: ctx.get('db'),
+                    globaldb: ctx.get('globaldb'),
+                    logger: ctx.get('logger'),
+                };
+            },
+        ),
     ),
 );
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -908,12 +908,10 @@ app.post(
     '/.ghost/activitypub/actions/repost/:id',
     requireRole(GhostRole.Owner),
     spanWrapper(
-        spanWrapper(
-            createRepostActionHandler(
-                accountRepository,
-                postService,
-                postRepository,
-            ),
+        createRepostActionHandler(
+            accountRepository,
+            postService,
+            postRepository,
         ),
     ),
 );


### PR DESCRIPTION
This is going to allow us to break spans down by the host they're hitting, as well as the endpoint they're hitting, without being specific to the params of the endpoint.

Right now all the usernames are `index` so this largely doesn't make a difference, but I thought I'd clean it up whilst I'm here.