### PR TITLE
Added various counts onto the `Account` entity

### DIFF
--- a/src/account/account.entity.ts
+++ b/src/account/account.entity.ts
@@ -15,6 +15,11 @@ export interface AccountData {
     apId: URL | null;
     url: URL | null;
     apFollowers: URL | null;
+    postCount: number;
+    repostCount: number;
+    likedPostCount: number;
+    followerCount: number;
+    followingCount: number;
 }
 
 export type AccountSite = {
@@ -39,6 +44,11 @@ export class Account extends BaseEntity {
         apId: URL | null,
         url: URL | null,
         apFollowers: URL | null,
+        public readonly postCount: number,
+        public readonly repostCount: number,
+        public readonly likedPostCount: number,
+        public readonly followerCount: number,
+        public readonly followingCount: number,
     ) {
         super(id);
         if (uuid === null) {
@@ -65,6 +75,10 @@ export class Account extends BaseEntity {
 
     get isInternal() {
         return this.site !== null;
+    }
+
+    get totalPostCount() {
+        return this.postCount + this.repostCount;
     }
 
     getApId() {
@@ -130,6 +144,11 @@ export class Account extends BaseEntity {
             data.apId,
             data.url,
             data.apFollowers,
+            data.postCount,
+            data.repostCount,
+            data.likedPostCount,
+            data.followerCount,
+            data.followingCount,
         );
     }
 }

--- a/src/account/account.entity.unit.test.ts
+++ b/src/account/account.entity.unit.test.ts
@@ -16,6 +16,11 @@ describe('Account', () => {
             new URL('https://foobar.com/user/1234'),
             null,
             new URL('https://foobar.com/followers/1234'),
+            0,
+            0,
+            0,
+            0,
+            0,
         );
 
         expect(account.url).toEqual(account.apId);
@@ -37,6 +42,11 @@ describe('Account', () => {
             null,
             null,
             new URL('https://foobar.com/followers/1234'),
+            0,
+            0,
+            0,
+            0,
+            0,
         );
 
         expect(account.apId.href).toBe(
@@ -61,10 +71,41 @@ describe('Account', () => {
             new URL('https://foobar.com/user/1234'),
             null,
             null,
+            0,
+            0,
+            0,
+            0,
+            0,
         );
 
         expect(account.apFollowers.href).toBe(
             'http://foobar.com/.ghost/activitypub/followers/foobar',
         );
+    });
+
+    it('Can get the total post count', () => {
+        const account = new Account(
+            123,
+            null,
+            'foobar',
+            'Foo Bar',
+            'Just a foobar',
+            new URL('https://foobar.com/avatar/foobar.png'),
+            new URL('https://foobar.com/banner/foobar.png'),
+            {
+                id: 1,
+                host: 'foobar.com',
+            },
+            new URL('https://foobar.com/user/123'),
+            null,
+            null,
+            1,
+            2,
+            0,
+            0,
+            0,
+        );
+
+        expect(account.totalPostCount).toBe(3);
     });
 });

--- a/src/account/account.repository.knex.integration.test.ts
+++ b/src/account/account.repository.knex.integration.test.ts
@@ -1,20 +1,37 @@
-import { beforeAll, describe, it } from 'vitest';
+import { beforeAll, beforeEach, describe, it } from 'vitest';
 
 import assert from 'node:assert';
 import { AsyncEvents } from 'core/events';
 import type { Knex } from 'knex';
 import { generateTestCryptoKeyPair } from 'test/crypto-key-pair';
 import { createTestDb } from 'test/db';
+import {
+    dbCreateAccount,
+    dbCreateFollow,
+    dbCreateLike,
+    dbCreatePost,
+    dbCreateRepost,
+} from 'test/fixtures';
 import { KnexAccountRepository } from '../account/account.repository.knex';
 import { AccountService } from '../account/account.service';
 import { FedifyContextFactory } from '../activitypub/fedify-context.factory';
-import { SiteService } from '../site/site.service';
+import { type Site, SiteService } from '../site/site.service';
 import { Account } from './account.entity';
-
 describe('KnexAccountRepository', () => {
     let client: Knex;
     beforeAll(async () => {
         client = await createTestDb();
+    });
+    beforeEach(async () => {
+        await client.raw('SET FOREIGN_KEY_CHECKS = 0');
+        await client('follows').truncate();
+        await client('likes').truncate();
+        await client('reposts').truncate();
+        await client('posts').truncate();
+        await client('users').truncate();
+        await client('accounts').truncate();
+        await client('sites').truncate();
+        await client.raw('SET FOREIGN_KEY_CHECKS = 1');
     });
     const getSiteDefaultAccount = async (siteId: number) => {
         return await client('accounts')
@@ -30,6 +47,81 @@ describe('KnexAccountRepository', () => {
         const account = await client('accounts').where('id', accountId).first();
 
         assert(account.uuid === null, 'Account should not have a uuid');
+    };
+
+    const setupFixturesForCountTests = async (
+        site: Site,
+        account: { id: number },
+    ) => {
+        // Create accounts that will follow / be followed
+        const followingAccount1 = await dbCreateAccount(client, site);
+        const followingAccount2 = await dbCreateAccount(client, site);
+        const followingAccount3 = await dbCreateAccount(client, site);
+        const followingAccount4 = await dbCreateAccount(client, site);
+        const followingAccount5 = await dbCreateAccount(client, site);
+        const followerAccount1 = await dbCreateAccount(client, site);
+        const followerAccount2 = await dbCreateAccount(client, site);
+        const followerAccount3 = await dbCreateAccount(client, site);
+        const followerAccount4 = await dbCreateAccount(client, site);
+        const followerAccount5 = await dbCreateAccount(client, site);
+        const followerAccount6 = await dbCreateAccount(client, site);
+
+        // Create follows for provided account
+        await dbCreateFollow(client, account, followingAccount1);
+        await dbCreateFollow(client, account, followingAccount2);
+        await dbCreateFollow(client, account, followingAccount3);
+        await dbCreateFollow(client, account, followingAccount4);
+        await dbCreateFollow(client, account, followingAccount5);
+        await dbCreateFollow(client, followerAccount1, account);
+        await dbCreateFollow(client, followerAccount2, account);
+        await dbCreateFollow(client, followerAccount3, account);
+        await dbCreateFollow(client, followerAccount4, account);
+        await dbCreateFollow(client, followerAccount5, account);
+        await dbCreateFollow(client, followerAccount6, account);
+
+        // Create misc follows for created accounts - This is to add extra data
+        // into table so we can ensure the filtering on the count queries is
+        // working as expected
+        await dbCreateFollow(client, followerAccount1, followingAccount1);
+        await dbCreateFollow(client, followerAccount1, followingAccount2);
+        await dbCreateFollow(client, followerAccount2, followingAccount1);
+        await dbCreateFollow(client, followerAccount3, followingAccount1);
+
+        // Create posts for the provided account
+        const post1 = await dbCreatePost(client, account, site);
+        const post2 = await dbCreatePost(client, account, site);
+
+        // Create misc posts for the created accounts
+        const post3 = await dbCreatePost(client, followingAccount1, site);
+        const post4 = await dbCreatePost(client, followingAccount2, site);
+        const post5 = await dbCreatePost(client, followingAccount3, site);
+        const post6 = await dbCreatePost(client, followingAccount4, site);
+        const post7 = await dbCreatePost(client, followingAccount5, site);
+        const post8 = await dbCreatePost(client, followerAccount1, site);
+
+        // Create likes for the provided account
+        await dbCreateLike(client, account, post3);
+        await dbCreateLike(client, account, post4);
+        await dbCreateLike(client, account, post5);
+
+        // Create misc likes for the created accounts - This is to add extra data
+        // into table so we can ensure the filtering on the count queries is
+        // working as expected
+        await dbCreateLike(client, followerAccount3, post1);
+        await dbCreateLike(client, followerAccount3, post2);
+        await dbCreateLike(client, followerAccount4, post2);
+
+        // Create reposts for the provided account
+        await dbCreateRepost(client, account, post5);
+        await dbCreateRepost(client, account, post6);
+        await dbCreateRepost(client, account, post7);
+        await dbCreateRepost(client, account, post8);
+
+        // Create misc reposts for the created accounts - This is to add extra data
+        // into table so we can ensure the filtering on the count queries is
+        // working as expected
+        await dbCreateRepost(client, followerAccount1, post1);
+        await dbCreateRepost(client, followerAccount2, post1);
     };
     it('Can get by site', async () => {
         const events = new AsyncEvents();
@@ -62,6 +154,43 @@ describe('KnexAccountRepository', () => {
             account instanceof Account,
             'An Account should have been fetched',
         );
+    });
+    it('Ensures an account has the correct counts when retrieved by site', async () => {
+        const events = new AsyncEvents();
+        const accountRepository = new KnexAccountRepository(client, events);
+        const fedifyContextFactory = new FedifyContextFactory();
+        const accountService = new AccountService(
+            client,
+            events,
+            accountRepository,
+            fedifyContextFactory,
+            generateTestCryptoKeyPair,
+        );
+        const siteService = new SiteService(client, accountService, {
+            async getSiteSettings(host: string) {
+                return {
+                    site: {
+                        title: 'Test Site',
+                        description: 'A fake site used for testing',
+                        icon: 'https://testing.com/favicon.ico',
+                    },
+                };
+            },
+        });
+
+        const site = await siteService.initialiseSiteForHost('testing.com');
+        const account = await getSiteDefaultAccount(site.id);
+
+        await setupFixturesForCountTests(site, account);
+
+        const result = await accountRepository.getBySite(site);
+
+        assert(result);
+        assert(result.postCount === 2);
+        assert(result.likedPostCount === 3);
+        assert(result.repostCount === 4);
+        assert(result.followingCount === 5);
+        assert(result.followerCount === 6);
     });
     it('Ensures an account has a uuid when retrieved for a site', async () => {
         const events = new AsyncEvents();
@@ -181,5 +310,47 @@ describe('KnexAccountRepository', () => {
 
         assert(result, 'Account should have been found');
         assert(result.uuid !== null, 'Account should have a uuid');
+    });
+    it('Ensures an account has the correct counts when retrieved by apId', async () => {
+        const events = new AsyncEvents();
+        const accountRepository = new KnexAccountRepository(client, events);
+        const fedifyContextFactory = new FedifyContextFactory();
+        const accountService = new AccountService(
+            client,
+            events,
+            accountRepository,
+            fedifyContextFactory,
+            generateTestCryptoKeyPair,
+        );
+        const siteService = new SiteService(client, accountService, {
+            async getSiteSettings(host: string) {
+                return {
+                    site: {
+                        title: 'Test Site',
+                        description: 'A fake site used for testing',
+                        icon: 'https://testing.com/favicon.ico',
+                    },
+                };
+            },
+        });
+
+        const site = await siteService.initialiseSiteForHost('testing.com');
+        const account = await accountRepository.getBySite(site);
+        const row = await client('accounts')
+            .where({ id: account.id })
+            .select('id', 'ap_id')
+            .first();
+        const url = new URL(row.ap_id);
+
+        await setupFixturesForCountTests(site, row);
+
+        const result = await accountRepository.getByApId(url);
+
+        assert(result);
+        assert(result.postCount === 2);
+        assert(result.likedPostCount === 3);
+        assert(result.repostCount === 4);
+        assert(result.followingCount === 5);
+        assert(result.followerCount === 6);
     });
 });

--- a/src/account/account.repository.knex.ts
+++ b/src/account/account.repository.knex.ts
@@ -26,6 +26,33 @@ export class KnexAccountRepository {
         // We can safely assume that there is an account for the user due to
         // the foreign key constraint on the users table
         const account = await this.db('accounts')
+            .select(
+                'accounts.id',
+                'accounts.uuid',
+                'accounts.username',
+                'accounts.name',
+                'accounts.bio',
+                'accounts.avatar_url',
+                'accounts.banner_image_url',
+                'accounts.ap_id',
+                'accounts.url',
+                'accounts.ap_followers_url',
+                this.db.raw(
+                    '(select count(*) from posts where posts.author_id = accounts.id) as post_count',
+                ),
+                this.db.raw(
+                    '(select count(*) from likes where likes.account_id = accounts.id) as like_count',
+                ),
+                this.db.raw(
+                    '(select count(*) from reposts where reposts.account_id = accounts.id) as repost_count',
+                ),
+                this.db.raw(
+                    '(select count(*) from follows where follows.follower_id = accounts.id) as following_count',
+                ),
+                this.db.raw(
+                    '(select count(*) from follows where follows.following_id = accounts.id) as follower_count',
+                ),
+            )
             .where('id', user.account_id)
             .first();
 
@@ -55,6 +82,11 @@ export class KnexAccountRepository {
             parseURL(account.ap_id),
             parseURL(account.url),
             parseURL(account.ap_followers_url),
+            account.post_count,
+            account.repost_count,
+            account.like_count,
+            account.follower_count,
+            account.following_count,
         );
     }
 
@@ -75,6 +107,21 @@ export class KnexAccountRepository {
                 'accounts.ap_followers_url',
                 'users.site_id',
                 'sites.host',
+                this.db.raw(
+                    '(select count(*) from posts where posts.author_id = accounts.id) as post_count',
+                ),
+                this.db.raw(
+                    '(select count(*) from likes where likes.account_id = accounts.id) as like_count',
+                ),
+                this.db.raw(
+                    '(select count(*) from reposts where reposts.account_id = accounts.id) as repost_count',
+                ),
+                this.db.raw(
+                    '(select count(*) from follows where follows.follower_id = accounts.id) as following_count',
+                ),
+                this.db.raw(
+                    '(select count(*) from follows where follows.following_id = accounts.id) as follower_count',
+                ),
             )
             .first();
 
@@ -112,6 +159,11 @@ export class KnexAccountRepository {
             parseURL(accountRow.ap_id),
             parseURL(accountRow.url),
             parseURL(accountRow.ap_followers_url),
+            accountRow.post_count,
+            accountRow.repost_count,
+            accountRow.like_count,
+            accountRow.follower_count,
+            accountRow.following_count,
         );
 
         return account;

--- a/src/feed/feed-update.service.unit.test.ts
+++ b/src/feed/feed-update.service.unit.test.ts
@@ -44,6 +44,11 @@ describe('FeedUpdateService', () => {
             apId: new URL('https://example.com/users/456'),
             url: new URL('https://example.com/users/456'),
             apFollowers: new URL('https://example.com/followers/456'),
+            postCount: 0,
+            repostCount: 0,
+            likedPostCount: 0,
+            followerCount: 0,
+            followingCount: 0,
         });
 
         feedUpdateService = new FeedUpdateService(events, feedService);

--- a/src/http/api/feed.unit.test.ts
+++ b/src/http/api/feed.unit.test.ts
@@ -34,6 +34,11 @@ describe('Feed API', () => {
             apId: new URL('https://example.com/users/456'),
             url: new URL('https://example.com/users/456'),
             apFollowers: new URL('https://example.com/followers/456'),
+            postCount: 0,
+            repostCount: 0,
+            likedPostCount: 0,
+            followerCount: 0,
+            followingCount: 0,
         });
         accountService = {
             getDefaultAccountForSite: async (_site: Site) => {

--- a/src/http/api/helpers/account.unit.test.ts
+++ b/src/http/api/helpers/account.unit.test.ts
@@ -58,6 +58,11 @@ describe('Account Helpers', () => {
                 ),
                 url: new URL('https://example.com/profile'),
                 apFollowers: new URL('https://example.com/followers'),
+                postCount: 0,
+                repostCount: 0,
+                likedPostCount: 0,
+                followerCount: 0,
+                followingCount: 0,
             };
 
             const defaultAccountData = {
@@ -78,6 +83,11 @@ describe('Account Helpers', () => {
                 ),
                 url: new URL('https://example.com/profile'),
                 apFollowers: new URL('https://example.com/followers'),
+                postCount: 0,
+                repostCount: 0,
+                likedPostCount: 0,
+                followerCount: 0,
+                followingCount: 0,
             };
 
             const account = Account.createFromData(accountData);
@@ -135,6 +145,11 @@ describe('Account Helpers', () => {
                 ),
                 url: null,
                 apFollowers: new URL('https://example.com/followers'),
+                postCount: 0,
+                repostCount: 0,
+                likedPostCount: 0,
+                followerCount: 0,
+                followingCount: 0,
             };
 
             const account = Account.createFromData(accountData);
@@ -157,6 +172,11 @@ describe('Account Helpers', () => {
                 ),
                 url: null,
                 apFollowers: new URL('https://example.com/followers'),
+                postCount: 0,
+                repostCount: 0,
+                likedPostCount: 0,
+                followerCount: 0,
+                followingCount: 0,
             };
 
             const defaultAccount = Account.createFromData(defaultAccountData);

--- a/src/http/api/helpers/post.unit.test.ts
+++ b/src/http/api/helpers/post.unit.test.ts
@@ -21,6 +21,11 @@ describe('postToPostDTO', () => {
             new URL('https://foobar.com/user/123'),
             null,
             new URL('https://foobar.com/followers/123'),
+            0,
+            0,
+            0,
+            0,
+            0,
         );
 
         const post = Post.createFromData(author, {
@@ -50,6 +55,11 @@ describe('postToPostDTO', () => {
             new URL('https://foobar.com/user/123'),
             null,
             new URL('https://foobar.com/followers/123'),
+            0,
+            0,
+            0,
+            0,
+            0,
         );
 
         const post = Post.createFromData(author, {

--- a/src/http/api/post.unit.test.ts
+++ b/src/http/api/post.unit.test.ts
@@ -81,6 +81,11 @@ describe('Post API', () => {
             apId: new URL(`https://${site.host}/users/456`),
             url: new URL(`https://${site.host}/users/456`),
             apFollowers: new URL(`https://${site.host}/followers/456`),
+            postCount: 0,
+            repostCount: 0,
+            likedPostCount: 0,
+            followerCount: 0,
+            followingCount: 0,
         });
         postService = {
             getByApId: vi.fn().mockResolvedValue(null),

--- a/src/http/api/thread.unit.test.ts
+++ b/src/http/api/thread.unit.test.ts
@@ -34,6 +34,11 @@ describe('Thread API', () => {
             apId: new URL('https://example.com/users/456'),
             url: new URL('https://example.com/users/456'),
             apFollowers: new URL('https://example.com/followers/456'),
+            postCount: 0,
+            repostCount: 0,
+            likedPostCount: 0,
+            followerCount: 0,
+            followingCount: 0,
         });
         accountService = {
             getDefaultAccountForSite: async (_site: Site) => {

--- a/src/post/post.entity.unit.test.ts
+++ b/src/post/post.entity.unit.test.ts
@@ -21,6 +21,11 @@ function mockAccount(id: number | null, internal: boolean) {
         new URL(`https://foobar.com/user/${id}`),
         null,
         new URL(`https://foobar.com/followers/${id}`),
+        0,
+        0,
+        0,
+        0,
+        0,
     );
 }
 

--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -99,6 +99,11 @@ export class KnexPostRepository {
             parseURL(row.author_ap_id),
             parseURL(row.author_url),
             parseURL(row.author_ap_followers_url),
+            0,
+            0,
+            0,
+            0,
+            0,
         );
 
         // Parse attachments and convert URL strings back to URL objects
@@ -346,6 +351,11 @@ export class KnexPostRepository {
                 parseURL(row.author_ap_id),
                 parseURL(row.author_url),
                 parseURL(row.author_ap_followers_url),
+                0,
+                0,
+                0,
+                0,
+                0,
             );
 
             const attachments = row.attachments

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from 'node:crypto';
+import type { Knex } from 'knex';
+
+let siteCount = 0;
+let accountCount = 0;
+let postCount = 0;
+
+export async function dbCreateSite(db: Knex) {
+    siteCount++;
+
+    const data = {
+        host: `site-${siteCount}.com`,
+        webhook_secret: 'test',
+    };
+
+    const [siteId] = await db('sites').insert(data);
+
+    return {
+        id: siteId,
+        ...data,
+    };
+}
+
+export async function dbCreateAccount(db: Knex, site: { host: string }) {
+    accountCount++;
+
+    const username = `account-${accountCount}`;
+    const uuid = randomUUID();
+    const data = {
+        username,
+        name: `Account ${accountCount}`,
+        bio: `Bio for account ${accountCount}`,
+        avatar_url: `https://${site.host}/${uuid}/avatar.png`,
+        banner_image_url: `https://${site.host}/${uuid}/banner.png`,
+        url: `https://${site.host}/${username}`,
+        ap_id: `https://${site.host}/${uuid}`,
+        ap_inbox_url: `https://${site.host}/${uuid}/inbox`,
+        ap_shared_inbox_url: `https://${site.host}/inbox`,
+        ap_outbox_url: `https://${site.host}/${uuid}/outbox`,
+        ap_following_url: `https://${site.host}/${uuid}/following`,
+        ap_followers_url: `https://${site.host}/${uuid}/followers`,
+        ap_liked_url: `https://${site.host}/${uuid}/liked`,
+        uuid,
+    };
+
+    const [accountId] = await db('accounts').insert(data);
+
+    return {
+        id: accountId,
+        ...data,
+    };
+}
+
+export async function dbCreateUser(
+    db: Knex,
+    account: { id: number },
+    site: { id: number },
+) {
+    const data = {
+        account_id: account.id,
+        site_id: site.id,
+    };
+
+    const [userId] = await db('users').insert(data);
+
+    return {
+        id: userId,
+        ...data,
+    };
+}
+
+export async function dbCreatePost(
+    db: Knex,
+    account: { id: number },
+    site: { host: string },
+) {
+    postCount++;
+
+    const uuid = randomUUID();
+    const data = {
+        uuid,
+        type: 1,
+        audience: 0,
+        author_id: account.id,
+        title: `Post ${postCount}`,
+        excerpt: `Excerpt for post ${postCount}`,
+        content: `<p>Content for post ${postCount}</p>`,
+        url: `https://${site.host}/post/post-${postCount}`,
+        ap_id: `https://${site.host}/post/${uuid}`,
+    };
+
+    const [postId] = await db('posts').insert(data);
+
+    return {
+        id: postId,
+        ...data,
+    };
+}
+
+export async function dbCreateFollow(
+    db: Knex,
+    follower: { id: number },
+    following: { id: number },
+) {
+    const data = {
+        follower_id: follower.id,
+        following_id: following.id,
+    };
+
+    await db('follows').insert(data);
+}
+
+export async function dbCreateLike(
+    db: Knex,
+    account: { id: number },
+    post: { id: number },
+) {
+    const data = {
+        account_id: account.id,
+        post_id: post.id,
+    };
+
+    await db('likes').insert(data);
+}
+
+export async function dbCreateRepost(
+    db: Knex,
+    account: { id: number },
+    post: { id: number },
+) {
+    const data = {
+        account_id: account.id,
+        post_id: post.id,
+    };
+
+    await db('reposts').insert(data);
+}


### PR DESCRIPTION
no ref

Added the following counts onto the `Account` entity:

- `postCount`
- `repostCount`
- `likedPostCount`
- `followerCount`
- `followingCount`

Having these counts on the entity means we can move away from using "helper" methods in services / repositories to retrieve this information from the database. This is particulary useful when we retrieve a "remote" account and we can't utilise the database to retrieve these count values (as we don't have them). This will later come into play when we refactor the account service to fetch account data either locally or remotely and return a single `Account` entity that can be serialised by the controller action.