### PR TITLE
Added notification for an account being followed

### DIFF
--- a/src/account/account-followed.event.ts
+++ b/src/account/account-followed.event.ts
@@ -1,0 +1,20 @@
+import type { Account } from 'account/types';
+
+export class AccountFollowedEvent {
+    constructor(
+        private readonly account: Account,
+        private readonly follower: Account,
+    ) {}
+
+    getAccount(): Account {
+        return this.account;
+    }
+
+    getFollower(): Account {
+        return this.follower;
+    }
+
+    static getName(): string {
+        return 'account.followed';
+    }
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -41,6 +41,7 @@ import { Hono, type Context as HonoContext, type Next } from 'hono';
 import { cors } from 'hono/cors';
 import jwt from 'jsonwebtoken';
 import jose from 'node-jose';
+import { NotificationEventService } from 'notification/notification-event.service';
 import { NotificationService } from 'notification/notification.service';
 import { KnexPostRepository } from 'post/post.repository.knex';
 import { behindProxy } from 'x-forwarded-fetch';
@@ -276,6 +277,11 @@ const fediverseBridge = new FediverseBridge(events, fedifyContextFactory);
 fediverseBridge.init();
 
 const notificationService = new NotificationService(client);
+const notificationEventService = new NotificationEventService(
+    events,
+    notificationService,
+);
+notificationEventService.init();
 
 /** Fedify */
 

--- a/src/notification/notification-event.service.ts
+++ b/src/notification/notification-event.service.ts
@@ -1,0 +1,24 @@
+import type { EventEmitter } from 'node:events';
+import { AccountFollowedEvent } from 'account/account-followed.event';
+import type { NotificationService } from 'notification/notification.service';
+
+export class NotificationEventService {
+    constructor(
+        private readonly events: EventEmitter,
+        private readonly notificationService: NotificationService,
+    ) {}
+
+    init() {
+        this.events.on(
+            AccountFollowedEvent.getName(),
+            this.handleAccountFollowedEvent.bind(this),
+        );
+    }
+
+    private async handleAccountFollowedEvent(event: AccountFollowedEvent) {
+        await this.notificationService.createFollowNotification(
+            event.getAccount(),
+            event.getFollower(),
+        );
+    }
+}

--- a/src/notification/notification-event.service.unit.test.ts
+++ b/src/notification/notification-event.service.unit.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EventEmitter } from 'node:events';
+
+import { AccountFollowedEvent } from 'account/account-followed.event';
+import type { Account } from 'account/types';
+import { NotificationEventService } from './notification-event.service';
+import type { NotificationService } from './notification.service';
+
+describe('NotificationEventService', () => {
+    let events: EventEmitter;
+    let notificationService: NotificationService;
+    let notificationEventService: NotificationEventService;
+
+    beforeEach(() => {
+        events = new EventEmitter();
+        notificationService = {
+            createFollowNotification: vi.fn(),
+        } as unknown as NotificationService;
+
+        notificationEventService = new NotificationEventService(
+            events,
+            notificationService,
+        );
+        notificationEventService.init();
+    });
+
+    describe('handling an account follow', () => {
+        it('should create a follow notification', () => {
+            const account = { id: 123 };
+            const followerAccount = { id: 456 };
+
+            events.emit(
+                AccountFollowedEvent.getName(),
+                new AccountFollowedEvent(
+                    account as Account,
+                    followerAccount as Account,
+                ),
+            );
+
+            expect(
+                notificationService.createFollowNotification,
+            ).toHaveBeenCalledWith(account, followerAccount);
+        });
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-901

Update the system to emit a `account.followed` event when an account is followed. This event is then picked up by the `NotificationEventService` which will insert a notification into the database for the account being followed.