### PR TITLE
Increased Sentry maxValueLength to 2000

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -19,6 +19,7 @@ if (process.env.SENTRY_DSN) {
         environment: process.env.NODE_ENV || 'unknown',
         release: process.env.K_REVISION,
         tracesSampleRate: 1.0,
+        maxValueLength: 2000,
     });
 
     if (process.env.K_SERVICE) {


### PR DESCRIPTION
We're seeing a bunch of errors in Sentry to do with DB inserts, but they are truncated too short to diagnose the underlying issue as the default value is 250.