### PR TITLE
Prevent notifications for actions by post author

### DIFF
--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -175,6 +175,12 @@ export class NotificationService {
      * @param accountId The ID of the account that is liking the post
      */
     async createLikeNotification(post: Post, accountId: number) {
+        if (post.author.id === accountId) {
+            // Do not create a notification for a post created by the same account
+            // that is liking it
+            return;
+        }
+
         const user = await this.db('users')
             .where('account_id', post.author.id)
             .select('id')
@@ -184,12 +190,6 @@ export class NotificationService {
             // If this like was for a post by an internal account that no longer
             // exists, or an external account, we can't create a notification for
             // it as there is not a corresponding user record in the database
-            return;
-        }
-
-        if (post.author.id === accountId) {
-            // Do not create a notification for a post created by the same account
-            // that is liking it
             return;
         }
 
@@ -208,6 +208,11 @@ export class NotificationService {
      * @param accountId The ID of the account that is reposting the post
      */
     async createRepostNotification(post: Post, accountId: number) {
+        if (post.author.id === accountId) {
+            // Do not create a notification for a repost by the author of the post
+            return;
+        }
+
         const user = await this.db('users')
             .where('account_id', post.author.id)
             .select('id')
@@ -217,11 +222,6 @@ export class NotificationService {
             // If this repost was for a post by an internal account that no longer
             // exists, or an external account, we can't create a notification for
             // it as there is not a corresponding user record in the database
-            return;
-        }
-
-        if (post.author.id === accountId) {
-            // Do not create a notification for a repost by the author of the post
             return;
         }
 

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -220,6 +220,11 @@ export class NotificationService {
             return;
         }
 
+        if (post.author.id === accountId) {
+            // Do not create a notification for a repost by the author of the post
+            return;
+        }
+
         await this.db('notifications').insert({
             user_id: user.id,
             account_id: accountId,

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -187,6 +187,12 @@ export class NotificationService {
             return;
         }
 
+        if (post.author.id === accountId) {
+            // Don't create a notification for a post created by the same account
+            // that is liking it
+            return;
+        }
+
         await this.db('notifications').insert({
             user_id: user.id,
             account_id: accountId,

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -188,7 +188,7 @@ export class NotificationService {
         }
 
         if (post.author.id === accountId) {
-            // Don't create a notification for a post created by the same account
+            // Do not create a notification for a post created by the same account
             // that is liking it
             return;
         }
@@ -246,6 +246,12 @@ export class NotificationService {
 
         if (!inReplyToPost) {
             throw new Error(`In reply to post not found: ${post.inReplyTo}`);
+        }
+
+        if (post.author.id === inReplyToPost.author_id) {
+            // Do not create a notification for a reply by the author of the
+            // original post
+            return;
         }
 
         const user = await this.db('users')


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-901

Prevented notifications for actions performed by an author of a post on their own post

- Notification is not created when a post author likes their own post
- Notification is not created when a post author reposts their own post
- Notification is not created when a post author replies to their own post

These rules are based on the [existing filtering we have in place in the UI](https://github.com/TryGhost/Ghost/blob/main/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx#L188-L238)