### PR TITLE
Added notification for a post being liked

### DIFF
--- a/src/notification/notification-event.service.ts
+++ b/src/notification/notification-event.service.ts
@@ -1,6 +1,7 @@
 import type { EventEmitter } from 'node:events';
 import { AccountFollowedEvent } from 'account/account-followed.event';
 import type { NotificationService } from 'notification/notification.service';
+import { PostLikedEvent } from 'post/post-liked.event';
 
 export class NotificationEventService {
     constructor(
@@ -13,12 +14,23 @@ export class NotificationEventService {
             AccountFollowedEvent.getName(),
             this.handleAccountFollowedEvent.bind(this),
         );
+        this.events.on(
+            PostLikedEvent.getName(),
+            this.handlePostLikedEvent.bind(this),
+        );
     }
 
     private async handleAccountFollowedEvent(event: AccountFollowedEvent) {
         await this.notificationService.createFollowNotification(
             event.getAccount(),
             event.getFollower(),
+        );
+    }
+
+    private async handlePostLikedEvent(event: PostLikedEvent) {
+        await this.notificationService.createLikeNotification(
+            event.getPost(),
+            event.getAccountId(),
         );
     }
 }

--- a/src/notification/notification-event.service.unit.test.ts
+++ b/src/notification/notification-event.service.unit.test.ts
@@ -4,6 +4,8 @@ import { EventEmitter } from 'node:events';
 
 import { AccountFollowedEvent } from 'account/account-followed.event';
 import type { Account } from 'account/types';
+import { PostLikedEvent } from 'post/post-liked.event';
+import type { Post } from 'post/post.entity';
 import { NotificationEventService } from './notification-event.service';
 import type { NotificationService } from './notification.service';
 
@@ -16,6 +18,7 @@ describe('NotificationEventService', () => {
         events = new EventEmitter();
         notificationService = {
             createFollowNotification: vi.fn(),
+            createLikeNotification: vi.fn(),
         } as unknown as NotificationService;
 
         notificationEventService = new NotificationEventService(
@@ -41,6 +44,27 @@ describe('NotificationEventService', () => {
             expect(
                 notificationService.createFollowNotification,
             ).toHaveBeenCalledWith(account, followerAccount);
+        });
+    });
+
+    describe('handling a post like', () => {
+        it('should create a like notification', () => {
+            const post = {
+                id: 123,
+                author: {
+                    id: 456,
+                },
+            } as Post;
+            const accountId = 789;
+
+            events.emit(
+                PostLikedEvent.getName(),
+                new PostLikedEvent(post as Post, accountId),
+            );
+
+            expect(
+                notificationService.createLikeNotification,
+            ).toHaveBeenCalledWith(post, accountId);
         });
     });
 });

--- a/src/notification/notification.service.integration.test.ts
+++ b/src/notification/notification.service.integration.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import type { Knex } from 'knex';
-import { Audience, PostType } from 'post/post.entity';
+import { Audience, type Post, PostType } from 'post/post.entity';
 import { createTestDb } from 'test/db';
 
 import type { Account } from 'account/types';
@@ -328,6 +328,83 @@ describe('NotificationService', () => {
                     followerAccount,
                 ),
             ).rejects.toThrow('User not found for account: 999');
+        });
+    });
+
+    describe('createLikeNotification', () => {
+        it('should create a like notification', async () => {
+            const notificationService = new NotificationService(client);
+
+            const [siteId] = await client('sites').insert({
+                host: 'alice.com',
+                webhook_secret: 'secret',
+            });
+
+            const [accountId] = await client('accounts').insert({
+                username: 'alice',
+                ap_id: 'https://alice.com/user/alice',
+                ap_inbox_url: 'https://alice.com/user/alice/inbox',
+            });
+
+            const [userId] = await client('users').insert({
+                site_id: siteId,
+                account_id: accountId,
+            });
+
+            const [userPostId] = await client('posts').insert({
+                author_id: accountId,
+                type: PostType.Article,
+                audience: Audience.Public,
+                content:
+                    'Velit culpa est amet nisi laboris aliqua cillum consectetur consequat duis excepteur esse non dolor irure.',
+                url: 'http://alice.com/post/some-post',
+                ap_id: 'https://alice.com/post/some-post',
+            });
+
+            const [likerAccountId] = await client('accounts').insert({
+                username: 'bob',
+                ap_id: 'https://bob.com/user/bob',
+                ap_inbox_url: 'https://bob.com/user/bob/inbox',
+            });
+
+            const post = {
+                id: userPostId,
+                author: {
+                    id: accountId,
+                },
+            } as Post;
+
+            await notificationService.createLikeNotification(
+                post,
+                likerAccountId,
+            );
+
+            const notifications = await client('notifications').select('*');
+
+            expect(notifications).toHaveLength(1);
+            expect(notifications[0].user_id).toBe(userId);
+            expect(notifications[0].account_id).toBe(likerAccountId);
+            expect(notifications[0].post_id).toBe(userPostId);
+            expect(notifications[0].event_type).toBe(NotificationType.Like);
+        });
+
+        it('should do nothing if user is not found for account', async () => {
+            const notificationService = new NotificationService(client);
+
+            const postWithAccountWithoutUser = {
+                author: {
+                    id: 999,
+                },
+            } as Post;
+
+            await notificationService.createLikeNotification(
+                postWithAccountWithoutUser,
+                123,
+            );
+
+            const notifications = await client('notifications').select('*');
+
+            expect(notifications).toHaveLength(0);
         });
     });
 });

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -2,6 +2,7 @@ import type { Knex } from 'knex';
 
 import type { Account } from 'account/types';
 import { sanitizeHtml } from 'helpers/html';
+import type { Post } from 'post/post.entity';
 
 export enum NotificationType {
     Like = 1,
@@ -161,6 +162,30 @@ export class NotificationService {
             user_id: user.id,
             account_id: followerAccount.id,
             event_type: NotificationType.Follow,
+        });
+    }
+
+    /**
+     * Create a notification for a like event
+     *
+     * @param post The post that is being liked
+     * @param accountId The ID of the account that is liking the post
+     */
+    async createLikeNotification(post: Post, accountId: number) {
+        const user = await this.db('users')
+            .where('account_id', post.author.id)
+            .select('id')
+            .first();
+
+        if (!user) {
+            return;
+        }
+
+        await this.db('notifications').insert({
+            user_id: user.id,
+            account_id: accountId,
+            post_id: post.id,
+            event_type: NotificationType.Like,
         });
     }
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-901

Updated the system to handle a `post.liked` event when a post is liked - The event gets picked up by the `NotificationEventService` which will insert a notification into the database for the author of the post being liked.