### PR TITLE
Updated `account.followed` handler to better handle non-existent users

### DIFF
--- a/src/notification/notification.service.integration.test.ts
+++ b/src/notification/notification.service.integration.test.ts
@@ -311,7 +311,7 @@ describe('NotificationService', () => {
             expect(notifications[0].event_type).toBe(NotificationType.Follow);
         });
 
-        it('should throw an error if user is not found for account', async () => {
+        it('should do nothing if user is not found for account', async () => {
             const notificationService = new NotificationService(client);
 
             const accountWithoutUser = {
@@ -322,12 +322,14 @@ describe('NotificationService', () => {
                 id: 1,
             } as Account;
 
-            await expect(
-                notificationService.createFollowNotification(
-                    accountWithoutUser,
-                    followerAccount,
-                ),
-            ).rejects.toThrow('User not found for account: 999');
+            await notificationService.createFollowNotification(
+                accountWithoutUser,
+                followerAccount,
+            );
+
+            const notifications = await client('notifications').select('*');
+
+            expect(notifications).toHaveLength(0);
         });
     });
 });

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -154,7 +154,7 @@ export class NotificationService {
             .first();
 
         if (!user) {
-            throw new Error(`User not found for account: ${account.id}`);
+            return;
         }
 
         await this.db('notifications').insert({


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-901

Updated `account.followed` handler to return early instead of throw an error if a user associated with the account can not be found. This is because the handler will be executed for follows of "external accounts" (i.e a Ghost site follows a Mastodon account) and in this case it is valid that the user does not exist.