### PR TITLE
Bump Fedify to 1.4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@cucumber/cucumber": "10.9.0",
-    "@fedify/cli": "1.4.6",
+    "@fedify/cli": "1.4.8",
     "@types/jsonwebtoken": "9.0.7",
     "@types/node": "20.17.6",
     "@types/node-jose": "1.1.13",
@@ -52,7 +52,7 @@
     "wiremock-captain": "3.5.0"
   },
   "dependencies": {
-    "@fedify/fedify": "1.4.6",
+    "@fedify/fedify": "1.4.8",
     "@google-cloud/opentelemetry-cloud-trace-exporter": "2.4.1",
     "@google-cloud/opentelemetry-cloud-trace-propagator": "0.20.0",
     "@google-cloud/pubsub": "4.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -501,15 +501,15 @@
   resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.1.tgz#b9da6a878a371829a0502c9b6c1c143ef6663f4d"
   integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
 
-"@fedify/cli@1.4.6":
-  version "1.4.6"
-  resolved "https://registry.yarnpkg.com/@fedify/cli/-/cli-1.4.6.tgz#18cfd2bda36a09b1603dc86d406ddea495aa440a"
-  integrity sha512-6pPRyZ8TRr2RRt1zmsgkqi+BDaCq/BgRyZpV1Xeb66qyu52L5pK68JofveaGmmOxn2L1i9eGjsq+zAJ66asW9Q==
+"@fedify/cli@1.4.8":
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/@fedify/cli/-/cli-1.4.8.tgz#51bbd02baf0c1ae1aa73d55530301f4f42fd3a76"
+  integrity sha512-uyRV2+BJ/VWAwCJRZ2eq/MzSDHQ1t2PWUWsG7zQEtdN/xVXezLdGGq+0cwf5lVM/r25Plf3ubcYAfNkREjYBbA==
 
-"@fedify/fedify@1.4.6":
-  version "1.4.6"
-  resolved "https://registry.yarnpkg.com/@fedify/fedify/-/fedify-1.4.6.tgz#bbfc2f00e6cfff5dd0a930e68321a89744310487"
-  integrity sha512-Fvfc0R2SNE72SoesQVtyvk/HrNU47VLUOR5Dj2HiHqOGtgbIPDfnEaOwoYEgGVqVwTKJRf+ZHZgNjUwAUUUhog==
+"@fedify/fedify@1.4.8":
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/@fedify/fedify/-/fedify-1.4.8.tgz#3137491e67cce967f700a78303ea1702d566b49b"
+  integrity sha512-eCQgPhya76GVAH1xN8a0R2gCvdTsdKFwxovATszX6OaW0C2ZwI0CXLde7MQI7d5D96kr0V9YDB9H8bXHJZ/3Qg==
   dependencies:
     "@deno/shim-crypto" "~0.3.1"
     "@deno/shim-deno" "~0.18.0"


### PR DESCRIPTION
Bump Fedify to [1.4.8](https://github.com/fedify-dev/fedify/releases/tag/1.4.8) to address bugs related to followers collection