### PR TITLE
Added initial Result implementation

### DIFF
--- a/src/core/result.ts
+++ b/src/core/result.ts
@@ -1,0 +1,43 @@
+export type Ok<T> = [null, T];
+export type Error<E> = [E, null];
+export type Result<T, E> = Ok<T> | Error<E>;
+
+/**
+ * A type predicate for the Error type
+ * ```ts
+ * if (isError(result)) {
+ *   // can safely call `getError(result)` here
+ * } else {
+ *   // can safely call `getValue(result)` here
+ * }
+ * ```
+ */
+export function isError<E>(input: Result<unknown, E>): input is Error<E> {
+    return input[1] === null;
+}
+
+export function getValue<T>(input: Ok<T>): T {
+    return input[1];
+}
+
+export function getError<E>(input: Error<E>): E {
+    return input[0];
+}
+
+/**
+ * Returns the value of a result, or throws the error if present.
+ */
+export function unsafeUnwrap<T>(input: Result<T, unknown>): T {
+    if (isError(input)) {
+        throw getError(input);
+    }
+    return getValue(input);
+}
+
+export function ok<T>(value: T): Ok<T> {
+    return [null, value];
+}
+
+export function error<E>(error: E): Error<E> {
+    return [error, null];
+}


### PR DESCRIPTION
We want to stop throwing Errors and instead returning Results from our methods in an effor to force us to handle errors explicitly and correctly. This is because we're working in a decentralised system where errors are abundant and expected, and we want to make them first class citizens of our application.

The current state of the system of throwing errors is leading to a lot of 500 errors in production, most of which can and should be handled at the application level, rather than bubbling up.

This implementation is very small and essentially boils down to 2 element tuples containing either null and the value, or an error and null.

A few helper functions have been provided to make the DX a little better, with the idea being that we can either build this up, or replace it with a library once we have a better understanding of our use-cases and desired feature set.