### PR TITLE
Converted URLs in Notes to links

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
     "jsonwebtoken": "9.0.2",
     "knex": "3.1.0",
     "ky": "1.7.3",
+    "linkify-html": "4.2.0",
+    "linkifyjs": "4.2.0",
     "mysql2": "3.11.5",
     "node-jose": "2.2.0",
     "sanitize-html": "2.14.0",

--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -223,6 +223,10 @@ export class Post extends BaseEntity {
         if (isPublic === false && ghostPost.html !== null) {
             content = ContentPreparer.prepare(ghostPost.html, {
                 removeMemberContent: true,
+                escapeHtml: false,
+                convertLineBreaks: false,
+                wrapInParagraph: false,
+                extractLinks: false,
             });
 
             if (
@@ -302,6 +306,7 @@ export class Post extends BaseEntity {
             escapeHtml: true,
             convertLineBreaks: true,
             wrapInParagraph: true,
+            extractLinks: true,
         });
 
         return new Post(
@@ -348,6 +353,7 @@ export class Post extends BaseEntity {
             escapeHtml: true,
             convertLineBreaks: true,
             wrapInParagraph: true,
+            extractLinks: true,
         });
 
         return new Post(

--- a/src/publishing/content.ts
+++ b/src/publishing/content.ts
@@ -1,4 +1,5 @@
 import { htmlToText } from 'html-to-text';
+import linkifyHtml from 'linkify-html';
 import { escapeHtml } from '../helpers/html';
 /**
  * Marker to indicate that the proceeding content is member content
@@ -12,19 +13,23 @@ interface PrepareContentOptions {
     /**
      * Whether to remove member content
      */
-    removeMemberContent?: boolean;
+    removeMemberContent: boolean;
     /**
      * Whether to escape HTML
      */
-    escapeHtml?: boolean;
+    escapeHtml: boolean;
     /**
      * Whether to convert line breaks to HTML
      */
-    convertLineBreaks?: boolean;
+    convertLineBreaks: boolean;
     /**
      * Whether to wrap in a paragraph
      */
-    wrapInParagraph?: boolean;
+    wrapInParagraph: boolean;
+    /**
+     * Convert URL's to anchor tags
+     */
+    extractLinks: boolean;
 }
 
 export class ContentPreparer {
@@ -37,6 +42,7 @@ export class ContentPreparer {
             escapeHtml: false,
             convertLineBreaks: false,
             wrapInParagraph: false,
+            extractLinks: false,
         },
     ) {
         return ContentPreparer.instance.prepare(content, options);
@@ -59,6 +65,7 @@ export class ContentPreparer {
             escapeHtml: false,
             convertLineBreaks: false,
             wrapInParagraph: false,
+            extractLinks: false,
         },
     ) {
         let prepared = content;
@@ -71,6 +78,10 @@ export class ContentPreparer {
             prepared = this.escapeHtml(prepared);
         }
 
+        if (options.extractLinks === true) {
+            prepared = this.extractLinks(prepared);
+        }
+
         if (options.convertLineBreaks === true) {
             prepared = this.convertLineBreaks(prepared);
         }
@@ -80,6 +91,18 @@ export class ContentPreparer {
         }
 
         return prepared;
+    }
+
+    /**
+     * Replace URLs in a string with an anchor tag pointing
+     * to the URL and with the text content of the URL
+     */
+    private extractLinks(html: string): string {
+        const options = {
+            defaultProtocol: 'https',
+            attributes: {},
+        };
+        return linkifyHtml(html, options);
     }
 
     /**

--- a/src/publishing/content.unit.test.ts
+++ b/src/publishing/content.unit.test.ts
@@ -5,10 +5,19 @@ describe('ContentPreparer', () => {
     const preparer = new ContentPreparer();
 
     describe('prepare', () => {
+        const allOptionsDisabled = {
+            removeMemberContent: false,
+            escapeHtml: false,
+            convertLineBreaks: false,
+            wrapInParagraph: false,
+            extractLinks: false,
+        };
+
         describe('Removing member content', () => {
             it('should remove member content', () => {
                 const content = `Hello, world!${MEMBER_CONTENT_MARKER}Member content`;
                 const result = preparer.prepare(content, {
+                    ...allOptionsDisabled,
                     removeMemberContent: true,
                 });
 
@@ -27,6 +36,7 @@ describe('ContentPreparer', () => {
             it('should escape HTML', () => {
                 const content = '<p>Hello, world!</p>';
                 const result = preparer.prepare(content, {
+                    ...allOptionsDisabled,
                     escapeHtml: true,
                 });
 
@@ -45,6 +55,7 @@ describe('ContentPreparer', () => {
             it('should convert line breaks to HTML', () => {
                 const content = 'Hello, world!\nThis is a new line';
                 const result = preparer.prepare(content, {
+                    ...allOptionsDisabled,
                     convertLineBreaks: true,
                 });
 
@@ -54,6 +65,7 @@ describe('ContentPreparer', () => {
             it('should convert line breaks to HTML with multiple line breaks', () => {
                 const content = 'Hello, world!\n\nThis is a new line';
                 const result = preparer.prepare(content, {
+                    ...allOptionsDisabled,
                     convertLineBreaks: true,
                 });
 
@@ -74,6 +86,7 @@ describe('ContentPreparer', () => {
             it('should wrap in paragraph', () => {
                 const content = 'Hello, world!';
                 const result = preparer.prepare(content, {
+                    ...allOptionsDisabled,
                     wrapInParagraph: true,
                 });
 

--- a/src/publishing/service.ts
+++ b/src/publishing/service.ts
@@ -106,6 +106,10 @@ export class FedifyPublishingService implements PublishingService {
         if (isPublic === false && post.content !== null) {
             articleContent = this.contentPreparer.prepare(post.content, {
                 removeMemberContent: true,
+                escapeHtml: false,
+                convertLineBreaks: false,
+                wrapInParagraph: false,
+                extractLinks: false,
             });
 
             if (articleContent === post.content) {

--- a/src/publishing/service.unit.test.ts
+++ b/src/publishing/service.unit.test.ts
@@ -265,6 +265,10 @@ describe('FedifyPublishingService', () => {
                 post.content,
                 {
                     removeMemberContent: true,
+                    convertLineBreaks: false,
+                    escapeHtml: false,
+                    extractLinks: false,
+                    wrapInParagraph: false,
                 },
             );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2657,6 +2657,16 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+linkify-html@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/linkify-html/-/linkify-html-4.2.0.tgz#06f78780827d90433424e412976d656912b13fb8"
+  integrity sha512-bVXuLiWmGwvlH95hq6q9DFGqTsQeFSGw/nHmvvjGMZv9T3GqkxuW2d2SOgk/a4DV2ajeS4c37EqlF16cjOj7GA==
+
+linkifyjs@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/linkifyjs/-/linkifyjs-4.2.0.tgz#9dd30222b9cbabec9c950e725ec00031c7fa3f08"
+  integrity sha512-pCj3PrQyATaoTYKHrgWRF3SJwsm61udVh+vuls/Rl6SptiDhgE7ziUIudAedRY9QEfynmM7/RmLEfPUyw1HPCw==
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"


### PR DESCRIPTION
closes https://linear.app/ghost/issue/AP-923

When we create notes and replies we want any URL's to be clickable links for clients, both in Ghost and in third party services like mastodon. In order to ensure this we convert the URL to an anchor tag, which is then used both internally in Ghost & sent as the content over the ActivityPub network.