### PR TITLE
Emit `post.liked` event when a post is liked

### DIFF
--- a/src/post/post-liked.event.ts
+++ b/src/post/post-liked.event.ts
@@ -1,0 +1,20 @@
+import type { Post } from './post.entity';
+
+export class PostLikedEvent {
+    constructor(
+        private readonly post: Post,
+        private readonly accountId: number,
+    ) {}
+
+    getPost(): Post {
+        return this.post;
+    }
+
+    getAccountId(): number {
+        return this.accountId;
+    }
+
+    static getName(): string {
+        return 'post.liked';
+    }
+}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-901

Emit `post.liked` event when a post is liked so that we can listen on this event and create a corresponding notification for the post author.