### PR TITLE
Removed fallbacks for account bio & icon, improved fallback for name

### DIFF
--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -16,7 +16,6 @@ import { FedifyContextFactory } from '../activitypub/fedify-context.factory';
 import {
     ACTOR_DEFAULT_ICON,
     ACTOR_DEFAULT_NAME,
-    ACTOR_DEFAULT_SUMMARY,
     AP_BASE_PATH,
 } from '../constants';
 import { AccountFollowedEvent } from './account-followed.event';
@@ -135,7 +134,7 @@ describe('AccountService', () => {
             const expectedAccount = {
                 name: internalAccountData.name || ACTOR_DEFAULT_NAME,
                 username: username,
-                bio: internalAccountData.bio || ACTOR_DEFAULT_SUMMARY,
+                bio: internalAccountData.bio || null,
                 avatar_url:
                     internalAccountData.avatar_url || ACTOR_DEFAULT_ICON,
                 url: `https://${site.host}`,

--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -13,11 +13,7 @@ import type { Knex } from 'knex';
 import { generateTestCryptoKeyPair } from 'test/crypto-key-pair';
 import { createTestDb } from 'test/db';
 import { FedifyContextFactory } from '../activitypub/fedify-context.factory';
-import {
-    ACTOR_DEFAULT_ICON,
-    ACTOR_DEFAULT_NAME,
-    AP_BASE_PATH,
-} from '../constants';
+import { ACTOR_DEFAULT_NAME, AP_BASE_PATH } from '../constants';
 import { AccountFollowedEvent } from './account-followed.event';
 import { KnexAccountRepository } from './account.repository.knex';
 import { AccountService } from './account.service';
@@ -135,8 +131,7 @@ describe('AccountService', () => {
                 name: internalAccountData.name || ACTOR_DEFAULT_NAME,
                 username: username,
                 bio: internalAccountData.bio || null,
-                avatar_url:
-                    internalAccountData.avatar_url || ACTOR_DEFAULT_ICON,
+                avatar_url: internalAccountData.avatar_url || null,
                 url: `https://${site.host}`,
                 custom_fields: null,
                 ap_id: `https://${site.host}${AP_BASE_PATH}/users/${username}`,

--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -13,7 +13,7 @@ import type { Knex } from 'knex';
 import { generateTestCryptoKeyPair } from 'test/crypto-key-pair';
 import { createTestDb } from 'test/db';
 import { FedifyContextFactory } from '../activitypub/fedify-context.factory';
-import { ACTOR_DEFAULT_NAME, AP_BASE_PATH } from '../constants';
+import { AP_BASE_PATH } from '../constants';
 import { AccountFollowedEvent } from './account-followed.event';
 import { KnexAccountRepository } from './account.repository.knex';
 import { AccountService } from './account.service';
@@ -67,7 +67,7 @@ describe('AccountService', () => {
 
         // Insert a site
         const siteData = {
-            host: 'example.com',
+            host: 'www.example.com',
             webhook_secret: 'secret',
         };
         const [id] = await db('sites').insert(siteData);
@@ -127,8 +127,9 @@ describe('AccountService', () => {
         it('should create an internal account', async () => {
             const username = internalAccountData.username;
 
+            const normalizedHost = site.host.replace(/^www\./, '');
             const expectedAccount = {
-                name: internalAccountData.name || ACTOR_DEFAULT_NAME,
+                name: internalAccountData.name || normalizedHost,
                 username: username,
                 bio: internalAccountData.bio || null,
                 avatar_url: internalAccountData.avatar_url || null,

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -9,7 +9,7 @@ import type { Knex } from 'knex';
 import { randomUUID } from 'node:crypto';
 import type { AsyncEvents } from 'core/events';
 import type { FedifyContextFactory } from '../activitypub/fedify-context.factory';
-import { ACTOR_DEFAULT_NAME, AP_BASE_PATH } from '../constants';
+import { AP_BASE_PATH } from '../constants';
 import { AccountFollowedEvent } from './account-followed.event';
 import type { Account } from './account.entity';
 import type { KnexAccountRepository } from './account.repository.knex';
@@ -98,8 +98,9 @@ export class AccountService {
         const keyPair = await this.generateKeyPair();
         const username = internalAccountData.username;
 
+        const normalizedHost = site.host.replace(/^www\./, '');
         const accountData = {
-            name: internalAccountData.name || ACTOR_DEFAULT_NAME,
+            name: internalAccountData.name || normalizedHost,
             uuid: randomUUID(),
             username: username,
             bio: internalAccountData.bio || null,

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -12,7 +12,6 @@ import type { FedifyContextFactory } from '../activitypub/fedify-context.factory
 import {
     ACTOR_DEFAULT_ICON,
     ACTOR_DEFAULT_NAME,
-    ACTOR_DEFAULT_SUMMARY,
     AP_BASE_PATH,
 } from '../constants';
 import { AccountFollowedEvent } from './account-followed.event';
@@ -107,7 +106,7 @@ export class AccountService {
             name: internalAccountData.name || ACTOR_DEFAULT_NAME,
             uuid: randomUUID(),
             username: username,
-            bio: internalAccountData.bio || ACTOR_DEFAULT_SUMMARY,
+            bio: internalAccountData.bio || null,
             avatar_url: internalAccountData.avatar_url || ACTOR_DEFAULT_ICON,
             banner_image_url: null,
             url: `https://${site.host}`,

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -9,11 +9,7 @@ import type { Knex } from 'knex';
 import { randomUUID } from 'node:crypto';
 import type { AsyncEvents } from 'core/events';
 import type { FedifyContextFactory } from '../activitypub/fedify-context.factory';
-import {
-    ACTOR_DEFAULT_ICON,
-    ACTOR_DEFAULT_NAME,
-    AP_BASE_PATH,
-} from '../constants';
+import { ACTOR_DEFAULT_NAME, AP_BASE_PATH } from '../constants';
 import { AccountFollowedEvent } from './account-followed.event';
 import type { Account } from './account.entity';
 import type { KnexAccountRepository } from './account.repository.knex';
@@ -107,7 +103,7 @@ export class AccountService {
             uuid: randomUUID(),
             username: username,
             bio: internalAccountData.bio || null,
-            avatar_url: internalAccountData.avatar_url || ACTOR_DEFAULT_ICON,
+            avatar_url: internalAccountData.avatar_url || null,
             banner_image_url: null,
             url: `https://${site.host}`,
             custom_fields: null,

--- a/src/account/types.ts
+++ b/src/account/types.ts
@@ -10,7 +10,7 @@ export interface Site {
 export interface InternalAccountData {
     username: string;
     name?: string;
-    bio?: string;
+    bio: string | null;
     avatar_url?: string;
 }
 

--- a/src/account/types.ts
+++ b/src/account/types.ts
@@ -11,7 +11,7 @@ export interface InternalAccountData {
     username: string;
     name?: string;
     bio: string | null;
-    avatar_url?: string;
+    avatar_url: string | null;
 }
 
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,6 @@ export const AP_BASE_PATH = '/.ghost/activitypub';
 export const ACTOR_DEFAULT_HANDLE = 'index';
 export const ACTOR_DEFAULT_NAME = 'Local Ghost site';
 export const ACTOR_DEFAULT_ICON = 'https://ghost.org/favicon.ico';
-export const ACTOR_DEFAULT_SUMMARY = 'This is a summary';
 
 export const ACTIVITY_TYPE_ANNOUNCE = 'Announce';
 export const ACTIVITY_TYPE_CREATE = 'Create';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,6 @@
 export const AP_BASE_PATH = '/.ghost/activitypub';
 
 export const ACTOR_DEFAULT_HANDLE = 'index';
-export const ACTOR_DEFAULT_NAME = 'Local Ghost site';
 
 export const ACTIVITY_TYPE_ANNOUNCE = 'Announce';
 export const ACTIVITY_TYPE_CREATE = 'Create';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,6 @@ export const AP_BASE_PATH = '/.ghost/activitypub';
 
 export const ACTOR_DEFAULT_HANDLE = 'index';
 export const ACTOR_DEFAULT_NAME = 'Local Ghost site';
-export const ACTOR_DEFAULT_ICON = 'https://ghost.org/favicon.ico';
 
 export const ACTIVITY_TYPE_ANNOUNCE = 'Announce';
 export const ACTIVITY_TYPE_CREATE = 'Create';

--- a/src/helpers/activitypub/actor.ts
+++ b/src/helpers/activitypub/actor.ts
@@ -11,6 +11,7 @@ import type { AccountService } from '../../account/account.service';
 import type { ContextData } from '../../app';
 import { ACTOR_DEFAULT_HANDLE } from '../../constants';
 import type { Site } from '../../site/site.service';
+import type { SiteSettings } from '../ghost';
 import { type UserData, getUserData, setUserData } from '../user';
 
 interface Attachment {
@@ -94,9 +95,7 @@ export function isHandle(handle: string): boolean {
 
 export async function updateSiteActor(
     apCtx: RequestContext<ContextData>,
-    getSiteSettings: (host: string) => Promise<{
-        site: { icon: string; title: string; description: string };
-    }>,
+    getSiteSettings: (host: string) => Promise<SiteSettings>,
 ) {
     const settings = await getSiteSettings(apCtx.host);
     const handle = ACTOR_DEFAULT_HANDLE;

--- a/src/helpers/activitypub/actor.ts
+++ b/src/helpers/activitypub/actor.ts
@@ -104,7 +104,7 @@ export async function updateSiteActor(
 
     if (
         current &&
-        current.icon.url?.toString() === settings.site.icon &&
+        current.icon?.url?.toString() === settings.site.icon &&
         current.name === settings.site.title &&
         current.summary === settings.site.description
     ) {
@@ -118,13 +118,15 @@ export async function updateSiteActor(
         ...current,
     };
 
-    try {
-        updated.icon = new Image({ url: new URL(settings.site.icon) });
-    } catch (err) {
-        apCtx.data.logger.error(
-            'Could not create Image from Icon value ({icon}): {error}',
-            { icon: settings.site.icon, error: err },
-        );
+    if (settings.site.icon) {
+        try {
+            updated.icon = new Image({ url: new URL(settings.site.icon) });
+        } catch (err) {
+            apCtx.data.logger.error(
+                'Could not create Image from Icon value ({icon}): {error}',
+                { icon: settings.site.icon, error: err },
+            );
+        }
     }
 
     updated.name = settings.site.title;

--- a/src/helpers/ghost.ts
+++ b/src/helpers/ghost.ts
@@ -1,14 +1,10 @@
 import ky from 'ky';
 
-import {
-    ACTOR_DEFAULT_ICON,
-    ACTOR_DEFAULT_NAME,
-    ACTOR_DEFAULT_SUMMARY,
-} from '../constants';
+import { ACTOR_DEFAULT_ICON, ACTOR_DEFAULT_NAME } from '../constants';
 
-type SiteSettings = {
+export type SiteSettings = {
     site: {
-        description: string;
+        description: string | null;
         icon: string;
         title: string;
     };
@@ -21,7 +17,7 @@ export async function getSiteSettings(host: string): Promise<SiteSettings> {
 
     return {
         site: {
-            description: settings?.site?.description || ACTOR_DEFAULT_SUMMARY,
+            description: settings?.site?.description || null,
             title: settings?.site?.title || ACTOR_DEFAULT_NAME,
             icon: settings?.site?.icon || ACTOR_DEFAULT_ICON,
         },

--- a/src/helpers/ghost.ts
+++ b/src/helpers/ghost.ts
@@ -1,7 +1,5 @@
 import ky from 'ky';
 
-import { ACTOR_DEFAULT_NAME } from '../constants';
-
 export type SiteSettings = {
     site: {
         description: string | null;
@@ -15,10 +13,11 @@ export async function getSiteSettings(host: string): Promise<SiteSettings> {
         .get(`https://${host}/ghost/api/admin/site/`)
         .json<Partial<SiteSettings>>();
 
+    const normalizedHost = host.replace(/^www\./, '');
     return {
         site: {
             description: settings?.site?.description || null,
-            title: settings?.site?.title || ACTOR_DEFAULT_NAME,
+            title: settings?.site?.title || normalizedHost,
             icon: settings?.site?.icon || null,
         },
     };

--- a/src/helpers/ghost.ts
+++ b/src/helpers/ghost.ts
@@ -1,11 +1,11 @@
 import ky from 'ky';
 
-import { ACTOR_DEFAULT_ICON, ACTOR_DEFAULT_NAME } from '../constants';
+import { ACTOR_DEFAULT_NAME } from '../constants';
 
 export type SiteSettings = {
     site: {
         description: string | null;
-        icon: string;
+        icon: string | null;
         title: string;
     };
 };
@@ -19,7 +19,7 @@ export async function getSiteSettings(host: string): Promise<SiteSettings> {
         site: {
             description: settings?.site?.description || null,
             title: settings?.site?.title || ACTOR_DEFAULT_NAME,
-            icon: settings?.site?.icon || ACTOR_DEFAULT_ICON,
+            icon: settings?.site?.icon || null,
         },
     };
 }

--- a/src/helpers/ghost.unit.test.ts
+++ b/src/helpers/ghost.unit.test.ts
@@ -4,11 +4,7 @@ import ky, { type ResponsePromise } from 'ky';
 
 vi.mock('ky');
 
-import {
-    ACTOR_DEFAULT_ICON,
-    ACTOR_DEFAULT_NAME,
-    ACTOR_DEFAULT_SUMMARY,
-} from '../constants';
+import { ACTOR_DEFAULT_ICON, ACTOR_DEFAULT_NAME } from '../constants';
 import { getSiteSettings } from './ghost';
 
 describe('getSiteSettings', () => {
@@ -36,28 +32,26 @@ describe('getSiteSettings', () => {
         );
     });
 
-    it('should use defaults for missing settings', async () => {
-        let result;
-
-        // Missing description
+    it('sets the description to null if missing', async () => {
         vi.mocked(ky.get).mockReturnValue({
             json: async () => ({
-                site: {
-                    title: 'bar',
-                    icon: 'https://example.com/baz.png',
-                },
+                site: { title: 'bar', icon: 'https://example.com/baz.png' },
             }),
         } as ResponsePromise);
 
-        result = await getSiteSettings(host);
+        const result = await getSiteSettings(host);
 
         expect(result).toEqual({
             site: {
-                description: ACTOR_DEFAULT_SUMMARY,
+                description: null,
                 title: 'bar',
                 icon: 'https://example.com/baz.png',
             },
         });
+    });
+
+    it('should use defaults for missing title & icon settings', async () => {
+        let result;
 
         // Missing title
         vi.mocked(ky.get).mockReturnValue({
@@ -95,21 +89,6 @@ describe('getSiteSettings', () => {
             site: {
                 description: 'foo',
                 title: 'bar',
-                icon: ACTOR_DEFAULT_ICON,
-            },
-        });
-
-        // Missing everything
-        vi.mocked(ky.get).mockReturnValue({
-            json: async () => ({}),
-        } as ResponsePromise);
-
-        result = await getSiteSettings(host);
-
-        expect(result).toEqual({
-            site: {
-                description: ACTOR_DEFAULT_SUMMARY,
-                title: ACTOR_DEFAULT_NAME,
                 icon: ACTOR_DEFAULT_ICON,
             },
         });

--- a/src/helpers/ghost.unit.test.ts
+++ b/src/helpers/ghost.unit.test.ts
@@ -4,7 +4,6 @@ import ky, { type ResponsePromise } from 'ky';
 
 vi.mock('ky');
 
-import { ACTOR_DEFAULT_NAME } from '../constants';
 import { getSiteSettings } from './ghost';
 
 describe('getSiteSettings', () => {
@@ -68,7 +67,7 @@ describe('getSiteSettings', () => {
         });
     });
 
-    it('sets the site icon to a default value if missing', async () => {
+    it('sets the site title to domain name if missing', async () => {
         vi.mocked(ky.get).mockReturnValue({
             json: async () => ({
                 site: {
@@ -83,7 +82,7 @@ describe('getSiteSettings', () => {
         expect(result).toEqual({
             site: {
                 description: 'foo',
-                title: ACTOR_DEFAULT_NAME,
+                title: 'example.com',
                 icon: 'https://example.com/baz.png',
             },
         });

--- a/src/helpers/ghost.unit.test.ts
+++ b/src/helpers/ghost.unit.test.ts
@@ -4,7 +4,7 @@ import ky, { type ResponsePromise } from 'ky';
 
 vi.mock('ky');
 
-import { ACTOR_DEFAULT_ICON, ACTOR_DEFAULT_NAME } from '../constants';
+import { ACTOR_DEFAULT_NAME } from '../constants';
 import { getSiteSettings } from './ghost';
 
 describe('getSiteSettings', () => {
@@ -32,7 +32,7 @@ describe('getSiteSettings', () => {
         );
     });
 
-    it('sets the description to null if missing', async () => {
+    it('sets the site description to null if missing', async () => {
         vi.mocked(ky.get).mockReturnValue({
             json: async () => ({
                 site: { title: 'bar', icon: 'https://example.com/baz.png' },
@@ -50,10 +50,25 @@ describe('getSiteSettings', () => {
         });
     });
 
-    it('should use defaults for missing title & icon settings', async () => {
-        let result;
+    it('sets the site icon to null if missing', async () => {
+        vi.mocked(ky.get).mockReturnValue({
+            json: async () => ({
+                site: { description: 'foo', title: 'bar' },
+            }),
+        } as ResponsePromise);
 
-        // Missing title
+        const result = await getSiteSettings(host);
+
+        expect(result).toEqual({
+            site: {
+                description: 'foo',
+                title: 'bar',
+                icon: null,
+            },
+        });
+    });
+
+    it('sets the site icon to a default value if missing', async () => {
         vi.mocked(ky.get).mockReturnValue({
             json: async () => ({
                 site: {
@@ -63,33 +78,13 @@ describe('getSiteSettings', () => {
             }),
         } as ResponsePromise);
 
-        result = await getSiteSettings(host);
+        const result = await getSiteSettings(host);
 
         expect(result).toEqual({
             site: {
                 description: 'foo',
                 title: ACTOR_DEFAULT_NAME,
                 icon: 'https://example.com/baz.png',
-            },
-        });
-
-        // Missing icon
-        vi.mocked(ky.get).mockReturnValue({
-            json: async () => ({
-                site: {
-                    description: 'foo',
-                    title: 'bar',
-                },
-            }),
-        } as ResponsePromise);
-
-        result = await getSiteSettings(host);
-
-        expect(result).toEqual({
-            site: {
-                description: 'foo',
-                title: 'bar',
-                icon: ACTOR_DEFAULT_ICON,
             },
         });
     });

--- a/src/helpers/user.ts
+++ b/src/helpers/user.ts
@@ -7,7 +7,6 @@ import {
     importJwk,
 } from '@fedify/fedify';
 import type { ContextData } from '../app';
-import { ACTOR_DEFAULT_NAME } from '../constants';
 
 export type PersonData = {
     id: string;
@@ -94,9 +93,10 @@ export async function getUserData(
         }
     }
 
+    const normalizedHost = ctx.host.replace(/^www\./, '');
     const data = {
         id: ctx.getActorUri(handle),
-        name: ACTOR_DEFAULT_NAME,
+        name: normalizedHost,
         summary: null,
         preferredUsername: handle,
         icon: null,

--- a/src/helpers/user.ts
+++ b/src/helpers/user.ts
@@ -7,16 +7,12 @@ import {
     importJwk,
 } from '@fedify/fedify';
 import type { ContextData } from '../app';
-import {
-    ACTOR_DEFAULT_ICON,
-    ACTOR_DEFAULT_NAME,
-    ACTOR_DEFAULT_SUMMARY,
-} from '../constants';
+import { ACTOR_DEFAULT_ICON, ACTOR_DEFAULT_NAME } from '../constants';
 
 export type PersonData = {
     id: string;
     name: string;
-    summary: string;
+    summary: string | null;
     preferredUsername: string;
     icon: string;
     inbox: string;
@@ -30,7 +26,7 @@ export type PersonData = {
 export type UserData = {
     id: URL;
     name: string;
-    summary: string;
+    summary: string | null;
     preferredUsername: string;
     icon: Image;
     inbox: URL;
@@ -100,7 +96,7 @@ export async function getUserData(
     const data = {
         id: ctx.getActorUri(handle),
         name: ACTOR_DEFAULT_NAME,
-        summary: ACTOR_DEFAULT_SUMMARY,
+        summary: null,
         preferredUsername: handle,
         icon: new Image({ url: new URL(ACTOR_DEFAULT_ICON) }),
         inbox: ctx.getInboxUri(handle),

--- a/src/helpers/user.ts
+++ b/src/helpers/user.ts
@@ -7,14 +7,14 @@ import {
     importJwk,
 } from '@fedify/fedify';
 import type { ContextData } from '../app';
-import { ACTOR_DEFAULT_ICON, ACTOR_DEFAULT_NAME } from '../constants';
+import { ACTOR_DEFAULT_NAME } from '../constants';
 
 export type PersonData = {
     id: string;
     name: string;
     summary: string | null;
     preferredUsername: string;
-    icon: string;
+    icon: string | null;
     inbox: string;
     outbox: string;
     following: string;
@@ -28,7 +28,7 @@ export type UserData = {
     name: string;
     summary: string | null;
     preferredUsername: string;
-    icon: Image;
+    icon: Image | null;
     inbox: URL;
     outbox: URL;
     following: URL;
@@ -46,14 +46,15 @@ export async function getUserData(
 
     if (existing) {
         let icon = null;
-        try {
-            icon = new Image({ url: new URL(existing.icon) });
-        } catch (err) {
-            ctx.data.logger.error(
-                'Could not create Image from Icon value ({icon}): {error}',
-                { icon: existing.icon, error: err },
-            );
-            icon = new Image({ url: new URL(ACTOR_DEFAULT_ICON) });
+        if (existing.icon) {
+            try {
+                icon = new Image({ url: new URL(existing.icon) });
+            } catch (err) {
+                ctx.data.logger.error(
+                    'Could not create Image from Icon value ({icon}): {error}',
+                    { icon: existing.icon, error: err },
+                );
+            }
         }
 
         let url = null;
@@ -98,7 +99,7 @@ export async function getUserData(
         name: ACTOR_DEFAULT_NAME,
         summary: null,
         preferredUsername: handle,
-        icon: new Image({ url: new URL(ACTOR_DEFAULT_ICON) }),
+        icon: null,
         inbox: ctx.getInboxUri(handle),
         outbox: ctx.getOutboxUri(handle),
         following: ctx.getFollowingUri(handle),
@@ -121,7 +122,7 @@ export async function setUserData(
     data: UserData,
     handle: string,
 ) {
-    const iconUrl = data.icon.url?.toString() || '';
+    const iconUrl = data.icon?.url?.toString() || null;
     const dataToStore: PersonData = {
         id: data.id.href,
         name: data.name,

--- a/src/helpers/user.unit.test.ts
+++ b/src/helpers/user.unit.test.ts
@@ -2,19 +2,18 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { Image } from '@fedify/fedify';
 
-import { ACTOR_DEFAULT_NAME } from '../constants';
 import { getUserData } from './user';
 
 const HANDLE = 'foo';
-const ACTOR_URI = `https://example.com/${HANDLE}`;
-const INBOX_URI = `https://example.com/${HANDLE}/inbox`;
-const OUTBOX_URI = `https://example.com/${HANDLE}/outbox`;
-const LIKED_URI = `https://example.com/${HANDLE}/liked`;
-const FOLLOWING_URI = `https://example.com/${HANDLE}/following`;
+const ACTOR_URI = `https://www.example.com/${HANDLE}`;
+const INBOX_URI = `https://www.example.com/${HANDLE}/inbox`;
+const OUTBOX_URI = `https://www.example.com/${HANDLE}/outbox`;
+const LIKED_URI = `https://www.example.com/${HANDLE}/liked`;
+const FOLLOWING_URI = `https://www.example.com/${HANDLE}/following`;
 const FOLLOWERS_URI = `https://example.com/${HANDLE}/followers`;
 
 function getCtx() {
-    const host = 'example.com';
+    const host = 'www.example.com';
 
     const ctx = {
         data: {
@@ -72,9 +71,10 @@ describe('getUserData', () => {
 
         const result = await getUserData(ctx, HANDLE);
 
+        const normalizedHost = ctx.host.replace(/^www\./, '');
         const expectedUserData = {
             id: new URL(`https://${ctx.host}/${HANDLE}`),
-            name: ACTOR_DEFAULT_NAME,
+            name: normalizedHost,
             summary: null,
             preferredUsername: HANDLE,
             icon: null,

--- a/src/helpers/user.unit.test.ts
+++ b/src/helpers/user.unit.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { Image } from '@fedify/fedify';
 
-import { ACTOR_DEFAULT_ICON, ACTOR_DEFAULT_NAME } from '../constants';
+import { ACTOR_DEFAULT_NAME } from '../constants';
 import { getUserData } from './user';
 
 const HANDLE = 'foo';
@@ -77,7 +77,7 @@ describe('getUserData', () => {
             name: ACTOR_DEFAULT_NAME,
             summary: null,
             preferredUsername: HANDLE,
-            icon: new Image({ url: new URL(ACTOR_DEFAULT_ICON) }),
+            icon: null,
             inbox: new URL(INBOX_URI),
             outbox: new URL(OUTBOX_URI),
             liked: new URL(LIKED_URI),
@@ -93,7 +93,7 @@ describe('getUserData', () => {
             name: expectedUserData.name,
             summary: expectedUserData.summary,
             preferredUsername: expectedUserData.preferredUsername,
-            icon: ACTOR_DEFAULT_ICON,
+            icon: null,
             inbox: expectedUserData.inbox.href,
             outbox: expectedUserData.outbox.href,
             liked: expectedUserData.liked.href,
@@ -145,7 +145,7 @@ describe('getUserData', () => {
         expect(result).toEqual(expectedUserData);
     });
 
-    it('handles retrieving a user with an invalid icon', async () => {
+    it('handles retrieving a user with a missing icon', async () => {
         const ctx = getCtx();
 
         const persistedUser = {
@@ -169,8 +169,8 @@ describe('getUserData', () => {
             id: new URL(`https://${ctx.host}/${HANDLE}`),
             name: 'foo',
             summary: 'bar',
+            icon: null,
             preferredUsername: HANDLE,
-            icon: new Image({ url: new URL(ACTOR_DEFAULT_ICON) }),
             inbox: new URL(INBOX_URI),
             outbox: new URL(OUTBOX_URI),
             liked: new URL(LIKED_URI),
@@ -184,7 +184,7 @@ describe('getUserData', () => {
         expect(result).toEqual(expectedUserData);
     });
 
-    it('handles retrieving a user with an invalid URL', async () => {
+    it('handles retrieving a user with a missing URL', async () => {
         const ctx = getCtx();
 
         const persistedUser = {

--- a/src/helpers/user.unit.test.ts
+++ b/src/helpers/user.unit.test.ts
@@ -2,11 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { Image } from '@fedify/fedify';
 
-import {
-    ACTOR_DEFAULT_ICON,
-    ACTOR_DEFAULT_NAME,
-    ACTOR_DEFAULT_SUMMARY,
-} from '../constants';
+import { ACTOR_DEFAULT_ICON, ACTOR_DEFAULT_NAME } from '../constants';
 import { getUserData } from './user';
 
 const HANDLE = 'foo';
@@ -79,7 +75,7 @@ describe('getUserData', () => {
         const expectedUserData = {
             id: new URL(`https://${ctx.host}/${HANDLE}`),
             name: ACTOR_DEFAULT_NAME,
-            summary: ACTOR_DEFAULT_SUMMARY,
+            summary: null,
             preferredUsername: HANDLE,
             icon: new Image({ url: new URL(ACTOR_DEFAULT_ICON) }),
             inbox: new URL(INBOX_URI),

--- a/src/site/site.service.ts
+++ b/src/site/site.service.ts
@@ -83,7 +83,7 @@ export class SiteService {
                 username: 'index',
                 name: settings?.site?.title,
                 bio: settings?.site?.description || null,
-                avatar_url: settings?.site?.icon,
+                avatar_url: settings?.site?.icon || null,
             };
 
             await this.accountService.createInternalAccount(

--- a/src/site/site.service.ts
+++ b/src/site/site.service.ts
@@ -82,7 +82,7 @@ export class SiteService {
             const internalAccountData: InternalAccountData = {
                 username: 'index',
                 name: settings?.site?.title,
-                bio: settings?.site?.description,
+                bio: settings?.site?.description || null,
                 avatar_url: settings?.site?.icon,
             };
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-1021

- previously, we used:
    - `"Local Ghost site"` as fallback for the profile name if not site title was available
    - `"This is a summary"` as fallback for the profile bio if no site description was available
    -  the Ghost 16x16 favicon as fallback for the profile icon/avatar if no site logo was available

- now, we use:
    - a normalized domain name as fallback for the profile name, e.g. `mysite.com`
    - no fallback for description (`null`)
    - no fallback for icon/avatar (`null`)