### PR TITLE
Fixed ActivityPub handles being turned into mailto links

### DIFF
--- a/src/post/content.ts
+++ b/src/post/content.ts
@@ -101,6 +101,9 @@ export class ContentPreparer {
         const options = {
             defaultProtocol: 'https',
             attributes: {},
+            validate(_url: unknown, type: string) {
+                return type === 'url';
+            },
         };
         return linkifyHtml(html, options);
     }

--- a/src/post/post.entity.unit.test.ts
+++ b/src/post/post.entity.unit.test.ts
@@ -226,6 +226,35 @@ describe('Post', () => {
                 '<p>Check out <a href="https://ghost.org">https://ghost.org</a> it is super cool</p>',
             );
         });
+
+        it('does not convert handles to mailto', () => {
+            const account = internalAccount();
+            const inReplyTo = Post.createNote(account, 'Parent');
+            (inReplyTo as any).id = 'fake-id';
+            const content =
+                'I wish I could mention someone like @index@activitypub.ghost.org';
+
+            const note = Post.createReply(account, content, inReplyTo);
+
+            expect(note.type).toBe(PostType.Note);
+
+            expect(note.content).toBe(
+                '<p>I wish I could mention someone like @index@activitypub.ghost.org</p>',
+            );
+        });
+
+        it('does not convert emails to mailto', () => {
+            const account = internalAccount();
+            const inReplyTo = Post.createNote(account, 'Parent');
+            (inReplyTo as any).id = 'fake-id';
+            const content = 'Email me at support@ghost.org';
+
+            const note = Post.createReply(account, content, inReplyTo);
+
+            expect(note.type).toBe(PostType.Note);
+
+            expect(note.content).toBe('<p>Email me at support@ghost.org</p>');
+        });
     });
     describe('createNote', () => {
         it('errors if the account is external', () => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-1054

The linkify-html library was parsing `@user@domain` as an email and converting it into an achore tag with a mail-to attribute. We only want to convert links so we now pass a validation function which only allows the transform of URLs