### PR TITLE
Changed subscription checks

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -200,7 +200,9 @@ if (process.env.USE_MQ === 'true') {
             hostIsEmulator: process.env.NODE_ENV !== 'production',
             projectId: process.env.MQ_PUBSUB_PROJECT_ID,
             topic: String(process.env.MQ_PUBSUB_TOPIC_NAME),
-            subscription: String(process.env.MQ_PUBSUB_SUBSCRIPTION_NAME),
+            subscription: process.env.MQ_PUBSUB_SUBSCRIPTION_NAME
+                ? String(process.env.MQ_PUBSUB_SUBSCRIPTION_NAME)
+                : undefined,
         });
 
         queue.registerErrorListener((error) => Sentry.captureException(error));

--- a/src/mq/gcloud-pubsub-push/mq.ts
+++ b/src/mq/gcloud-pubsub-push/mq.ts
@@ -328,7 +328,7 @@ export type CreateMessageQueueConfig = {
     /**
      * Name of the Pub/Sub subscription that will push messages will be recieved from
      */
-    subscription: string;
+    subscription?: string;
 };
 
 /**
@@ -373,14 +373,16 @@ export async function createMessageQueue(
     }
 
     // Check that the subscription exists
-    const fullSubscription = getFullSubscription(
-        pubSubClient.projectId,
-        subscription,
-    );
-    const [subscriptions] = await pubSubClient.getSubscriptions();
+    if (subscription !== undefined) {
+        const fullSubscription = getFullSubscription(
+            pubSubClient.projectId,
+            subscription,
+        );
+        const [subscriptions] = await pubSubClient.getSubscriptions();
 
-    if (!subscriptions.some(({ name }) => name === fullSubscription)) {
-        throw new Error(`Subscription [${subscription}] does not exist`);
+        if (!subscriptions.some(({ name }) => name === fullSubscription)) {
+            throw new Error(`Subscription [${subscription}] does not exist`);
+        }
     }
 
     // Return a message queue instance


### PR DESCRIPTION
ref no-issue

- On an API deployment, we don't need to check if there's a valid PubSub
subscription, only on queue processing deployments.