### PR TITLE
Improved `handleGetProfilePosts` perf

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -971,7 +971,7 @@ app.get(
 app.get(
     '/.ghost/activitypub/profile/:handle/posts',
     requireRole(GhostRole.Owner, GhostRole.Administrator),
-    spanWrapper(createGetProfilePostsHandler(accountService)),
+    spanWrapper(createGetProfilePostsHandler(accountService, postRepository)),
 );
 app.get(
     '/.ghost/activitypub/thread/:post_ap_id',

--- a/src/http/api/profile.ts
+++ b/src/http/api/profile.ts
@@ -10,7 +10,6 @@ import {
 
 import type { AccountService } from 'account/account.service';
 import { type AppContext, fedify } from 'app';
-import { getActivityChildrenCount, getRepostCount } from 'db';
 import {
     getAttachments,
     getFollowerCount,
@@ -22,6 +21,7 @@ import {
 import { sanitizeHtml } from 'helpers/html';
 import { isUri } from 'helpers/uri';
 import { lookupObject } from 'lookup-helpers';
+import type { KnexPostRepository } from 'post/post.repository.knex';
 
 interface Profile {
     actor: any;
@@ -128,7 +128,10 @@ interface PostsResult {
  *
  * @param accountService Account service instance
  */
-export function createGetProfilePostsHandler(accountService: AccountService) {
+export function createGetProfilePostsHandler(
+    accountService: AccountService,
+    postRepository: KnexPostRepository,
+) {
     /**
      * Handle a request for a profile's posts
      *
@@ -243,9 +246,15 @@ export function createGetProfilePostsHandler(accountService: AccountService) {
                     defaultSiteAccount.ap_id === activity.actor.id;
 
                 // Add reply count and repost count to the object
-                activity.object.replyCount =
-                    await getActivityChildrenCount(activity);
-                activity.object.repostCount = await getRepostCount(activity);
+                activity.object.replyCount = 0;
+                activity.object.repostCount = 0;
+
+                if (object?.id) {
+                    const post = await postRepository.getByApId(object.id);
+
+                    activity.object.replyCount = post ? post.replyCount : 0;
+                    activity.object.repostCount = post ? post.repostCount : 0;
+                }
 
                 // Check if the activity is liked or reposted by default site account
                 const objectId = activity.object.id;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-1018

Changed `handleGetProfilePosts` to retrieve repost & reply counts for a post in the outbox from the `posts` table instead of computing the counts based on the data in the `key_value` table. This should make retrieving posts for a remote account more peformant.