### PR TITLE
Fixed error for concurrent writes to key_value

### DIFF
--- a/migrate/migrations/000001_create-key-value-table.up.sql
+++ b/migrate/migrations/000001_create-key-value-table.up.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS key_value (
     id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    `key` VARCHAR(2048),
+    `key` VARCHAR(256) UNIQUE,
     value JSON NOT NULL,
     expires DATETIME NULL
 );

--- a/src/knex.kvstore.ts
+++ b/src/knex.kvstore.ts
@@ -41,21 +41,13 @@ export class KnexKvStore implements KvStore {
             value: JSON.stringify(valueToStore),
             expires: null,
         };
-        await this.knex.transaction(async (transaction) => {
-            const exists = await transaction(this.table).where(query).first();
-            if (!exists) {
-                await transaction(this.table).insert({
-                    ...query,
-                    ...values,
-                });
-            } else {
-                await transaction(this.table)
-                    .where(query)
-                    .update({
-                        ...values,
-                    });
-            }
-        });
+        await this.knex(this.table)
+            .insert({
+                ...query,
+                ...values,
+            })
+            .onConflict('key')
+            .merge(['value', 'expires']);
     }
 
     async delete(key: KvKey) {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-1055

A transaction doesn't help us when the row doesn't exist! Instead we can use
MySQLs ON CONFLICT and then merge the values, effectively doing an upsert.

Knex.js does provide an `upsert` method but this is only implemented for MySQL
and CockroachDB - wheras the onConflict works for SQLite and PostgreSQL, giving
us more portability of the code for an inherently uncertain future.