### PR TITLE
Remove duplicate `accounts` rows

### DIFF
--- a/migrate/migrations/000038_remove-duplicate-account-rows.down.sql
+++ b/migrate/migrations/000038_remove-duplicate-account-rows.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE accounts
+DROP INDEX idx_ap_id_hash;
+
+ALTER TABLE accounts
+DROP COLUMN ap_id_hash;

--- a/migrate/migrations/000038_remove-duplicate-account-rows.up.sql
+++ b/migrate/migrations/000038_remove-duplicate-account-rows.up.sql
@@ -1,0 +1,85 @@
+START TRANSACTION;
+
+CREATE TEMPORARY TABLE account_masters (
+    ap_id VARCHAR(255) NOT NULL,
+    master_id BIGINT UNSIGNED NOT NULL,
+    PRIMARY KEY (ap_id, master_id)
+);
+
+INSERT INTO account_masters
+SELECT a.ap_id, MIN(a.id) as master_id
+FROM accounts a
+INNER JOIN users u ON a.id = u.account_id
+GROUP BY a.ap_id;
+
+CREATE TEMPORARY TABLE remaining_ap_ids AS
+SELECT DISTINCT a.ap_id
+FROM accounts a
+LEFT JOIN account_masters am ON a.ap_id = am.ap_id
+WHERE am.ap_id IS NULL;
+
+INSERT INTO account_masters
+SELECT a.ap_id, MIN(a.id) as master_id
+FROM accounts a
+INNER JOIN remaining_ap_ids r ON a.ap_id = r.ap_id
+GROUP BY a.ap_id;
+
+CREATE TEMPORARY TABLE accounts_to_migrate (
+    duplicate_id BIGINT UNSIGNED NOT NULL,
+    master_id BIGINT UNSIGNED NOT NULL,
+    PRIMARY KEY (duplicate_id)
+);
+
+INSERT INTO accounts_to_migrate
+SELECT a.id as duplicate_id, am.master_id
+FROM accounts a
+JOIN account_masters am ON a.ap_id = am.ap_id
+WHERE a.id != am.master_id;
+
+UPDATE feeds t
+JOIN accounts_to_migrate atm ON t.author_id = atm.duplicate_id
+SET t.author_id = atm.master_id;
+
+UPDATE feeds t
+JOIN accounts_to_migrate atm ON t.reposted_by_id = atm.duplicate_id
+SET t.reposted_by_id = atm.master_id;
+
+UPDATE follows t
+JOIN accounts_to_migrate atm ON t.follower_id = atm.duplicate_id
+SET t.follower_id = atm.master_id;
+
+UPDATE follows t
+JOIN accounts_to_migrate atm ON t.following_id = atm.duplicate_id
+SET t.following_id = atm.master_id;
+
+UPDATE notifications t
+JOIN accounts_to_migrate atm ON t.account_id = atm.duplicate_id
+SET t.account_id = atm.master_id;
+
+UPDATE posts t
+JOIN accounts_to_migrate atm ON t.author_id = atm.duplicate_id
+SET t.author_id = atm.master_id;
+
+UPDATE IGNORE likes t
+JOIN accounts_to_migrate atm ON t.account_id = atm.duplicate_id
+SET t.account_id = atm.master_id;
+
+UPDATE IGNORE reposts t
+JOIN accounts_to_migrate atm ON t.account_id = atm.duplicate_id
+SET t.account_id = atm.master_id;
+
+DELETE FROM accounts
+WHERE id IN (SELECT duplicate_id FROM accounts_to_migrate);
+
+ALTER TABLE accounts
+ADD COLUMN ap_id_hash BINARY(32)
+GENERATED ALWAYS AS (UNHEX(SHA2(ap_id, 256))) STORED;
+
+ALTER TABLE accounts
+ADD UNIQUE INDEX idx_ap_id_hash (ap_id_hash);
+
+DROP TEMPORARY TABLE account_masters;
+DROP TEMPORARY TABLE remaining_ap_ids;
+DROP TEMPORARY TABLE accounts_to_migrate;
+
+COMMIT;

--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -143,7 +143,9 @@ export class KnexPostRepository {
 
     async getByApId(apId: URL): Promise<Post | null> {
         return await this.getByQuery((qb: Knex.QueryBuilder) => {
-            return qb.whereRaw('ap_id_hash = UNHEX(SHA2(?, 256))', [apId.href]);
+            return qb.whereRaw('posts.ap_id_hash = UNHEX(SHA2(?, 256))', [
+                apId.href,
+            ]);
         });
     }
 


### PR DESCRIPTION
This is a pretty gnarly migration and has taken a few days to piece together.

We have duplicate (by ap_id) rows in the `accounts` table, which this migration
will clean up completely.

First we create a temporary table `account_masters` which serves as a mapping
between each ap_id and its "master" account, the account that we want to keep.

We populate this initially with internal accounts, using an inner join we only
get ap_ids which have a corresponding row in the users table.

After this we create a list of the remaining ap_ids, and use that to populate
the `account_masters` with the lowest id of each group of ap_ids.

From here we create a temporary table `accounts_to_migrate` which serves as a
mapping between a duplicate account id and its master account id.

Then we update all tables which reference `accounts.id` to update the link from
a duplicate id to the master. Note that for `likes` and `reposts` there is a
unique constraint covering the `account_id` columns - which means it's possible
we violate it when doing the UPDATE. We handle that by doing an UPDATE IGNORE
for these tables, which is safe because we also have an ON DELETE CASCADE
trigger set up for these columns which will be triggered by the next step.

At this point we still have all accounts in our system, however all duplicate
accounts are not referenced anywhere in the database (with the exception of
some rows in the `likes` and `reposts` table as mentioned above), any previous
references have been updated to point at the master account.

We can now delete all duplicate accounts, triggered any ON DELETE CASCADE which
cleans up remaining rows.

In order to prevent this from happening we want to use the same approach as the
`posts` table, so we add an `ap_id_hash` column to the `accounts` table as well
as a UNIQUE constraint over it.