### PR TITLE
Added getById method to KnexPostRepository

### DIFF
--- a/src/post/post.repository.knex.integration.test.ts
+++ b/src/post/post.repository.knex.integration.test.ts
@@ -440,6 +440,32 @@ describe('KnexPostRepository', () => {
         assert(result.uuid === post.uuid);
     });
 
+    it('Can get by id', async () => {
+        const site = await siteService.initialiseSiteForHost(
+            'testing-by-apid.com',
+        );
+        const account = await accountRepository.getBySite(site);
+        const post = Post.createArticleFromGhostPost(account, {
+            title: 'Title',
+            uuid: randomUUID(),
+            html: '<p>Hello, world!</p>',
+            excerpt: 'Hello, world!',
+            feature_image: null,
+            url: 'https://testing.com/hello-world',
+            published_at: '2025-01-01',
+            visibility: 'public',
+        });
+
+        await postRepository.save(post);
+
+        const result = await postRepository.getById(post.id);
+
+        assert(result);
+
+        assert(result.author.uuid === account.uuid);
+        assert(result.uuid === post.uuid);
+    });
+
     it('Ensures an account associated with a post has a uuid when retrieved by apId', async () => {
         const site = await siteService.initialiseSiteForHost(
             'testing-account-uuid.com',

--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -23,6 +23,118 @@ export class KnexPostRepository {
         private readonly events: AsyncEvents,
     ) {}
 
+    async getById(id: Post['id']): Promise<Post | null> {
+        const row = await this.db(TABLE_POSTS)
+            .join('accounts', 'accounts.id', 'posts.author_id')
+            .leftJoin('users', 'users.account_id', 'accounts.id')
+            .leftJoin('sites', 'sites.id', 'users.site_id')
+            .where('posts.id', id)
+            .select(
+                'posts.id',
+                'posts.uuid',
+                'posts.type',
+                'posts.audience',
+                'posts.title',
+                'posts.excerpt',
+                'posts.content',
+                'posts.url',
+                'posts.image_url',
+                'posts.published_at',
+                'posts.like_count',
+                'posts.repost_count',
+                'posts.reply_count',
+                'posts.reading_time_minutes',
+                'posts.attachments',
+                'posts.author_id',
+                'posts.ap_id',
+                'posts.in_reply_to',
+                'posts.thread_root',
+                'posts.deleted_at',
+                'accounts.username',
+                'accounts.uuid as author_uuid',
+                'accounts.name',
+                'accounts.bio',
+                'accounts.avatar_url',
+                'accounts.banner_image_url',
+                'accounts.ap_id as author_ap_id',
+                'accounts.url as author_url',
+                'accounts.ap_followers_url as author_ap_followers_url',
+                'sites.id as site_id',
+                'sites.host as site_host',
+            )
+            .first();
+
+        if (!row) {
+            return null;
+        }
+
+        if (!row.author_uuid) {
+            row.author_uuid = randomUUID();
+            await this.db('accounts')
+                .update({ uuid: row.author_uuid })
+                .where({ id: row.author_id });
+        }
+
+        let site: AccountSite | null = null;
+
+        if (
+            typeof row.site_id === 'number' &&
+            typeof row.site_host === 'string'
+        ) {
+            site = {
+                id: row.site_id,
+                host: row.site_host,
+            };
+        }
+
+        const author = new Account(
+            row.author_id,
+            row.author_uuid,
+            row.username,
+            row.name,
+            row.bio,
+            parseURL(row.avatar_url),
+            parseURL(row.banner_image_url),
+            site,
+            parseURL(row.author_ap_id),
+            parseURL(row.author_url),
+            parseURL(row.author_ap_followers_url),
+        );
+
+        // Parse attachments and convert URL strings back to URL objects
+        const attachments = row.attachments
+            ? row.attachments.map((attachment: any) => ({
+                  ...attachment,
+                  url: new URL(attachment.url),
+              }))
+            : [];
+
+        const post = new Post(
+            row.id,
+            row.uuid,
+            author,
+            row.type,
+            row.audience,
+            row.title,
+            row.excerpt,
+            row.content,
+            new URL(row.url),
+            parseURL(row.image_url),
+            new Date(row.published_at),
+            row.like_count,
+            row.repost_count,
+            row.reply_count,
+            row.in_reply_to,
+            row.thread_root,
+            row.reading_time_minutes,
+            attachments,
+            new URL(row.ap_id),
+            row.deleted_at !== null,
+        );
+
+        return post;
+    }
+
     async getByApId(apId: URL): Promise<Post | null> {
         const row = await this.db(TABLE_POSTS)
             .join('accounts', 'accounts.id', 'posts.author_id')

--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -23,12 +23,12 @@ export class KnexPostRepository {
         private readonly events: AsyncEvents,
     ) {}
 
-    async getById(id: Post['id']): Promise<Post | null> {
-        const row = await this.db(TABLE_POSTS)
+    private async getByQuery(query: Knex.QueryCallback): Promise<Post | null> {
+        const row = await this.db('posts')
             .join('accounts', 'accounts.id', 'posts.author_id')
             .leftJoin('users', 'users.account_id', 'accounts.id')
             .leftJoin('sites', 'sites.id', 'users.site_id')
-            .where('posts.id', id)
+            .where(query)
             .select(
                 'posts.id',
                 'posts.uuid',
@@ -134,117 +134,16 @@ export class KnexPostRepository {
 
         return post;
     }
+    async getById(id: Post['id']): Promise<Post | null> {
+        return await this.getByQuery((qb: Knex.QueryBuilder) => {
+            return qb.where('posts.id', id);
+        });
+    }
 
     async getByApId(apId: URL): Promise<Post | null> {
-        const row = await this.db(TABLE_POSTS)
-            .join('accounts', 'accounts.id', 'posts.author_id')
-            .leftJoin('users', 'users.account_id', 'accounts.id')
-            .leftJoin('sites', 'sites.id', 'users.site_id')
-            .whereRaw('ap_id_hash = UNHEX(SHA2(?, 256))', [apId.href])
-            .select(
-                'posts.id',
-                'posts.uuid',
-                'posts.type',
-                'posts.audience',
-                'posts.title',
-                'posts.excerpt',
-                'posts.content',
-                'posts.url',
-                'posts.image_url',
-                'posts.published_at',
-                'posts.like_count',
-                'posts.repost_count',
-                'posts.reply_count',
-                'posts.reading_time_minutes',
-                'posts.attachments',
-                'posts.author_id',
-                'posts.ap_id',
-                'posts.in_reply_to',
-                'posts.thread_root',
-                'posts.deleted_at',
-                'accounts.username',
-                'accounts.uuid as author_uuid',
-                'accounts.name',
-                'accounts.bio',
-                'accounts.avatar_url',
-                'accounts.banner_image_url',
-                'accounts.ap_id as author_ap_id',
-                'accounts.url as author_url',
-                'accounts.ap_followers_url as author_ap_followers_url',
-                'sites.id as site_id',
-                'sites.host as site_host',
-            )
-            .first();
-
-        if (!row) {
-            return null;
-        }
-
-        if (!row.author_uuid) {
-            row.author_uuid = randomUUID();
-            await this.db('accounts')
-                .update({ uuid: row.author_uuid })
-                .where({ id: row.author_id });
-        }
-
-        let site: AccountSite | null = null;
-
-        if (
-            typeof row.site_id === 'number' &&
-            typeof row.site_host === 'string'
-        ) {
-            site = {
-                id: row.site_id,
-                host: row.site_host,
-            };
-        }
-
-        const author = new Account(
-            row.author_id,
-            row.author_uuid,
-            row.username,
-            row.name,
-            row.bio,
-            parseURL(row.avatar_url),
-            parseURL(row.banner_image_url),
-            site,
-            parseURL(row.author_ap_id),
-            parseURL(row.author_url),
-            parseURL(row.author_ap_followers_url),
-        );
-
-        // Parse attachments and convert URL strings back to URL objects
-        const attachments = row.attachments
-            ? row.attachments.map((attachment: any) => ({
-                  ...attachment,
-                  url: new URL(attachment.url),
-              }))
-            : [];
-
-        const post = new Post(
-            row.id,
-            row.uuid,
-            author,
-            row.type,
-            row.audience,
-            row.title,
-            row.excerpt,
-            row.content,
-            new URL(row.url),
-            parseURL(row.image_url),
-            new Date(row.published_at),
-            row.like_count,
-            row.repost_count,
-            row.reply_count,
-            row.in_reply_to,
-            row.thread_root,
-            row.reading_time_minutes,
-            attachments,
-            new URL(row.ap_id),
-            row.deleted_at !== null,
-        );
-
-        return post;
+        return await this.getByQuery((qb: Knex.QueryBuilder) => {
+            return qb.whereRaw('ap_id_hash = UNHEX(SHA2(?, 256))', [apId.href]);
+        });
     }
 
     /**


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-880

When sending messages on PubSub we want to keep size to a minimum, to achieve this we'll use id's instead of values and then fetch the values from the DB.