### PR TITLE
Removed pagination support from followers

### DIFF
--- a/features/followers.feature
+++ b/features/followers.feature
@@ -7,7 +7,6 @@ Feature: Followers
       | Bob     | Person |
       | Charlie | Person |
       | Dave    | Person |
-    And the list of followers is paginated across multiple pages
     When we create a note "Note" with the content
       """
       Hello, world!

--- a/src/activitypub/followers.service.ts
+++ b/src/activitypub/followers.service.ts
@@ -1,0 +1,47 @@
+import type { Recipient } from '@fedify/fedify';
+import type { Account } from 'account/account.entity';
+import { parseURL } from 'core/url';
+import type { Knex } from 'knex';
+
+export class FollowersService {
+    constructor(private readonly client: Knex) {}
+    async getFollowers(accountId: Account['id']): Promise<Recipient[]> {
+        const rows: unknown[] = await this.client('follows')
+            .select(
+                'accounts.ap_id',
+                'accounts.ap_inbox_url',
+                'accounts.ap_shared_inbox_url',
+            )
+            .where('follows.following_id', accountId)
+            .innerJoin('accounts', 'accounts.id', 'follows.follower_id')
+            .orderBy('follows.id', 'desc');
+
+        return rows.reduce(
+            (recipients: Recipient[], row: unknown): Recipient[] => {
+                if (!row || typeof row !== 'object') {
+                    return recipients;
+                }
+                let id = null;
+                if ('ap_id' in row) {
+                    id = parseURL(row.ap_id);
+                }
+                let inboxId = null;
+                if ('ap_inbox_url' in row) {
+                    inboxId = parseURL(row.ap_inbox_url);
+                }
+                let sharedInbox = null;
+                if ('ap_shared_inbox_url' in row) {
+                    sharedInbox = parseURL(row.ap_shared_inbox_url);
+                }
+                return recipients.concat({
+                    id,
+                    inboxId,
+                    endpoints: {
+                        sharedInbox,
+                    },
+                });
+            },
+            [],
+        );
+    }
+}

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -19,6 +19,8 @@ import {
     verifyObject,
 } from '@fedify/fedify';
 import * as Sentry from '@sentry/node';
+import type { KnexAccountRepository } from 'account/account.repository.knex';
+import type { FollowersService } from 'activitypub/followers.service';
 import { v4 as uuidv4 } from 'uuid';
 import type { AccountService } from './account/account.service';
 import { mapActorToExternalAccountData } from './account/utils';
@@ -703,97 +705,26 @@ export async function inboxErrorHandler(
 
 export function createFollowersDispatcher(
     siteService: SiteService,
-    accountService: AccountService,
+    accountRepository: KnexAccountRepository,
+    followersService: FollowersService,
 ) {
     return async function dispatchFollowers(
         ctx: Context<ContextData>,
         handle: string,
-        cursor: string | null,
     ) {
-        ctx.data.logger.info('Followers Dispatcher');
-
-        if (cursor === null) {
-            ctx.data.logger.info('No cursor provided, returning early');
-
-            return null;
-        }
-
-        const pageSize = Number.parseInt(
-            process.env.ACTIVITYPUB_COLLECTION_PAGE_SIZE || '',
-        );
-
-        if (Number.isNaN(pageSize)) {
-            throw new Error(`Page size: ${pageSize} is not valid`);
-        }
-
-        const offset = Number.parseInt(cursor ?? '0');
-        let nextCursor: string | null = null;
-
         const site = await siteService.getSiteByHost(ctx.host);
         if (!site) {
             throw new Error(`Site not found for host: ${ctx.host}`);
         }
 
-        // @TODO: Get account by provided handle instead of default account?
-        const siteDefaultAccount =
-            await accountService.getDefaultAccountForSite(site);
+        const account = await accountRepository.getBySite(site);
 
-        const results = await accountService.getFollowerAccounts(
-            siteDefaultAccount,
-            {
-                fields: ['ap_id', 'ap_inbox_url', 'ap_shared_inbox_url'],
-                limit: pageSize,
-                offset,
-            },
-        );
-        const totalFollowers =
-            await accountService.getFollowerAccountsCount(siteDefaultAccount);
-
-        nextCursor =
-            totalFollowers > offset + pageSize
-                ? (offset + pageSize).toString()
-                : null;
-
-        ctx.data.logger.info('Followers results', { results });
+        const followers = await followersService.getFollowers(account.id);
 
         return {
-            items: results.map((result) => ({
-                id: new URL(result.ap_id),
-                inboxId: new URL(result.ap_inbox_url),
-                sharedInboxId: result.ap_shared_inbox_url
-                    ? new URL(result.ap_shared_inbox_url)
-                    : null,
-            })),
-            nextCursor,
+            items: followers,
         };
     };
-}
-
-export function createFollowersCounter(
-    siteService: SiteService,
-    accountService: AccountService,
-) {
-    return async function countFollowers(
-        ctx: RequestContext<ContextData>,
-        handle: string,
-    ) {
-        const site = await siteService.getSiteByHost(ctx.host);
-        if (!site) {
-            throw new Error(`Site not found for host: ${ctx.host}`);
-        }
-
-        // @TODO: Get account by provided handle instead of default account?
-        const siteDefaultAccount =
-            await accountService.getDefaultAccountForSite(site);
-
-        return await accountService.getFollowerAccountsCount(
-            siteDefaultAccount,
-        );
-    };
-}
-
-export function followersFirstCursor() {
-    return '0';
 }
 
 export function createFollowingDispatcher(


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-871

There seems to be a problem with how Fedify handles Followers Sync for paginated followers dispatchers which don't support filtering. We have seen some loss of followers and think it might be linked. We're going to disable pagination for now to see if it fixes the problem.