### PR TITLE
Updated renovate config to use automerge profile

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,9 @@
 {
-  "extends": ["github>tryghost/renovate-config:default"]
+  "extends": ["github>tryghost/renovate-config:quiet"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["@fedify/fedify", "@fedify/fedify-cli"],
+      "automerge": false
+    }
+  ]
 }


### PR DESCRIPTION
NOTE: Preparing changes ready to merge tomorrow when there's been some time for all team members to dissent

---


- The default profile has no automerging, this was chosen originally due to a lack of tests/confidence in CI catching issues with dependency upgrades
- Now we're further along in the project we have confidence to enable automerging
- This will make renovate work for us, keeping packages up to date, instead of creating lots of PRs for us to merge
- Note: The packages @fedify/fedify and @fedify/fedify-cli are excluded from automerge, as requested by @allouis