### PR TITLE
Update `AccountService.recordAccountFollow` to use `Account` entity

### DIFF
--- a/src/account/account-followed.event.ts
+++ b/src/account/account-followed.event.ts
@@ -1,4 +1,4 @@
-import type { Account } from 'account/types';
+import type { Account } from './account.entity';
 
 export class AccountFollowedEvent {
     constructor(

--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -28,6 +28,7 @@ import type {
     InternalAccountData,
     Site,
 } from './types';
+import { asAccountEntity } from './utils';
 
 vi.mock('@fedify/fedify', async () => {
     // generateCryptoKeyPair is a slow operation so we generate a key pair
@@ -87,7 +88,7 @@ describe('AccountService', () => {
             username: 'index',
             name: 'Test Site Title',
             bio: 'Test Site Description',
-            avatar_url: 'Test Site Icon',
+            avatar_url: 'https://example.com/avatars/internal-account.png',
         };
         externalAccountData = {
             username: 'external-account',
@@ -214,7 +215,10 @@ describe('AccountService', () => {
                 username: 'follower',
             });
 
-            await service.recordAccountFollow(account, follower);
+            await service.recordAccountFollow(
+                asAccountEntity(account),
+                asAccountEntity(follower),
+            );
 
             // Assert the follow was inserted into the database
             const follows = await db('follows').select('*');
@@ -245,7 +249,10 @@ describe('AccountService', () => {
                 username: 'follower',
             });
 
-            await service.recordAccountFollow(account, follower);
+            await service.recordAccountFollow(
+                asAccountEntity(account),
+                asAccountEntity(follower),
+            );
 
             // Assert the follow was inserted into the database
             const follows = await db('follows').select('*');
@@ -268,11 +275,17 @@ describe('AccountService', () => {
                 username: 'follower',
             });
 
-            await service.recordAccountFollow(account, follower);
+            await service.recordAccountFollow(
+                asAccountEntity(account),
+                asAccountEntity(follower),
+            );
 
             const firstFollow = await db('follows').where({ id: 1 }).first();
 
-            await service.recordAccountFollow(account, follower);
+            await service.recordAccountFollow(
+                asAccountEntity(account),
+                asAccountEntity(follower),
+            );
 
             // Assert the follow was inserted into the database only once
             const follows = await db('follows').select('*');
@@ -304,15 +317,18 @@ describe('AccountService', () => {
                 username: 'follower',
             });
 
-            await service.recordAccountFollow(account, follower);
+            await service.recordAccountFollow(
+                asAccountEntity(account),
+                asAccountEntity(follower),
+            );
 
             await vi.waitFor(() => {
                 return accountFollowedEvent !== undefined;
             });
 
             expect(accountFollowedEvent).toBeDefined();
-            expect(accountFollowedEvent?.getAccount()).toBe(account);
-            expect(accountFollowedEvent?.getFollower()).toBe(follower);
+            expect(accountFollowedEvent?.getAccount().id).toBe(account.id);
+            expect(accountFollowedEvent?.getFollower().id).toBe(follower.id);
         });
 
         it('should not emit an account.followed event if the follow is not recorded due to being a duplicate', async () => {
@@ -333,8 +349,14 @@ describe('AccountService', () => {
                 username: 'follower',
             });
 
-            await service.recordAccountFollow(account, follower);
-            await service.recordAccountFollow(account, follower);
+            await service.recordAccountFollow(
+                asAccountEntity(account),
+                asAccountEntity(follower),
+            );
+            await service.recordAccountFollow(
+                asAccountEntity(account),
+                asAccountEntity(follower),
+            );
 
             await vi.advanceTimersByTime(1000);
 
@@ -428,9 +450,18 @@ describe('AccountService', () => {
                 username: 'following3',
             });
 
-            await service.recordAccountFollow(following1, account);
-            await service.recordAccountFollow(following2, account);
-            await service.recordAccountFollow(following3, account);
+            await service.recordAccountFollow(
+                asAccountEntity(following1),
+                asAccountEntity(account),
+            );
+            await service.recordAccountFollow(
+                asAccountEntity(following2),
+                asAccountEntity(account),
+            );
+            await service.recordAccountFollow(
+                asAccountEntity(following3),
+                asAccountEntity(account),
+            );
 
             // Get a page of following accounts and assert the requested fields are returned
             const followingAccounts = await service.getFollowingAccounts(
@@ -500,8 +531,14 @@ describe('AccountService', () => {
                 username: 'following2',
             });
 
-            await service.recordAccountFollow(following1, account);
-            await service.recordAccountFollow(following2, account);
+            await service.recordAccountFollow(
+                asAccountEntity(following1),
+                asAccountEntity(account),
+            );
+            await service.recordAccountFollow(
+                asAccountEntity(following2),
+                asAccountEntity(account),
+            );
 
             const count = await service.getFollowingAccountsCount(account);
 
@@ -528,9 +565,18 @@ describe('AccountService', () => {
                 username: 'follower3',
             });
 
-            await service.recordAccountFollow(account, follower1);
-            await service.recordAccountFollow(account, follower2);
-            await service.recordAccountFollow(account, follower3);
+            await service.recordAccountFollow(
+                asAccountEntity(account),
+                asAccountEntity(follower1),
+            );
+            await service.recordAccountFollow(
+                asAccountEntity(account),
+                asAccountEntity(follower2),
+            );
+            await service.recordAccountFollow(
+                asAccountEntity(account),
+                asAccountEntity(follower3),
+            );
 
             // Get a page of followers and assert the requested fields are returned
             const followers = await service.getFollowerAccounts(account, {
@@ -596,8 +642,14 @@ describe('AccountService', () => {
                 username: 'follower2',
             });
 
-            await service.recordAccountFollow(account, follower1);
-            await service.recordAccountFollow(account, follower2);
+            await service.recordAccountFollow(
+                asAccountEntity(account),
+                asAccountEntity(follower1),
+            );
+            await service.recordAccountFollow(
+                asAccountEntity(account),
+                asAccountEntity(follower2),
+            );
 
             const count = await service.getFollowerAccountsCount(account);
 
@@ -620,7 +672,10 @@ describe('AccountService', () => {
                 username: 'non-followee',
             });
 
-            await service.recordAccountFollow(followee, account);
+            await service.recordAccountFollow(
+                asAccountEntity(followee),
+                asAccountEntity(account),
+            );
 
             const isFollowing = await service.checkIfAccountIsFollowing(
                 account,

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -173,8 +173,8 @@ export class AccountService {
      * @param follower Following account
      */
     async recordAccountFollow(
-        followee: AccountType,
-        follower: AccountType,
+        followee: Account,
+        follower: Account,
     ): Promise<void> {
         const [insertCount] = await this.db('follows')
             .insert({

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -151,15 +151,18 @@ export class AccountService {
     async createExternalAccount(
         accountData: ExternalAccountData,
     ): Promise<AccountType> {
+        const uuid = randomUUID();
+
         const [accountId] = await this.db('accounts').insert({
             ...accountData,
-            uuid: randomUUID(),
+            uuid,
         });
 
         return {
             id: accountId,
             ...accountData,
             ap_private_key: null,
+            uuid,
         };
     }
 
@@ -415,6 +418,7 @@ export class AccountService {
             ap_liked_url: row.ap_liked_url,
             ap_public_key: row.ap_public_key,
             ap_private_key: row.ap_private_key,
+            uuid: row.uuid,
         };
     }
 

--- a/src/account/types.ts
+++ b/src/account/types.ts
@@ -35,9 +35,13 @@ export interface Account {
     ap_liked_url: string;
     ap_public_key: string;
     ap_private_key: string | null;
+    uuid: string | null;
 }
 
 /**
  * Data used when creating an external account
  */
-export type ExternalAccountData = Omit<Account, 'id' | 'ap_private_key'>;
+export type ExternalAccountData = Omit<
+    Account,
+    'id' | 'ap_private_key' | 'uuid'
+>;

--- a/src/account/utils.ts
+++ b/src/account/utils.ts
@@ -1,5 +1,6 @@
 import { type Actor, PropertyValue } from '@fedify/fedify';
-import type { ExternalAccountData } from './types';
+import { Account } from './account.entity';
+import type { Account as AccountType, ExternalAccountData } from './types';
 
 interface PublicKey {
     id: string;
@@ -76,4 +77,25 @@ export async function mapActorToExternalAccountData(
  */
 export function getAccountHandle(host?: string, username?: string) {
     return `@${username || 'unknown'}@${host || 'unknown'}`;
+}
+
+/**
+ * Convert an account type to an account entity
+ *
+ * @param account Account type
+ */
+export function asAccountEntity(account: AccountType): Account {
+    return new Account(
+        account.id,
+        account.uuid,
+        account.username,
+        account.name,
+        account.bio,
+        account.avatar_url ? new URL(account.avatar_url) : null,
+        account.banner_image_url ? new URL(account.banner_image_url) : null,
+        null, // site
+        new URL(account.ap_id),
+        account.url ? new URL(account.url) : null,
+        new URL(account.ap_followers_url),
+    );
 }

--- a/src/activitypub/fediverse-bridge.unit.test.ts
+++ b/src/activitypub/fediverse-bridge.unit.test.ts
@@ -54,6 +54,7 @@ describe('FediverseBridge', () => {
             ap_liked_url: 'https://account.com/liked',
             ap_public_key: '{}',
             ap_private_key: '{}',
+            uuid: null,
         };
 
         events.emit('account.updated', account);

--- a/src/activitypub/followers.service.integration.test.ts
+++ b/src/activitypub/followers.service.integration.test.ts
@@ -1,5 +1,6 @@
 import { KnexAccountRepository } from 'account/account.repository.knex';
 import { AccountService } from 'account/account.service';
+import { asAccountEntity } from 'account/utils';
 import { AsyncEvents } from 'core/events';
 import type { Knex } from 'knex';
 import { generateTestCryptoKeyPair } from 'test/crypto-key-pair';
@@ -53,7 +54,7 @@ describe('FollowersService', () => {
                 username: 'index',
                 name: 'Test Site Title',
                 bio: 'Test Site Description',
-                avatar_url: 'Test Site Icon',
+                avatar_url: 'https://example.com/avatars/internal-account.png',
             };
             const account = await accountService.createInternalAccount(site, {
                 ...internalAccountData,
@@ -72,9 +73,18 @@ describe('FollowersService', () => {
                 username: 'follower3',
             });
 
-            await accountService.recordAccountFollow(account, follower1);
-            await accountService.recordAccountFollow(account, follower2);
-            await accountService.recordAccountFollow(account, follower3);
+            await accountService.recordAccountFollow(
+                asAccountEntity(account),
+                asAccountEntity(follower1),
+            );
+            await accountService.recordAccountFollow(
+                asAccountEntity(account),
+                asAccountEntity(follower2),
+            );
+            await accountService.recordAccountFollow(
+                asAccountEntity(account),
+                asAccountEntity(follower3),
+            );
 
             const followers = await service.getFollowers(account.id);
 

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -23,7 +23,10 @@ import type { KnexAccountRepository } from 'account/account.repository.knex';
 import type { FollowersService } from 'activitypub/followers.service';
 import { v4 as uuidv4 } from 'uuid';
 import type { AccountService } from './account/account.service';
-import { mapActorToExternalAccountData } from './account/utils';
+import {
+    asAccountEntity,
+    mapActorToExternalAccountData,
+} from './account/utils';
 import { type ContextData, fedify } from './app';
 import { ACTOR_DEFAULT_HANDLE } from './constants';
 import { isFollowedByDefaultSiteAccount } from './helpers/activitypub/actor';
@@ -164,8 +167,8 @@ export function createFollowHandler(accountService: AccountService) {
             }
 
             await accountService.recordAccountFollow(
-                followeeAccount,
-                followerAccount,
+                asAccountEntity(followeeAccount),
+                asAccountEntity(followerAccount),
             );
         }
 
@@ -237,8 +240,8 @@ export function createAcceptHandler(accountService: AccountService) {
             }
 
             await accountService.recordAccountFollow(
-                followeeAccount,
-                followerAccount,
+                asAccountEntity(followeeAccount),
+                asAccountEntity(followerAccount),
             );
         }
     };

--- a/src/feed/feed.service.integration.test.ts
+++ b/src/feed/feed.service.integration.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
+import { asAccountEntity } from 'account/utils';
 import { AsyncEvents } from 'core/events';
 import type { Knex } from 'knex';
 import { generateTestCryptoKeyPair } from 'test/crypto-key-pair';
@@ -7,7 +8,7 @@ import { createTestDb } from 'test/db';
 import type { Account } from '../account/account.entity';
 import { KnexAccountRepository } from '../account/account.repository.knex';
 import { AccountService } from '../account/account.service';
-import type { Account as AccountType, Site } from '../account/types';
+import type { Site } from '../account/types';
 import { FedifyContextFactory } from '../activitypub/fedify-context.factory';
 import {
     Audience,
@@ -154,8 +155,8 @@ describe('FeedService', () => {
             const followedAccount = await createInternalAccount('bar.com');
 
             await accountService.recordAccountFollow(
-                followedAccount as unknown as AccountType,
-                userAccount as unknown as AccountType,
+                followedAccount as unknown as Account,
+                userAccount as unknown as Account,
             );
 
             const followedAccountPost = await createPost(followedAccount, {
@@ -198,8 +199,8 @@ describe('FeedService', () => {
             );
 
             await accountService.recordAccountFollow(
-                followedAccount as unknown as AccountType,
-                userAccount as unknown as AccountType,
+                followedAccount as unknown as Account,
+                userAccount as unknown as Account,
             );
 
             // Create posts with specific dates
@@ -277,8 +278,8 @@ describe('FeedService', () => {
             );
 
             await accountService.recordAccountFollow(
-                followedAccount as unknown as AccountType,
-                userAccount as unknown as AccountType,
+                followedAccount as unknown as Account,
+                userAccount as unknown as Account,
             );
 
             // Initialise an internal account that the user will not follow
@@ -293,8 +294,8 @@ describe('FeedService', () => {
             );
 
             await accountService.recordAccountFollow(
-                userAccount as unknown as AccountType, // @TODO: Update this when AccountEntity is used everywhere
-                externalAccount,
+                userAccount as unknown as Account,
+                asAccountEntity(externalAccount),
             );
 
             // Initialise posts
@@ -386,9 +387,8 @@ describe('FeedService', () => {
             );
 
             await accountService.recordAccountFollow(
-                // @TODO: Update this when AccountEntity is used everywhere
-                followedAccount as unknown as AccountType,
-                userAccount as unknown as AccountType,
+                followedAccount as unknown as Account,
+                userAccount as unknown as Account,
             );
 
             // Initialise an internal account that the user will not follow
@@ -473,8 +473,8 @@ describe('FeedService', () => {
             );
 
             await accountService.recordAccountFollow(
-                followedAccount as unknown as AccountType,
-                userAccount as unknown as AccountType,
+                followedAccount as unknown as Account,
+                userAccount as unknown as Account,
             );
 
             // Initialise a post that the user will reply to
@@ -604,8 +604,8 @@ describe('FeedService', () => {
             );
 
             await accountService.recordAccountFollow(
-                followedAccount as unknown as AccountType,
-                userAccount as unknown as AccountType,
+                followedAccount as unknown as Account,
+                userAccount as unknown as Account,
             );
 
             // Initialise another internal account that will follow the internal
@@ -614,8 +614,8 @@ describe('FeedService', () => {
                 await createInternalAccount('add-post-other.com');
 
             await accountService.recordAccountFollow(
-                followedAccount as unknown as AccountType,
-                otherAccount as unknown as AccountType,
+                followedAccount as unknown as Account,
+                otherAccount as unknown as Account,
             );
 
             // Initialise posts
@@ -674,8 +674,8 @@ describe('FeedService', () => {
             );
 
             await accountService.recordAccountFollow(
-                followedAccount as unknown as AccountType,
-                userAccount as unknown as AccountType,
+                followedAccount as unknown as Account,
+                userAccount as unknown as Account,
             );
 
             // Create post and repost
@@ -730,13 +730,13 @@ describe('FeedService', () => {
             );
 
             await accountService.recordAccountFollow(
-                reposter1 as unknown as AccountType,
-                userAccount as unknown as AccountType,
+                reposter1 as unknown as Account,
+                userAccount as unknown as Account,
             );
 
             await accountService.recordAccountFollow(
-                reposter2 as unknown as AccountType,
-                userAccount as unknown as AccountType,
+                reposter2 as unknown as Account,
+                userAccount as unknown as Account,
             );
 
             // Create post and add two reposts

--- a/src/notification/notification-event.service.unit.test.ts
+++ b/src/notification/notification-event.service.unit.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
 
 import { AccountFollowedEvent } from 'account/account-followed.event';
-import type { Account } from 'account/types';
+import type { Account } from 'account/account.entity';
 import { PostCreatedEvent } from 'post/post-created.event';
 import { PostLikedEvent } from 'post/post-liked.event';
 import { PostRepostedEvent } from 'post/post-reposted.event';

--- a/src/notification/notification.service.integration.test.ts
+++ b/src/notification/notification.service.integration.test.ts
@@ -1,11 +1,10 @@
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
+import type { Account } from 'account/account.entity';
 import type { Knex } from 'knex';
 import { Audience, PostType } from 'post/post.entity';
 import type { Post } from 'post/post.entity';
 import { createTestDb } from 'test/db';
-
-import type { Account } from 'account/types';
 import { NotificationService, NotificationType } from './notification.service';
 
 describe('NotificationService', () => {

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -1,6 +1,6 @@
 import type { Knex } from 'knex';
 
-import type { Account } from 'account/types';
+import type { Account } from 'account/account.entity';
 import { sanitizeHtml } from 'helpers/html';
 import type { Post } from 'post/post.entity';
 


### PR DESCRIPTION
refs https://github.com/TryGhost/ActivityPub/pull/441/files#diff-fb5a965e319e4cc068e247181f63852dc961379121ca4cad8a64a70d025866a5

- Updated `Account` type to have `uuid` as this was missing
- Introduced `asAccountEntity` helper that maps `Account` type to `Account` entity
- Updated `AccountService.recordAccountFollow` to accept `Account` entity instead of `Account` type