### PR TITLE
Set default number of users per Ghost install in nodeinfo

### DIFF
--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -1128,7 +1128,9 @@ export async function nodeInfoDispatcher(ctx: RequestContext<ContextData>) {
         protocols: ['activitypub'] as Protocol[],
         openRegistrations: false,
         usage: {
-            users: {},
+            users: {
+                total: 1,
+            },
             localPosts: 0,
             localComments: 0,
         },

--- a/src/dispatchers.unit.test.ts
+++ b/src/dispatchers.unit.test.ts
@@ -340,7 +340,9 @@ describe('dispatchers', () => {
                 protocols: ['activitypub'],
                 openRegistrations: false,
                 usage: {
-                    users: {},
+                    users: {
+                        total: 1,
+                    },
                     localPosts: 0,
                     localComments: 0,
                 },


### PR DESCRIPTION
FediDB was breaking because we give an empty value