### PR TITLE
Fixed container tags in branches other than main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
             europe-west4-docker.pkg.dev/ghost-activitypub/main/activitypub
             europe-docker.pkg.dev/ghost-activitypub/activitypub/activitypub
           tags: |
-            type=edge,branch=main
+            ${{ github.ref == 'refs/heads/main' && 'type=edge,branch=main' || '' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
@@ -66,7 +66,7 @@ jobs:
             europe-west4-docker.pkg.dev/ghost-activitypub/main/migrations
             europe-docker.pkg.dev/ghost-activitypub/activitypub/migrations
           tags: |
-            type=edge,branch=main
+            ${{ github.ref == 'refs/heads/main' && 'type=edge,branch=main' || '' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}


### PR DESCRIPTION
ref no-issue

- This is a regression introduced that tagged edge and main on every PR. This changes back to only tagging those values on the main branch.