### PR TITLE
Remove table const usage in favour of string literals

### DIFF
--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -29,12 +29,6 @@ const __dirname = dirname(__filename);
 const URL_EXTERNAL_ACTIVITY_PUB = 'http://fake-external-activitypub';
 const URL_GHOST_ACTIVITY_PUB = 'http://fake-ghost-activitypub';
 
-const TABLE_ACCOUNTS = 'accounts';
-const TABLE_FOLLOWS = 'follows';
-const TABLE_KEY_VALUE = 'key_value';
-const TABLE_SITES = 'sites';
-const TABLE_USERS = 'users';
-
 async function createActivity(type, object, actor) {
     let activity;
 
@@ -454,11 +448,11 @@ BeforeAll(async () => {
     });
 
     await client.raw('SET FOREIGN_KEY_CHECKS = 0');
-    await client(TABLE_KEY_VALUE).truncate();
-    await client(TABLE_FOLLOWS).truncate();
-    await client(TABLE_ACCOUNTS).truncate();
-    await client(TABLE_USERS).truncate();
-    await client(TABLE_SITES).truncate();
+    await client('key_value').truncate();
+    await client('follows').truncate();
+    await client('accounts').truncate();
+    await client('users').truncate();
+    await client('sites').truncate();
     await client.raw('SET FOREIGN_KEY_CHECKS = 1');
 
     webhookSecret = fs.readFileSync(
@@ -527,14 +521,14 @@ AfterAll(async () => {
 Before(async function () {
     await externalActivityPub.clearAllRequests();
     await client.raw('SET FOREIGN_KEY_CHECKS = 0');
-    await client(TABLE_KEY_VALUE).truncate();
-    await client(TABLE_FOLLOWS).truncate();
-    await client(TABLE_USERS).truncate();
-    await client(TABLE_ACCOUNTS).truncate();
-    await client(TABLE_SITES).truncate();
+    await client('key_value').truncate();
+    await client('follows').truncate();
+    await client('users').truncate();
+    await client('accounts').truncate();
+    await client('sites').truncate();
     await client.raw('SET FOREIGN_KEY_CHECKS = 1');
 
-    const [siteId] = await client(TABLE_SITES).insert({
+    const [siteId] = await client('sites').insert({
         host: new URL(URL_GHOST_ACTIVITY_PUB).host,
         webhook_secret: webhookSecret,
     });
@@ -554,7 +548,7 @@ Before(async function () {
 
         const keypair = await generateCryptoKeyPair();
 
-        const [accountId] = await client(TABLE_ACCOUNTS).insert({
+        const [accountId] = await client('accounts').insert({
             username: actor.preferredUsername,
             name: actor.name,
             bio: actor.summary,
@@ -573,7 +567,7 @@ Before(async function () {
             ap_private_key: JSON.stringify(await exportJwk(keypair.privateKey)),
         });
 
-        await client(TABLE_USERS).insert({
+        await client('users').insert({
             account_id: accountId,
             site_id: this.SITE_ID,
         });
@@ -613,7 +607,7 @@ async function fetchActivityPub(url, options = {}, auth = true) {
 }
 
 Given('there is no entry in the sites table', async function () {
-    await client(TABLE_SITES).del();
+    await client('sites').del();
 
     this.SITE_ID = null;
 });

--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -10,10 +10,6 @@ import {
     ACTOR_DEFAULT_NAME,
     ACTOR_DEFAULT_SUMMARY,
     AP_BASE_PATH,
-    TABLE_ACCOUNTS,
-    TABLE_FOLLOWS,
-    TABLE_SITES,
-    TABLE_USERS,
 } from '../constants';
 import { KnexAccountRepository } from './account.repository.knex';
 import { AccountService } from './account.service';
@@ -53,10 +49,10 @@ describe('AccountService', () => {
     beforeEach(async () => {
         // Clean up the database
         await db.raw('SET FOREIGN_KEY_CHECKS = 0');
-        await db(TABLE_FOLLOWS).truncate();
-        await db(TABLE_ACCOUNTS).truncate();
-        await db(TABLE_USERS).truncate();
-        await db(TABLE_SITES).truncate();
+        await db('follows').truncate();
+        await db('accounts').truncate();
+        await db('users').truncate();
+        await db('sites').truncate();
         await db.raw('SET FOREIGN_KEY_CHECKS = 1');
 
         // Insert a site
@@ -152,7 +148,7 @@ describe('AccountService', () => {
             expect(account.ap_private_key).toContain('key_ops');
 
             // Assert the account was inserted into the database
-            const accounts = await db(TABLE_ACCOUNTS).select('*');
+            const accounts = await db('accounts').select('*');
 
             expect(accounts).toHaveLength(1);
 
@@ -161,7 +157,7 @@ describe('AccountService', () => {
             expect(dbAccount).toMatchObject(expectedAccount);
 
             // Assert the user was inserted into the database
-            const users = await db(TABLE_USERS).select('*');
+            const users = await db('users').select('*');
 
             expect(users).toHaveLength(1);
 
@@ -182,7 +178,7 @@ describe('AccountService', () => {
             expect(account.id).toBeGreaterThan(0);
 
             // Assert the account was inserted into the database
-            const accounts = await db(TABLE_ACCOUNTS).select('*');
+            const accounts = await db('accounts').select('*');
 
             expect(accounts).toHaveLength(1);
 
@@ -206,7 +202,7 @@ describe('AccountService', () => {
             await service.recordAccountFollow(account, follower);
 
             // Assert the follow was inserted into the database
-            const follows = await db(TABLE_FOLLOWS).select('*');
+            const follows = await db('follows').select('*');
 
             expect(follows).toHaveLength(1);
 
@@ -217,7 +213,7 @@ describe('AccountService', () => {
 
             await service.recordAccountUnfollow(account, follower);
 
-            const followsAfter = await db(TABLE_FOLLOWS).select('*');
+            const followsAfter = await db('follows').select('*');
 
             expect(followsAfter).toHaveLength(0);
         });
@@ -237,7 +233,7 @@ describe('AccountService', () => {
             await service.recordAccountFollow(account, follower);
 
             // Assert the follow was inserted into the database
-            const follows = await db(TABLE_FOLLOWS).select('*');
+            const follows = await db('follows').select('*');
 
             expect(follows).toHaveLength(1);
 
@@ -259,14 +255,12 @@ describe('AccountService', () => {
 
             await service.recordAccountFollow(account, follower);
 
-            const firstFollow = await db(TABLE_FOLLOWS)
-                .where({ id: 1 })
-                .first();
+            const firstFollow = await db('follows').where({ id: 1 }).first();
 
             await service.recordAccountFollow(account, follower);
 
             // Assert the follow was inserted into the database only once
-            const follows = await db(TABLE_FOLLOWS).select('*');
+            const follows = await db('follows').select('*');
 
             expect(follows).toHaveLength(1);
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,12 +9,3 @@ export const ACTIVITY_TYPE_ANNOUNCE = 'Announce';
 export const ACTIVITY_TYPE_CREATE = 'Create';
 export const ACTIVITY_OBJECT_TYPE_ARTICLE = 'Article';
 export const ACTIVITY_OBJECT_TYPE_NOTE = 'Note';
-
-export const TABLE_ACCOUNTS = 'accounts';
-export const TABLE_FOLLOWS = 'follows';
-export const TABLE_SITES = 'sites';
-export const TABLE_USERS = 'users';
-export const TABLE_POSTS = 'posts';
-export const TABLE_LIKES = 'likes';
-export const TABLE_REPOSTS = 'reposts';
-export const TABLE_FEEDS = 'feeds';

--- a/src/feed/feed.service.integration.test.ts
+++ b/src/feed/feed.service.integration.test.ts
@@ -10,15 +10,6 @@ import { AccountService } from '../account/account.service';
 import type { Account as AccountType, Site } from '../account/types';
 import { FedifyContextFactory } from '../activitypub/fedify-context.factory';
 import {
-    TABLE_ACCOUNTS,
-    TABLE_FEEDS,
-    TABLE_FOLLOWS,
-    TABLE_POSTS,
-    TABLE_REPOSTS,
-    TABLE_SITES,
-    TABLE_USERS,
-} from '../constants';
-import {
     Audience,
     type FollowersOnlyPost,
     type PostData,
@@ -102,14 +93,10 @@ describe('FeedService', () => {
     };
 
     const getFeedDataForAccount = async (account: Account) => {
-        const feed = await client(TABLE_FEEDS)
-            .join(TABLE_USERS, `${TABLE_USERS}.id`, `${TABLE_FEEDS}.user_id`)
-            .join(
-                TABLE_ACCOUNTS,
-                `${TABLE_ACCOUNTS}.id`,
-                `${TABLE_USERS}.account_id`,
-            )
-            .where(`${TABLE_ACCOUNTS}.id`, account.id);
+        const feed = await client('feeds')
+            .join('users', 'users.id', 'feeds.user_id')
+            .join('accounts', 'accounts.id', 'users.account_id')
+            .where('accounts.id', account.id);
 
         return feed;
     };
@@ -117,13 +104,13 @@ describe('FeedService', () => {
     beforeEach(async () => {
         // Clean up the database
         await client.raw('SET FOREIGN_KEY_CHECKS = 0');
-        await client(TABLE_FEEDS).truncate();
-        await client(TABLE_REPOSTS).truncate();
-        await client(TABLE_POSTS).truncate();
-        await client(TABLE_FOLLOWS).truncate();
-        await client(TABLE_ACCOUNTS).truncate();
-        await client(TABLE_USERS).truncate();
-        await client(TABLE_SITES).truncate();
+        await client('feeds').truncate();
+        await client('reposts').truncate();
+        await client('posts').truncate();
+        await client('follows').truncate();
+        await client('accounts').truncate();
+        await client('users').truncate();
+        await client('sites').truncate();
         await client.raw('SET FOREIGN_KEY_CHECKS = 1');
 
         // Reset test state
@@ -235,7 +222,7 @@ describe('FeedService', () => {
             await postRepository.save(post1);
 
             // Set repost date
-            await client(TABLE_REPOSTS)
+            await client('reposts')
                 .where({ post_id: post1.id, account_id: userAccount.id })
                 .update({ created_at: new Date('2024-01-03T10:00:00Z') });
 

--- a/src/post/post.repository.knex.integration.test.ts
+++ b/src/post/post.repository.knex.integration.test.ts
@@ -10,7 +10,6 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { KnexAccountRepository } from '../account/account.repository.knex';
 import { AccountService } from '../account/account.service';
 import { FedifyContextFactory } from '../activitypub/fedify-context.factory';
-import { TABLE_LIKES, TABLE_POSTS, TABLE_REPOSTS } from '../constants';
 import { SiteService } from '../site/site.service';
 import { PostCreatedEvent } from './post-created.event';
 import { PostDeletedEvent } from './post-deleted.event';
@@ -42,9 +41,9 @@ describe('KnexPostRepository', () => {
     beforeEach(async () => {
         // Clean up the database
         await client.raw('SET FOREIGN_KEY_CHECKS = 0');
-        await client(TABLE_REPOSTS).truncate();
-        await client(TABLE_LIKES).truncate();
-        await client(TABLE_POSTS).truncate();
+        await client('reposts').truncate();
+        await client('likes').truncate();
+        await client('posts').truncate();
         await client.raw('SET FOREIGN_KEY_CHECKS = 1');
 
         // Init dependencies
@@ -175,7 +174,7 @@ describe('KnexPostRepository', () => {
 
             await postRepository.save(post);
 
-            const rowInDb = await client(TABLE_POSTS)
+            const rowInDb = await client('posts')
                 .where({
                     uuid: post.uuid,
                 })
@@ -219,7 +218,7 @@ describe('KnexPostRepository', () => {
 
             await postRepository.save(reply);
 
-            const postRowInDb = await client(TABLE_POSTS)
+            const postRowInDb = await client('posts')
                 .where({
                     uuid: post.uuid,
                 })
@@ -237,7 +236,7 @@ describe('KnexPostRepository', () => {
 
             await postRepository.save(reply);
 
-            const replyRowInDb = await client(TABLE_POSTS)
+            const replyRowInDb = await client('posts')
                 .where({
                     uuid: reply.uuid,
                 })
@@ -252,7 +251,7 @@ describe('KnexPostRepository', () => {
 
             expect(postDeletedEvent.getPost().id).toBe(reply.id);
 
-            const postRowAfterDelete = await client(TABLE_POSTS)
+            const postRowAfterDelete = await client('posts')
                 .where({
                     uuid: post.uuid,
                 })
@@ -290,7 +289,7 @@ describe('KnexPostRepository', () => {
             await postRepository.save(post);
 
             // Verify that the like exists in the database
-            const likesBeforeDelete = await client(TABLE_LIKES)
+            const likesBeforeDelete = await client('likes')
                 .where({ post_id: post.id })
                 .select('*');
             expect(likesBeforeDelete).toHaveLength(1);
@@ -300,7 +299,7 @@ describe('KnexPostRepository', () => {
             await postRepository.save(post);
 
             // Verify that the like has been removed from the database
-            const likesAfterDelete = await client(TABLE_LIKES)
+            const likesAfterDelete = await client('likes')
                 .where({ post_id: post.id })
                 .select('*');
             expect(likesAfterDelete).toHaveLength(0);
@@ -326,7 +325,7 @@ describe('KnexPostRepository', () => {
 
             await postRepository.save(post);
 
-            const rowInDb = await client(TABLE_POSTS)
+            const rowInDb = await client('posts')
                 .where({
                     uuid: post.uuid,
                 })
@@ -354,7 +353,7 @@ describe('KnexPostRepository', () => {
 
         await postRepository.save(post);
 
-        const rowInDb = await client(TABLE_POSTS)
+        const rowInDb = await client('posts')
             .where({
                 uuid: post.uuid,
             })
@@ -575,7 +574,7 @@ describe('KnexPostRepository', () => {
 
         await postRepository.save(post);
 
-        const rowInDb = await client(TABLE_POSTS)
+        const rowInDb = await client('posts')
             .where({
                 uuid: post.uuid,
             })
@@ -585,7 +584,7 @@ describe('KnexPostRepository', () => {
         assert(rowInDb, 'A row should have been saved in the DB');
         assert.equal(rowInDb.like_count, 3, 'There should be 3 likes');
 
-        const likesInDb = await client(TABLE_LIKES)
+        const likesInDb = await client('likes')
             .where({
                 post_id: post.id,
             })
@@ -629,7 +628,7 @@ describe('KnexPostRepository', () => {
 
         await postRepository.save(post);
 
-        const rowInDb = await client(TABLE_POSTS)
+        const rowInDb = await client('posts')
             .where({
                 uuid: post.uuid,
             })
@@ -665,7 +664,7 @@ describe('KnexPostRepository', () => {
 
         await postRepository.save(post);
 
-        const rowInDb = await client(TABLE_POSTS)
+        const rowInDb = await client('posts')
             .where({
                 uuid: post.uuid,
             })
@@ -675,7 +674,7 @@ describe('KnexPostRepository', () => {
         assert(rowInDb, 'A row should have been saved in the DB');
         assert.equal(rowInDb.repost_count, 2, 'There should be 2 reposts');
 
-        const repostsInDb = await client(TABLE_REPOSTS)
+        const repostsInDb = await client('reposts')
             .where({
                 post_id: post.id,
             })
@@ -736,7 +735,7 @@ describe('KnexPostRepository', () => {
 
         await postRepository.save(post);
 
-        const rowInDb = await client(TABLE_POSTS)
+        const rowInDb = await client('posts')
             .where({
                 uuid: post.uuid,
             })
@@ -822,7 +821,7 @@ describe('KnexPostRepository', () => {
         await postRepository.save(reply2);
         await postRepository.save(reply3);
 
-        const rowInDb = await client(TABLE_POSTS)
+        const rowInDb = await client('posts')
             .where({
                 uuid: originalPost.uuid,
             })
@@ -831,7 +830,7 @@ describe('KnexPostRepository', () => {
 
         assert.equal(rowInDb.reply_count, 3, 'There should be 3 replies');
 
-        const repliesInDb = await client(TABLE_POSTS)
+        const repliesInDb = await client('posts')
             .where({
                 thread_root: originalPost.id,
             })

--- a/src/site/site.service.integration.test.ts
+++ b/src/site/site.service.integration.test.ts
@@ -8,7 +8,6 @@ import { KnexAccountRepository } from '../account/account.repository.knex';
 import { AccountService } from '../account/account.service';
 import type { Account } from '../account/types';
 import { FedifyContextFactory } from '../activitypub/fedify-context.factory';
-import { TABLE_ACCOUNTS, TABLE_SITES, TABLE_USERS } from '../constants';
 import { type IGhostService, type Site, SiteService } from './site.service';
 
 vi.mock('@fedify/fedify', async () => {
@@ -39,9 +38,9 @@ describe('SiteService', () => {
     beforeEach(async () => {
         // Clean up the database
         await db.raw('SET FOREIGN_KEY_CHECKS = 0');
-        await db(TABLE_SITES).truncate();
-        await db(TABLE_USERS).truncate();
-        await db(TABLE_ACCOUNTS).truncate();
+        await db('sites').truncate();
+        await db('users').truncate();
+        await db('accounts').truncate();
         await db.raw('SET FOREIGN_KEY_CHECKS = 1');
 
         const events = new AsyncEvents();
@@ -87,7 +86,7 @@ describe('SiteService', () => {
 
         expect(createInternalAccount.mock.calls).toHaveLength(1);
 
-        const siteRows = await db(TABLE_SITES).select('*');
+        const siteRows = await db('sites').select('*');
 
         expect(siteRows).toHaveLength(1);
 
@@ -101,7 +100,7 @@ describe('SiteService', () => {
 
         expect(siteTwo).toMatchObject(site);
 
-        const siteRowsAfterSecondInit = await db(TABLE_SITES).select('*');
+        const siteRowsAfterSecondInit = await db('sites').select('*');
 
         expect(siteRowsAfterSecondInit).toHaveLength(1);
 


### PR DESCRIPTION
no refs

We decided to remove the usage of table constants in favour of string literals. This brings constistency where table names are referenced and also makes writing / reading complex queries easier