### PR TITLE
Added wire-up for new notifications endpoint

### DIFF
--- a/features/notifications.feature
+++ b/features/notifications.feature
@@ -1,0 +1,8 @@
+Feature: Notifications
+  In order to know when someone in the Fediverse interacts with me or my content
+  As a user
+  I want to be able to receive notifications of the interactions
+
+  Scenario: Requests for notifications with limit over 100 are rejected
+    When an authenticated request is made to "/.ghost/activitypub/notifications?limit=200"
+    Then the request is rejected with a 400

--- a/src/app.ts
+++ b/src/app.ts
@@ -41,6 +41,7 @@ import { Hono, type Context as HonoContext, type Next } from 'hono';
 import { cors } from 'hono/cors';
 import jwt from 'jsonwebtoken';
 import jose from 'node-jose';
+import { NotificationService } from 'notification/notification.service';
 import { KnexPostRepository } from 'post/post.repository.knex';
 import { behindProxy } from 'x-forwarded-fetch';
 import { AccountService } from './account/account.service';
@@ -101,6 +102,7 @@ import {
     createGetAccountLikedPostsHandler,
     createGetAccountPostsHandler,
     createGetFeedHandler,
+    createGetNotificationsHandler,
     createGetProfileFollowersHandler,
     createGetProfileFollowingHandler,
     createGetProfileHandler,
@@ -270,6 +272,8 @@ feedUpdateService.init();
 
 const fediverseBridge = new FediverseBridge(events, fedifyContextFactory);
 fediverseBridge.init();
+
+const notificationService = new NotificationService(client);
 
 /** Fedify */
 
@@ -1000,6 +1004,13 @@ app.delete(
     requireRole(GhostRole.Owner),
     spanWrapper(
         createDeletePostHandler(accountRepository, postRepository, postService),
+    ),
+);
+app.get(
+    '/.ghost/activitypub/notifications',
+    requireRole(GhostRole.Owner),
+    spanWrapper(
+        createGetNotificationsHandler(accountService, notificationService),
     ),
 );
 /** Federation wire up */

--- a/src/http/api/index.ts
+++ b/src/http/api/index.ts
@@ -1,6 +1,7 @@
 export * from './activities';
 export * from './account';
 export * from './feed';
+export * from './notification';
 export * from './note';
 export * from './post';
 export * from './profile';

--- a/src/http/api/notification.ts
+++ b/src/http/api/notification.ts
@@ -1,0 +1,63 @@
+import type { AccountService } from 'account/account.service';
+import type { NotificationService } from 'notification/notification.service';
+import type { AppContext } from '../../app';
+import type { NotificationDTO } from './types';
+
+const DEFAULT_NOTIFICATIONS_LIMIT = 20;
+const MAX_NOTIFICATIONS_LIMIT = 100;
+
+/**
+ * Create a handler for a request for a user's notifications
+ *
+ * @param accountService Account service instance
+ */
+export function createGetNotificationsHandler(
+    accountService: AccountService,
+    notificationService: NotificationService,
+) {
+    /**
+     * Handle a request for a user's notifications
+     *
+     * @param ctx App context instance
+     */
+    return async function handleGetNotifications(ctx: AppContext) {
+        const queryCursor = ctx.req.query('next');
+        const cursor = queryCursor ? decodeURIComponent(queryCursor) : null;
+
+        const queryLimit = ctx.req.query('limit');
+        const limit = queryLimit
+            ? Number(queryLimit)
+            : DEFAULT_NOTIFICATIONS_LIMIT;
+
+        if (limit > MAX_NOTIFICATIONS_LIMIT) {
+            return new Response(null, {
+                status: 400,
+            });
+        }
+
+        const account = await accountService.getDefaultAccountForSite(
+            ctx.get('site'),
+        );
+
+        const { results, nextCursor } =
+            await notificationService.getNotificationsData({
+                accountId: account.id,
+                limit,
+                cursor,
+            });
+
+        const notifications: NotificationDTO[] = results.map((result) => {
+            return { id: result.id.toString() };
+        });
+
+        return new Response(
+            JSON.stringify({
+                notifications,
+                next: nextCursor,
+            }),
+            {
+                status: 200,
+            },
+        );
+    };
+}

--- a/src/http/api/types.ts
+++ b/src/http/api/types.ts
@@ -163,3 +163,14 @@ export interface PostDTO {
      */
     repostedBy: AuthorDTO | null;
 }
+
+/**
+ * Notification returned by the API - Anywhere a notification is returned via the API,
+ * it should be this shape, or a partial version of it
+ */
+export interface NotificationDTO {
+    /**
+     * Internal ID of the notification
+     */
+    id: string;
+}

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -1,0 +1,57 @@
+import type { Knex } from 'knex';
+
+export interface GetNotificationsDataOptions {
+    /**
+     * ID of the account associated with the user to get the notifications for
+     */
+    accountId: number;
+    /**
+     * Maximum number of notifications to return
+     */
+    limit: number;
+    /**
+     * Cursor to use for pagination
+     */
+    cursor: string | null;
+}
+
+interface BaseGetNotificationsDataResultRow {
+    id: number;
+}
+
+export interface GetNotificationsDataResult {
+    results: BaseGetNotificationsDataResultRow[];
+    nextCursor: string | null;
+}
+
+export class NotificationService {
+    /**
+     * @param db Database client
+     */
+    constructor(private readonly db: Knex) {}
+
+    /**
+     * Get data for a notifications based on the provided options
+     *
+     * @param options Options for the query
+     */
+    async getNotificationsData(
+        options: GetNotificationsDataOptions,
+    ): Promise<GetNotificationsDataResult> {
+        const { id: userId } = await this.db('users')
+            .where('account_id', options.accountId)
+            .select('id')
+            .first();
+
+        const results = await this.db('notifications')
+            .where('user_id', userId)
+            .limit(options.limit);
+
+        // @TODO: Implement
+
+        return {
+            results: results.map((row) => ({ id: row.id })),
+            nextCursor: null,
+        };
+    }
+}


### PR DESCRIPTION
refs https://linear.app/ghost/issue/AP-899

Added a new endpoint for retrieving notifications with a dummy implementation:

- Adds a new `GET /notifications` endpoint
- Adds a new `NotificationService` that will be responsible for fetching notifications from the database
  - Service follows the same pattern as the `FeedService`
  - In the future this service may also be responsible for inserting new notifications into the database