### PR TITLE
Added logging of followers collection response

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1029,7 +1029,7 @@ app.get(
             logger.info(body.orderedItems.join(','));
         } catch (err) {
             if (err instanceof Error) {
-                logger.error(err.message);
+                logger.error('{error}', { error: err.message });
             }
         }
     },

--- a/src/app.ts
+++ b/src/app.ts
@@ -1018,6 +1018,23 @@ app.get(
 );
 /** Federation wire up */
 
+app.get(
+    '/.ghost/activitypub/followers/:handle',
+    async (ctx: HonoContext, next: Next) => {
+        await next();
+        const logger = ctx.get('logger');
+        try {
+            const res = ctx.res.clone();
+            const body = await res.json();
+            logger.info(body.orderedItems.join(','));
+        } catch (err) {
+            if (err instanceof Error) {
+                logger.error(err.message);
+            }
+        }
+    },
+);
+
 app.use(
     federation(
         fedify,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-871

As part of our debugging efforts with the followers collection sync issues, we want to temporarily log out the response body of our followers collection requests to get an idea of what's being returned.