### PR TITLE
Configured local PubSub to have two topics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,10 @@ services:
       - USE_MQ=true
       - MQ_PUBSUB_PROJECT_ID=activitypub
       - MQ_PUBSUB_HOST=pubsub:8085
-      - MQ_PUBSUB_TOPIC_NAME=activitypub_topic_changeme
-      - MQ_PUBSUB_SUBSCRIPTION_NAME=activitypub_subscription_changeme
+      - MQ_PUBSUB_TOPIC_NAME=fedify-topic
+      - MQ_PUBSUB_SUBSCRIPTION_NAME=fedify-subscription
+      - MQ_PUBSUB_GHOST_TOPIC_NAME=ghost-topic
+      - MQ_PUBSUB_GHOST_SUBSCRIPTION_NAME=ghost-subscription
       - ACTIVITYPUB_COLLECTION_PAGE_SIZE=20
     command: yarn build:watch
     depends_on:
@@ -85,9 +87,12 @@ services:
       - ./pubsub/start.sh:/opt/activitypub/start-pubsub.sh
     environment:
       - PROJECT_ID=activitypub
-      - TOPIC_NAME=activitypub_topic_changeme
-      - SUBSCRIPTION_NAME=activitypub_subscription_changeme
-      - PUSH_ENDPOINT=http://activitypub:8080/.ghost/activitypub/mq
+      - FEDIFY_TOPIC_NAME=fedify-topic
+      - FEDIFY_SUBSCRIPTION_NAME=fedify-subscription
+      - FEDIFY_PUSH_ENDPOINT=http://activitypub:8080/.ghost/activitypub/mq
+      - GHOST_TOPIC_NAME=ghost-topic
+      - GHOST_SUBSCRIPTION_NAME=ghost-subscription
+      - GHOST_PUSH_ENDPOINT=http://activitypub:8080/pubsub/ghost/push
     healthcheck:
       test: "curl -f http://localhost:8085 || exit 1"
       interval: 1s
@@ -115,8 +120,10 @@ services:
       - USE_MQ=true
       - MQ_PUBSUB_PROJECT_ID=activitypub
       - MQ_PUBSUB_HOST=pubsub-testing:8085
-      - MQ_PUBSUB_TOPIC_NAME=activitypub_topic_changeme
-      - MQ_PUBSUB_SUBSCRIPTION_NAME=activitypub_subscription_changeme
+      - MQ_PUBSUB_TOPIC_NAME=fedify-topic
+      - MQ_PUBSUB_SUBSCRIPTION_NAME=fedify-subscription
+      - MQ_PUBSUB_GHOST_TOPIC_NAME=ghost-topic
+      - MQ_PUBSUB_GHOST_SUBSCRIPTION_NAME=ghost-subscription
       - ACTIVITYPUB_COLLECTION_PAGE_SIZE=2
     command: yarn build:watch
     depends_on:
@@ -185,9 +192,12 @@ services:
       - ./pubsub/start.sh:/opt/activitypub/start-pubsub.sh
     environment:
       - PROJECT_ID=activitypub
-      - TOPIC_NAME=activitypub_topic_changeme
-      - SUBSCRIPTION_NAME=activitypub_subscription_changeme
-      - PUSH_ENDPOINT=http://activitypub-testing:8083/.ghost/activitypub/mq
+      - FEDIFY_TOPIC_NAME=fedify-topic
+      - FEDIFY_SUBSCRIPTION_NAME=fedify-subscription
+      - FEDIFY_PUSH_ENDPOINT=http://activitypub-testing:8083/.ghost/activitypub/mq
+      - GHOST_TOPIC_NAME=ghost-topic
+      - GHOST_SUBSCRIPTION_NAME=ghost-subscription
+      - GHOST_PUSH_ENDPOINT=http://activitypub-testing:8083/pubsub/ghost/push
     healthcheck:
       test: "curl -f http://localhost:8085 || exit 1"
       interval: 1s

--- a/pubsub/start.sh
+++ b/pubsub/start.sh
@@ -23,27 +23,51 @@ until curl -f http://${HOST}; do
 done
 
 # Create the topic via REST API
-if curl -s -o /dev/null -w "%{http_code}" -X PUT http://${HOST}/v1/projects/${PROJECT_ID}/topics/${TOPIC_NAME} | grep -q "200"; then
-    echo "Topic created: ${TOPIC_NAME}"
+if curl -s -o /dev/null -w "%{http_code}" -X PUT http://${HOST}/v1/projects/${PROJECT_ID}/topics/${FEDIFY_TOPIC_NAME} | grep -q "200"; then
+    echo "Topic created: ${FEDIFY_TOPIC_NAME}"
 else
-    echo "Failed to create topic: ${TOPIC_NAME}"
+    echo "Failed to create topic: ${FEDIFY_TOPIC_NAME}"
     exit 1
 fi
 
 # Create the (push) subscription via REST API
-if curl -s -o /dev/null -w "%{http_code}" -X PUT http://${HOST}/v1/projects/${PROJECT_ID}/subscriptions/${SUBSCRIPTION_NAME} \
+if curl -s -o /dev/null -w "%{http_code}" -X PUT http://${HOST}/v1/projects/${PROJECT_ID}/subscriptions/${FEDIFY_SUBSCRIPTION_NAME} \
     -H "Content-Type: application/json" \
     -d '{
-  "topic": "projects/'${PROJECT_ID}'/topics/'${TOPIC_NAME}'",
+  "topic": "projects/'${PROJECT_ID}'/topics/'${FEDIFY_TOPIC_NAME}'",
   "pushConfig": {
-    "pushEndpoint": "'${PUSH_ENDPOINT}'"
+    "pushEndpoint": "'${FEDIFY_PUSH_ENDPOINT}'"
   }
 }' | grep -q "200"; then
-    echo "Subscription created: ${SUBSCRIPTION_NAME}"
+    echo "Subscription created: ${FEDIFY_SUBSCRIPTION_NAME}"
 else
-    echo "Failed to create subscription: ${SUBSCRIPTION_NAME}"
+    echo "Failed to create subscription: ${FEDIFY_SUBSCRIPTION_NAME}"
     exit 1
 fi
+
+# Create the topic via REST API
+if curl -s -o /dev/null -w "%{http_code}" -X PUT http://${HOST}/v1/projects/${PROJECT_ID}/topics/${GHOST_TOPIC_NAME} | grep -q "200"; then
+    echo "Topic created: ${GHOST_TOPIC_NAME}"
+else
+    echo "Failed to create topic: ${GHOST_TOPIC_NAME}"
+    exit 1
+fi
+
+# Create the (push) subscription via REST API
+if curl -s -o /dev/null -w "%{http_code}" -X PUT http://${HOST}/v1/projects/${PROJECT_ID}/subscriptions/${GHOST_SUBSCRIPTION_NAME} \
+    -H "Content-Type: application/json" \
+    -d '{
+  "topic": "projects/'${PROJECT_ID}'/topics/'${GHOST_TOPIC_NAME}'",
+  "pushConfig": {
+    "pushEndpoint": "'${GHOST_PUSH_ENDPOINT}'"
+  }
+}' | grep -q "200"; then
+    echo "Subscription created: ${GHOST_SUBSCRIPTION_NAME}"
+else
+    echo "Failed to create subscription: ${GHOST_SUBSCRIPTION_NAME}"
+    exit 1
+fi
+
 
 # Keep the container running
 tail -f /dev/null


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-880

We want to set up a second topic to separate the Ghost & Fedify messages at the infrastructure level, this avoids awkward routing code at the application level and decouples the internal events from Fedify related implementation code.