### PR TITLE
Account for dots (.) in the username part of handle

### DIFF
--- a/src/helpers/activitypub/actor.ts
+++ b/src/helpers/activitypub/actor.ts
@@ -89,7 +89,7 @@ export async function isFollowedByDefaultSiteAccount(
 }
 
 export function isHandle(handle: string): boolean {
-    return /^@([\w-]+)@([\w-]+\.[\w.-]+)$/.test(handle);
+    return /^@([\w.-]+)@([\w-]+\.[\w.-]+)$/.test(handle);
 }
 
 export async function updateSiteActor(

--- a/src/helpers/activitypub/actor.ts
+++ b/src/helpers/activitypub/actor.ts
@@ -89,7 +89,7 @@ export async function isFollowedByDefaultSiteAccount(
 }
 
 export function isHandle(handle: string): boolean {
-    return /^@([\w.-]+)@([\w-]+\.[\w.-]+)$/.test(handle);
+    return /^@([\w.-]+)@([\w-]+\.[\w.-]+[^.])$/.test(handle);
 }
 
 export async function updateSiteActor(

--- a/src/helpers/activitypub/actor.unit.test.ts
+++ b/src/helpers/activitypub/actor.unit.test.ts
@@ -293,6 +293,9 @@ describe('isHandle', () => {
         expect(isHandle('@@foo')).toBe(false);
         expect(isHandle('@foo@')).toBe(false);
         expect(isHandle('@foo@@example.com')).toBe(false);
+        expect(isHandle('@some.user.name@example.domain.com')).toBe(true);
+        expect(isHandle('@some.user.name@example.com/bar')).toBe(false);
+        expect(isHandle('@foo@example.com.')).toBe(false);
     });
 });
 


### PR DESCRIPTION
Currently, searching for `@bsky.brid.gy@bsky.brid.gy` in Ghost yields no results. 
Reason is that [the regex check for handle](https://github.com/TryGhost/ActivityPub/blob/main/src/helpers/activitypub/actor.ts#L92) is failing because it doesn't account for dots (.) in the username part. The current pattern [\w-] only allows word characters (a-z, A-Z, 0-9, _) and hyphens (-).

- Changed `[\w-]` to `[\w.-]` in the first capture group to allow dots in usernames
- This will now match handles like `@bsky.brid.gy@bsky.brid.gy`