### PR TITLE
Updating `getByApId` to return `Result<Post>` 

### DIFF
--- a/src/activity-handlers/delete.handler.ts
+++ b/src/activity-handlers/delete.handler.ts
@@ -2,7 +2,7 @@ import type { Actor, Context, Delete } from '@fedify/fedify';
 import type { Account } from 'account/account.entity';
 import type { AccountService } from 'account/account.service';
 import type { ContextData } from 'app';
-import type { Post } from 'post/post.entity';
+import { exhaustiveCheck, getError, getValue, isError } from 'core/result';
 import type { KnexPostRepository } from 'post/post.repository.knex';
 import type { PostService } from 'post/post.service';
 import { getRelatedActivities } from '../db';
@@ -59,20 +59,23 @@ export class DeleteHandler {
             return;
         }
 
-        let post: Post | null = null;
+        const postResult = await this.postService.getByApId(
+            deleteActivity.objectId,
+        );
 
-        try {
-            post = await this.postService.getByApId(deleteActivity.objectId);
-        } catch (error) {
-            ctx.data.logger.error('Error fetching post', { error });
-            return;
+        if (isError(postResult)) {
+            const error = getError(postResult);
+            switch (error) {
+                case 'upstream-error':
+                case 'missing-author':
+                case 'not-a-post':
+                    return;
+                default:
+                    return exhaustiveCheck(error);
+            }
         }
 
-        if (post === null) {
-            ctx.data.logger.info('Post not found, exit early');
-            return;
-        }
-
+        const post = getValue(postResult);
         post.delete(senderAccount);
         await this.postRepository.save(post);
 

--- a/src/core/result.ts
+++ b/src/core/result.ts
@@ -41,3 +41,7 @@ export function ok<T>(value: T): Ok<T> {
 export function error<E>(error: E): Error<E> {
     return [error, null];
 }
+
+export function exhaustiveCheck(error: never): never {
+    throw new Error(`Unhandled error case: ${error}`);
+}

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -21,6 +21,7 @@ import {
 import * as Sentry from '@sentry/node';
 import type { KnexAccountRepository } from 'account/account.repository.knex';
 import type { FollowersService } from 'activitypub/followers.service';
+import { exhaustiveCheck, getError, getValue, isError } from 'core/result';
 import { v4 as uuidv4 } from 'uuid';
 import type { AccountService } from './account/account.service';
 import { mapActorToExternalAccountData } from './account/utils';
@@ -371,7 +372,39 @@ export async function handleAnnoucedCreate(
         return;
     }
     // This handles storing the posts in the posts table
-    const post = await postService.getByApId(create.objectId);
+    const postResult = await postService.getByApId(create.objectId);
+
+    if (isError(postResult)) {
+        const error = getError(postResult);
+        switch (error) {
+            case 'upstream-error':
+                ctx.data.logger.info(
+                    'Upstream error fetching post for create handling',
+                    {
+                        postId: create.objectId.href,
+                    },
+                );
+                break;
+            case 'not-a-post':
+                ctx.data.logger.info(
+                    'Resource is not a post in create handling',
+                    {
+                        postId: create.objectId.href,
+                    },
+                );
+                break;
+            case 'missing-author':
+                ctx.data.logger.info(
+                    'Post has missing author in create handling',
+                    {
+                        postId: create.objectId.href,
+                    },
+                );
+                break;
+            default:
+                exhaustiveCheck(error);
+        }
+    }
 
     const object = await create.getObject();
     const replyTarget = await object?.getReplyTarget();
@@ -452,14 +485,45 @@ export const createUndoHandler = (
             }
 
             if (senderAccount !== null) {
-                const originalPost = await postService.getByApId(
+                const originalPostResult = await postService.getByApId(
                     object.objectId,
                 );
 
-                if (originalPost !== null) {
-                    originalPost.removeRepost(senderAccount);
-                    await postRepository.save(originalPost);
+                if (isError(originalPostResult)) {
+                    const error = getError(originalPostResult);
+                    switch (error) {
+                        case 'upstream-error':
+                            ctx.data.logger.info(
+                                'Upstream error fetching post for undoing announce',
+                                {
+                                    postId: object.objectId.href,
+                                },
+                            );
+                            break;
+                        case 'not-a-post':
+                            ctx.data.logger.info(
+                                'Resource is not a post in undoing announce',
+                                {
+                                    postId: object.objectId.href,
+                                },
+                            );
+                            break;
+                        case 'missing-author':
+                            ctx.data.logger.info(
+                                'Post has missing author in undoing announce',
+                                {
+                                    postId: object.objectId.href,
+                                },
+                            );
+                            break;
+                        default:
+                            return exhaustiveCheck(error);
+                    }
+                    return;
                 }
+                const originalPost = getValue(originalPostResult);
+                originalPost.removeRepost(senderAccount);
+                await postRepository.save(originalPost);
             }
         }
 
@@ -590,9 +654,40 @@ export function createAnnounceHandler(
 
         if (senderAccount !== null) {
             // This will save the post if it doesn't already exist
-            const post = await postService.getByApId(announce.objectId);
+            const postResult = await postService.getByApId(announce.objectId);
 
-            if (post !== null) {
+            if (isError(postResult)) {
+                const error = getError(postResult);
+                switch (error) {
+                    case 'upstream-error':
+                        ctx.data.logger.info(
+                            'Upstream error fetching post for reposting',
+                            {
+                                postId: announce.objectId.href,
+                            },
+                        );
+                        break;
+                    case 'not-a-post':
+                        ctx.data.logger.info(
+                            'Resource for reposting is not a post',
+                            {
+                                postId: announce.objectId.href,
+                            },
+                        );
+                        break;
+                    case 'missing-author':
+                        ctx.data.logger.info(
+                            'Post for reposting has missing author',
+                            {
+                                postId: announce.objectId.href,
+                            },
+                        );
+                        break;
+                    default:
+                        return exhaustiveCheck(error);
+                }
+            } else {
+                const post = getValue(postResult);
                 post.addRepost(senderAccount);
                 await postRepository.save(post);
             }
@@ -637,11 +732,42 @@ export function createLikeHandler(
 
         const account = await accountService.getByApId(like.actorId);
         if (account !== null) {
-            const post = await postService.getByApId(like.objectId);
+            const postResult = await postService.getByApId(like.objectId);
 
-            if (post !== null) {
+            if (isError(postResult)) {
+                const error = getError(postResult);
+                switch (error) {
+                    case 'upstream-error':
+                        ctx.data.logger.info(
+                            'Upstream error fetching post for liking',
+                            {
+                                postId: like.objectId.href,
+                            },
+                        );
+                        break;
+                    case 'not-a-post':
+                        ctx.data.logger.info(
+                            'Resource for liking is not a post',
+                            {
+                                postId: like.objectId.href,
+                            },
+                        );
+                        break;
+                    case 'missing-author':
+                        ctx.data.logger.info(
+                            'Post for liking has missing author',
+                            {
+                                postId: like.objectId.href,
+                            },
+                        );
+                        break;
+                    default: {
+                        return exhaustiveCheck(error);
+                    }
+                }
+            } else {
+                const post = getValue(postResult);
                 post.addLike(account);
-
                 await postRepository.save(post);
             }
         }

--- a/src/http/api/post.unit.test.ts
+++ b/src/http/api/post.unit.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Account } from 'account/account.entity';
 import type { AccountService } from 'account/account.service';
 import type { AppContext } from 'app';
+import { error, ok } from 'core/result';
 import { Audience, Post, PostType } from 'post/post.entity';
 import type { PostService } from 'post/post.service';
 import type { Site } from 'site/site.service';
@@ -86,7 +87,7 @@ describe('Post API', () => {
             apFollowers: new URL(`https://${site.host}/followers/456`),
         });
         postService = {
-            getByApId: vi.fn().mockResolvedValue(null),
+            getByApId: vi.fn().mockResolvedValue(error('not-a-post')),
             isLikedByAccount: vi.fn().mockResolvedValue(false),
             isRepostedByAccount: vi.fn().mockResolvedValue(false),
         } as unknown as PostService;
@@ -101,10 +102,10 @@ describe('Post API', () => {
 
         postService.getByApId = vi.fn().mockImplementation((_postApId) => {
             if (_postApId.href === postApId) {
-                return createPost(postId);
+                return ok(createPost(postId));
             }
 
-            return null;
+            return error('not-a-post');
         });
 
         accountService.getDefaultAccountForSite = vi
@@ -129,10 +130,10 @@ describe('Post API', () => {
 
         postService.getByApId = vi.fn().mockImplementation((_postApId) => {
             if (_postApId.href === postApId) {
-                return createPost(postId);
+                return ok(createPost(postId));
             }
 
-            return null;
+            return error('not-a-post');
         });
 
         accountService.getDefaultAccountForSite = vi
@@ -157,10 +158,10 @@ describe('Post API', () => {
 
         postService.getByApId = vi.fn().mockImplementation((_postApId) => {
             if (_postApId.href === postApId) {
-                return createPost(postId);
+                return ok(createPost(postId));
             }
 
-            return null;
+            return error('not-a-post');
         });
 
         postService.isLikedByAccount = vi
@@ -194,10 +195,10 @@ describe('Post API', () => {
 
         postService.getByApId = vi.fn().mockImplementation((_postApId) => {
             if (_postApId.href === postApId) {
-                return createPost(postId);
+                return ok(createPost(postId));
             }
 
-            return null;
+            return error('not-a-post');
         });
 
         postService.isRepostedByAccount = vi
@@ -240,7 +241,7 @@ describe('Post API', () => {
 
         const ctx = getMockAppContext(postApId);
 
-        postService.getByApId = vi.fn().mockResolvedValue(null);
+        postService.getByApId = vi.fn().mockResolvedValue(error('not-a-post'));
 
         const handler = createGetPostHandler(postService, accountService);
         const response = await handler(ctx);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-1045

This uses our new Result type to make sure that we handle all possible errors,
and we no longer return 500's for any of these "expected" errors. If/when we
find that there are still 500's created from this flow, we should explicitly
catch and return these errors and handle them