### PR TITLE
Updated the GET /post API to fetch remote posts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ This section documents quirks and conventions specific to our implementation.
 ### Do's
 
 - Do model business logic in the Entities
+- Do use services in HTTP handlers & Fedify wirings
 
 ### Don'ts
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1010,7 +1010,7 @@ app.get(
 app.get(
     '/.ghost/activitypub/post/:post_ap_id',
     requireRole(GhostRole.Owner, GhostRole.Administrator),
-    spanWrapper(createGetPostHandler(postRepository)),
+    spanWrapper(createGetPostHandler(postService)),
 );
 app.delete(
     '/.ghost/activitypub/post/:id',

--- a/src/http/api/post.ts
+++ b/src/http/api/post.ts
@@ -10,7 +10,7 @@ import { postToDTO } from './helpers/post';
 /**
  * Create a handler for a request to get a post
  */
-export function createGetPostHandler(postRepository: KnexPostRepository) {
+export function createGetPostHandler(postService: PostService) {
     /**
      * Handle a request to get a post
      */
@@ -24,7 +24,7 @@ export function createGetPostHandler(postRepository: KnexPostRepository) {
             });
         }
 
-        const post = await postRepository.getByApId(idAsUrl);
+        const post = await postService.getByApId(idAsUrl);
 
         if (!post) {
             return new Response(null, {

--- a/src/http/api/post.unit.test.ts
+++ b/src/http/api/post.unit.test.ts
@@ -3,14 +3,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Account } from 'account/account.entity';
 import type { AppContext } from 'app';
 import { Audience, Post, PostType } from 'post/post.entity';
-import type { KnexPostRepository } from 'post/post.repository.knex';
+import type { PostService } from 'post/post.service';
 import type { Site } from 'site/site.service';
 import { createGetPostHandler } from './post';
 
 describe('Post API', () => {
     let site: Site;
     let account: Account;
-    let postRepository: KnexPostRepository;
+    let postService: PostService;
 
     beforeEach(() => {
         vi.setSystemTime(new Date('2025-03-25T14:00:00Z'));
@@ -33,7 +33,7 @@ describe('Post API', () => {
             url: new URL('https://example.com/users/456'),
             apFollowers: new URL('https://example.com/followers/456'),
         });
-        postRepository = {} as KnexPostRepository;
+        postService = {} as PostService;
     });
 
     it('should return a post', async () => {
@@ -55,7 +55,7 @@ describe('Post API', () => {
             },
         } as unknown as AppContext;
 
-        postRepository.getByApId = vi.fn().mockImplementation((_postApId) => {
+        postService.getByApId = vi.fn().mockImplementation((_postApId) => {
             if (_postApId.href === postApId) {
                 return new Post(
                     123,
@@ -78,7 +78,7 @@ describe('Post API', () => {
             return null;
         });
 
-        const handler = createGetPostHandler(postRepository);
+        const handler = createGetPostHandler(postService);
 
         const response = await handler(ctx);
 
@@ -107,7 +107,7 @@ describe('Post API', () => {
             },
         } as unknown as AppContext;
 
-        const handler = createGetPostHandler(postRepository);
+        const handler = createGetPostHandler(postService);
         const response = await handler(ctx);
 
         expect(response.status).toBe(400);
@@ -132,9 +132,9 @@ describe('Post API', () => {
             },
         } as unknown as AppContext;
 
-        postRepository.getByApId = vi.fn().mockResolvedValue(null);
+        postService.getByApId = vi.fn().mockResolvedValue(null);
 
-        const handler = createGetPostHandler(postRepository);
+        const handler = createGetPostHandler(postService);
         const response = await handler(ctx);
 
         expect(response.status).toBe(404);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-1015

The PostService implements remote fetching, and stores the post locally for us.

Generally we should try to use the service layer in controllers, so we can take advantage of the advanced functionality, as well as the ability to alter the functionality without modifying the repository layer.