### PR TITLE
Enabled /notifications and /post/:post_ap_id endpoints for Admin users

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1011,7 +1011,7 @@ app.get(
 );
 app.get(
     '/.ghost/activitypub/post/:post_ap_id',
-    requireRole(GhostRole.Owner),
+    requireRole(GhostRole.Owner, GhostRole.Administrator),
     spanWrapper(createGetPostHandler(postRepository)),
 );
 app.delete(
@@ -1023,7 +1023,7 @@ app.delete(
 );
 app.get(
     '/.ghost/activitypub/notifications',
-    requireRole(GhostRole.Owner),
+    requireRole(GhostRole.Owner, GhostRole.Administrator),
     spanWrapper(
         createGetNotificationsHandler(accountService, notificationService),
     ),


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-1005
ref https://linear.app/ghost/issue/AP-964

- we've recently enabled ActivityPub for Admin users
- Admin access was missing for the new /notifications and /post/:post_ap_id endpoints