### PR TITLE
Replaced Post object with postId in PostCreatedEvent

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -265,7 +265,11 @@ const siteService = new SiteService(client, accountService, {
     getSiteSettings: getSiteSettings,
 });
 const feedService = new FeedService(client);
-const feedUpdateService = new FeedUpdateService(events, feedService);
+const feedUpdateService = new FeedUpdateService(
+    events,
+    feedService,
+    postRepository,
+);
 feedUpdateService.init();
 
 const fediverseBridge = new FediverseBridge(events, fedifyContextFactory);

--- a/src/feed/feed-update.service.ts
+++ b/src/feed/feed-update.service.ts
@@ -8,11 +8,13 @@ import { PostDeletedEvent } from 'post/post-deleted.event';
 import { PostDerepostedEvent } from 'post/post-dereposted.event';
 import { PostRepostedEvent } from 'post/post-reposted.event';
 import { isFollowersOnlyPost, isPublicPost } from 'post/post.entity';
+import type { KnexPostRepository } from 'post/post.repository.knex';
 
 export class FeedUpdateService {
     constructor(
         private readonly events: EventEmitter,
         private readonly feedService: FeedService,
+        private readonly postRepository: KnexPostRepository,
     ) {}
 
     init() {
@@ -35,7 +37,12 @@ export class FeedUpdateService {
     }
 
     private async handlePostCreatedEvent(event: PostCreatedEvent) {
-        const post = event.getPost();
+        const postId = event.getPostId();
+        const post = await this.postRepository.getById(postId);
+
+        if (!post) {
+            return;
+        }
 
         let updatedFeedUserIds: number[] = [];
 

--- a/src/feed/feed-update.service.unit.test.ts
+++ b/src/feed/feed-update.service.unit.test.ts
@@ -21,6 +21,7 @@ import { PostDeletedEvent } from 'post/post-deleted.event';
 import { PostDerepostedEvent } from 'post/post-dereposted.event';
 import { PostRepostedEvent } from 'post/post-reposted.event';
 import { Audience, Post, PostType } from 'post/post.entity';
+import type { KnexPostRepository } from 'post/post.repository.knex';
 
 describe('FeedUpdateService', () => {
     let events: EventEmitter;
@@ -60,7 +61,20 @@ describe('FeedUpdateService', () => {
             type: PostType.Article,
         });
 
-        feedUpdateService = new FeedUpdateService(events, feedService);
+        const postRepository = {
+            async getById(id) {
+                if (id !== post.id) {
+                    return null;
+                }
+                return post;
+            },
+        } as KnexPostRepository;
+
+        feedUpdateService = new FeedUpdateService(
+            events,
+            feedService,
+            postRepository,
+        );
         feedUpdateService.init();
     });
 
@@ -77,7 +91,10 @@ describe('FeedUpdateService', () => {
                     return [];
                 });
 
-            events.emit(PostCreatedEvent.getName(), new PostCreatedEvent(post));
+            events.emit(
+                PostCreatedEvent.getName(),
+                new PostCreatedEvent(post.id),
+            );
 
             await vi.advanceTimersByTimeAsync(1000 * 10);
 
@@ -104,7 +121,10 @@ describe('FeedUpdateService', () => {
                     return [1123, 4456];
                 });
 
-            events.emit(PostCreatedEvent.getName(), new PostCreatedEvent(post));
+            events.emit(
+                PostCreatedEvent.getName(),
+                new PostCreatedEvent(post.id),
+            );
 
             await vi.advanceTimersByTimeAsync(1000 * 10);
 
@@ -127,7 +147,10 @@ describe('FeedUpdateService', () => {
                     return [1123, 4456];
                 });
 
-            events.emit(PostCreatedEvent.getName(), new PostCreatedEvent(post));
+            events.emit(
+                PostCreatedEvent.getName(),
+                new PostCreatedEvent(post.id),
+            );
 
             await vi.advanceTimersByTimeAsync(1000 * 10);
 

--- a/src/post/post-created.event.ts
+++ b/src/post/post-created.event.ts
@@ -1,10 +1,10 @@
 import type { Post } from './post.entity';
 
 export class PostCreatedEvent {
-    constructor(private readonly post: Post) {}
+    constructor(private readonly postId: Post['id']) {}
 
-    getPost(): Post {
-        return this.post;
+    getPostId(): Post['id'] {
+        return this.postId;
     }
 
     static getName(): string {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-880

Changed PostCreatedEvent to use postId instead of the full post object to reduce event payload size. This optimization prepares for future PubSub integration where message size constraints are important.