### PR TITLE
Added some unit tests for createNote

### DIFF
--- a/src/post/post.entity.unit.test.ts
+++ b/src/post/post.entity.unit.test.ts
@@ -144,6 +144,56 @@ describe('Post', () => {
         });
     });
 
+    describe('createNote', () => {
+        it('errors if the account is external', () => {
+            const account = externalAccount();
+            const content = 'My first note';
+
+            expect(() =>
+                Post.createNote(account, content),
+            ).toThrowErrorMatchingInlineSnapshot(
+                '[Error: createNote is for use with internal accounts]',
+            );
+        });
+
+        it('creates a note with html content', () => {
+            const account = internalAccount();
+            const content = 'My first note';
+
+            const note = Post.createNote(account, content);
+
+            expect(note.type).toBe(PostType.Note);
+
+            expect(note.content).toBe('<p>My first note</p>');
+        });
+
+        it('creates a note with line breaks', () => {
+            const account = internalAccount();
+            const content = `My
+                            first
+                            note`;
+
+            const note = Post.createNote(account, content);
+
+            expect(note.type).toBe(PostType.Note);
+
+            expect(note.content).toBe('<p>My<br />first<br />note</p>');
+        });
+
+        it('creates a note with escaped html', () => {
+            const account = internalAccount();
+            const content = '<script>alert("hax")</script> Hello, world!';
+
+            const note = Post.createNote(account, content);
+
+            expect(note.type).toBe(PostType.Note);
+
+            expect(note.content).toBe(
+                '<p>&lt;script&gt;alert("hax")&lt;/script&gt; Hello, world!</p>',
+            );
+        });
+    });
+
     it('should correctly create an article from a Ghost Post', () => {
         const account = internalAccount();
         const ghostPost = {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-923

In order to turn URLs into links, we need to be able to test that we do so! This adds some tests for the existing functionality of createNote so that we can build on it later.