### PR TITLE
Handled missing member content marker in ContentPreparer

### DIFF
--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -229,20 +229,16 @@ export class Post extends BaseEntity {
                 extractLinks: false,
             });
 
+            if (content === '') {
+                throw new Error('Cannot create Post from private content');
+            }
+
             if (
                 ghostPost.custom_excerpt === null ||
                 ghostPost.custom_excerpt === ''
             ) {
                 excerpt = ContentPreparer.regenerateExcerpt(content);
             }
-
-            if (content === ghostPost.html) {
-                content = '';
-            }
-        }
-
-        if (isPublic === false && content === '') {
-            throw new Error('Cannot create Post from private content');
         }
 
         return new Post(

--- a/src/publishing/content.ts
+++ b/src/publishing/content.ts
@@ -180,10 +180,6 @@ export class ContentPreparer {
     private removeMemberContent(content: string) {
         const memberContentIdx = content.indexOf(MEMBER_CONTENT_MARKER);
 
-        if (memberContentIdx !== -1) {
-            return content.substring(0, memberContentIdx);
-        }
-
-        return content;
+        return content.substring(0, memberContentIdx);
     }
 }

--- a/src/publishing/content.unit.test.ts
+++ b/src/publishing/content.unit.test.ts
@@ -24,6 +24,16 @@ describe('ContentPreparer', () => {
                 expect(result).toEqual('Hello, world!');
             });
 
+            it('should remove all content if no marker is found', () => {
+                const content = 'This whole thing is member content';
+                const result = preparer.prepare(content, {
+                    ...allOptionsDisabled,
+                    removeMemberContent: true,
+                });
+
+                expect(result).toEqual('');
+            });
+
             it('should not remove member by default', () => {
                 const content = `Hello, world!${MEMBER_CONTENT_MARKER}Member content`;
                 const result = preparer.prepare(content);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-961

When we do `if (content === post.html) content = ''` we're secretly doing the
removal of member content, for the case where the whole post is member content.

When adding extra steps to the content preparation we may do other
modifications to the content which should not be done if the post
is members only.

Instead the method to remove members content will now remove everything if a
members content marker isn't found. This means that it should never be called
on a public post, this is covered by unit tests in our Post entity.