### PR TITLE
Updated logic for computing liked / reposted status on remote account post retrieval 

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -28,6 +28,10 @@ interface ActivityJsonLd {
     [key: string]: any;
 }
 
+/**
+ * @deprecated Do not use this function. Instead, resolve the post via the
+ * post repository and use the `replyCount` property
+ */
 export async function getActivityChildrenCount(activity: ActivityJsonLd) {
     const objectId = activity.object.id;
 
@@ -54,6 +58,10 @@ export async function getActivityChildrenCount(activity: ActivityJsonLd) {
     return result[0].count;
 }
 
+/**
+ * @deprecated Do not use this function. Instead, resolve the post via the
+ * post repository and use the `repostCount` property
+ */
 export async function getRepostCount(activity: ActivityJsonLd) {
     const objectId = activity.object.id;
 

--- a/src/http/api/profile.ts
+++ b/src/http/api/profile.ts
@@ -1,11 +1,4 @@
-import { createHash } from 'node:crypto';
-import {
-    Activity,
-    type Actor,
-    Announce,
-    CollectionPage,
-    isActor,
-} from '@fedify/fedify';
+import { Activity, type Actor, CollectionPage, isActor } from '@fedify/fedify';
 
 import type { AccountService } from 'account/account.service';
 import { type AppContext, fedify } from 'app';
@@ -256,22 +249,19 @@ export function createGetProfilePostsHandler(
                     activity.object.replyCount = post ? post.replyCount : 0;
                     activity.object.repostCount = post ? post.repostCount : 0;
 
-                    const repostId = apCtx.getObjectUri(Announce, {
-                        id: createHash('sha256')
-                            .update(object.id.toString())
-                            .digest('hex'),
-                    });
-
-                    const reposted =
-                        (await db.get<string[]>(['reposted'])) || [];
-
                     activity.object.liked = post
                         ? await postRepository.isLikedByAccount(
                               post.id!,
                               defaultSiteAccount.id,
                           )
                         : false;
-                    activity.object.reposted = reposted.includes(repostId.href);
+
+                    activity.object.reposted = post
+                        ? await postRepository.isRepostedByAccount(
+                              post.id!,
+                              defaultSiteAccount.id,
+                          )
+                        : false;
                 }
 
                 if (typeof activity.actor === 'string') {

--- a/src/post/post.repository.knex.integration.test.ts
+++ b/src/post/post.repository.knex.integration.test.ts
@@ -977,4 +977,45 @@ describe('KnexPostRepository', () => {
 
         assert(isLiked, 'Post should be liked by account');
     });
+
+    it('Can check if a post is reposted by an account', async () => {
+        const site = await siteService.initialiseSiteForHost(
+            'testing-is-reposted-by-account.com',
+        );
+        const account = await accountRepository.getBySite(site);
+        const reposterAccount = await accountRepository.getBySite(
+            await siteService.initialiseSiteForHost('reposter-site.com'),
+        );
+        const post = Post.createArticleFromGhostPost(account, {
+            title: 'Title',
+            uuid: randomUUID(),
+            html: '<p>Hello, world!</p>',
+            excerpt: 'Hello, world!',
+            custom_excerpt: null,
+            feature_image: null,
+            url: 'https://testing-is-reposted-by-account.com/hello-world',
+            published_at: '2025-04-01',
+            visibility: 'public',
+        });
+
+        post.addRepost(reposterAccount);
+
+        await postRepository.save(post);
+
+        const rowInDb = await client('posts')
+            .where({
+                uuid: post.uuid,
+            })
+            .select('*')
+            .first();
+
+        assert(rowInDb, 'Post should be saved in the DB');
+
+        const isReposted = await postRepository.isRepostedByAccount(
+            rowInDb.id,
+            Number(reposterAccount.id),
+        );
+
+        assert(isReposted, 'Post should be reposted by reposter account');
+    });
 });

--- a/src/post/post.repository.knex.integration.test.ts
+++ b/src/post/post.repository.knex.integration.test.ts
@@ -939,4 +939,42 @@ describe('KnexPostRepository', () => {
             'Attachments should match',
         );
     });
+
+    it('Can check if a post is liked by an account', async () => {
+        const site = await siteService.initialiseSiteForHost(
+            'testing-is-liked-by-account.com',
+        );
+        const account = await accountRepository.getBySite(site);
+        const post = Post.createArticleFromGhostPost(account, {
+            title: 'Title',
+            uuid: randomUUID(),
+            html: '<p>Hello, world!</p>',
+            excerpt: 'Hello, world!',
+            custom_excerpt: null,
+            feature_image: null,
+            url: 'https://testing-is-liked-by-account.com/hello-world',
+            published_at: '2025-04-01',
+            visibility: 'public',
+        });
+
+        post.addLike(account);
+
+        await postRepository.save(post);
+
+        const rowInDb = await client('posts')
+            .where({
+                uuid: post.uuid,
+            })
+            .select('*')
+            .first();
+
+        assert(rowInDb, 'Post should be saved in the DB');
+
+        const isLiked = await postRepository.isLikedByAccount(
+            rowInDb.id,
+            Number(account.id),
+        );
+
+        assert(isLiked, 'Post should be liked by account');
+    });
 });

--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -845,4 +845,22 @@ export class KnexPostRepository {
 
         return result !== undefined;
     }
+
+    /**
+     * Check if a post is reposted by an account
+     *
+     * @param postId ID of the post to check
+     * @param accountId ID of the account to check
+     * @returns True if the post is reposted by the account, false otherwise
+     */
+    async isRepostedByAccount(postId: number, accountId: number) {
+        const result = await this.db('reposts')
+            .where({
+                post_id: postId,
+                account_id: accountId,
+            })
+            .first();
+
+        return result !== undefined;
+    }
 }

--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -827,4 +827,22 @@ export class KnexPostRepository {
             accountIdsInserted: newRepostAccountIds,
         };
     }
+
+    /**
+     * Check if a post is liked by an account
+     *
+     * @param postId ID of the post to check
+     * @param accountId ID of the account to check
+     * @returns True if the post is liked by the account, false otherwise
+     */
+    async isLikedByAccount(postId: number, accountId: number) {
+        const result = await this.db('likes')
+            .where({
+                post_id: postId,
+                account_id: accountId,
+            })
+            .first();
+
+        return result !== undefined;
+    }
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-1022

When computing liked / reposted status on posts retrieved for a remote account, we now use the database instead of the key value store for better efficiency and to move away from using the key value store as a source of this information