### PR TITLE
Fixed breaking test on `main`

### DIFF
--- a/src/activitypub/activity.unit.test.ts
+++ b/src/activitypub/activity.unit.test.ts
@@ -9,7 +9,6 @@ import { FedifyActivitySender } from './activity';
 describe('FedifyActivitySender', () => {
     describe('sendActivityToActorFollowers', () => {
         it('should send an Activity to the followers of an Actor', async () => {
-            expect(1).toBe(2);
             const handle = 'foo';
 
             const mockActor = {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-1053

As part of the testing of the slack notification for ci failure we added a breaking test to `main`. This is the cleanup of the broken test.