### PR TITLE
Banned use of explicit any

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -28,9 +28,7 @@
         "noNonNullAssertion": "off"
       },
       "suspicious": {
-        "noConsoleLog": "off",
-        "noExplicitAny": "warn",
-        "noImplicitAnyLet": "warn"
+        "noConsoleLog": "off"
       }
     }
   },

--- a/cedar/query-runner/src/app.ts
+++ b/cedar/query-runner/src/app.ts
@@ -43,6 +43,8 @@ const warmupPool = async () => {
     console.timeEnd('Warmup');
 };
 
+// TODO: Clean up the any type
+// biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
 const timeQuery = async (query: string, args: any[]) => {
     //: { [key: string]: string }) => {
     const start = performance.now();
@@ -51,6 +53,8 @@ const timeQuery = async (query: string, args: any[]) => {
     return end - start;
 };
 
+// TODO: Clean up the any type
+// biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
 const runQuery = async (query: string, args: any[]) => {
     // { [key: string]: string }) => {
     const runTimes: number[] = Array(SERIES_RUNS).fill(

--- a/src/activity-handlers/create.handler.ts
+++ b/src/activity-handlers/create.handler.ts
@@ -44,6 +44,8 @@ export class CreateHandler {
         const replyTarget = await object?.getReplyTarget();
 
         if (replyTarget?.id?.href) {
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             const data = await ctx.data.globaldb.get<any>([
                 replyTarget.id.href,
             ]);

--- a/src/app.ts
+++ b/src/app.ts
@@ -297,6 +297,8 @@ function ensureCorrectContext<B, R>(
     return async (ctx: Context<ContextData>, b: B) => {
         const host = ctx.host;
         if (!ctx.data) {
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             (ctx as any).data = {};
         }
         if (!ctx.data.globaldb) {

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -1,6 +1,8 @@
 import EventEmitter from 'node:events';
 
 export class AsyncEvents extends EventEmitter {
+    // TODO: Clean up the any type
+    // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
     async emitAsync(eventName: string, ...args: any[]): Promise<boolean> {
         const handlers = this.listeners(eventName);
         if (handlers.length === 0) {

--- a/src/db.ts
+++ b/src/db.ts
@@ -25,6 +25,8 @@ export const client = Knex({
 });
 
 interface ActivityJsonLd {
+    // TODO: Clean up the any type
+    // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
     [key: string]: any;
 }
 

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -377,6 +377,8 @@ export async function handleAnnoucedCreate(
     const replyTarget = await object?.getReplyTarget();
 
     if (replyTarget?.id?.href) {
+        // TODO: Clean up the any type
+        // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
         const data = await ctx.data.globaldb.get<any>([replyTarget.id.href]);
         const replyTargetAuthor = data?.attributedTo?.id;
         const inboxActor = await getUserData(ctx, 'index');
@@ -954,8 +956,12 @@ export async function likedDispatcher(
                         object:
                             | string
                             | {
+                                  // TODO: Clean up the any type
+                                  // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
                                   [key: string]: any;
                               };
+                        // TODO: Clean up the any type
+                        // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
                         [key: string]: any;
                     }>([result]);
 

--- a/src/dispatchers.unit.test.ts
+++ b/src/dispatchers.unit.test.ts
@@ -28,6 +28,8 @@ vi.mock('./app', () => ({
 describe('dispatchers', () => {
     describe('actorDispatcher', () => {
         it(`returns null if the handle is not "${ACTOR_DEFAULT_HANDLE}"`, async () => {
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             const ctx = {} as RequestContext<any>;
             const handle = 'anything';
 
@@ -42,6 +44,8 @@ describe('dispatchers', () => {
     });
 
     describe('likedDispatcher', () => {
+        // TODO: Clean up the any type
+        // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
         const likeActivities: Record<string, any> = {
             'https://example.com/like/123': {
                 '@context': [
@@ -81,6 +85,8 @@ describe('dispatchers', () => {
                     info: vi.fn(),
                 },
             },
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
         } as RequestContext<any>;
 
         beforeEach(() => {
@@ -147,6 +153,8 @@ describe('dispatchers', () => {
         it('hydrates the object of a like', async () => {
             const actorId = 'https://example.com/actor/123';
 
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             const likeActivities: Record<string, any> = {
                 'https://example.com/like/123': {
                     '@context': [
@@ -262,6 +270,8 @@ describe('dispatchers', () => {
                     error: vi.fn(),
                 },
             },
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
         } as RequestContext<any>;
 
         beforeEach(() => {
@@ -328,6 +338,8 @@ describe('dispatchers', () => {
 
     describe('nodeInfoDispatcher', () => {
         it('returns the node info', async () => {
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             const result = await nodeInfoDispatcher({} as RequestContext<any>);
 
             expect(result).toEqual({

--- a/src/helpers/activitypub/activity.ts
+++ b/src/helpers/activitypub/activity.ts
@@ -17,12 +17,16 @@ export interface ActivityObject {
     id: string;
     content: string;
     attachment?: ActivityObjectAttachment | ActivityObjectAttachment[];
+    // TODO: Clean up the any type
+    // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
     [key: string]: any;
 }
 
 export interface Activity {
     id: string;
     object: string | ActivityObject;
+    // TODO: Clean up the any type
+    // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
     [key: string]: any;
 }
 

--- a/src/helpers/user.ts
+++ b/src/helpers/user.ts
@@ -144,6 +144,8 @@ export async function getUserKeypair(
     ctx: Context<ContextData>,
     handle: string,
 ) {
+    // TODO: Clean up the any types
+    // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
     const existing = await ctx.data.db.get<{ publicKey: any; privateKey: any }>(
         ['keypair', handle],
     );

--- a/src/helpers/user.unit.test.ts
+++ b/src/helpers/user.unit.test.ts
@@ -60,6 +60,8 @@ function getCtx() {
         return handle === HANDLE ? new URL(FOLLOWERS_URI) : undefined;
     });
 
+    // TODO: Clean up the any type
+    // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
     return ctx as any;
 }
 

--- a/src/http/api/helpers/account.ts
+++ b/src/http/api/helpers/account.ts
@@ -83,6 +83,8 @@ export async function getAccountDTOByHandle(
         throw new Error('Actor not found');
     }
 
+    // TODO: Clean up the any type
+    // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
     const actor: any = await actorObj.toJsonLd();
 
     const [followerCount, followingCount, isFollowingResult, attachments] =

--- a/src/http/api/helpers/account.unit.test.ts
+++ b/src/http/api/helpers/account.unit.test.ts
@@ -234,6 +234,8 @@ describe('Account Helpers', () => {
                 getAttachments as unknown as ReturnType<typeof vi.fn>
             ).mockResolvedValue([]);
 
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             const apCtx = {} as Context<any>;
             const site = {} as Site;
             const accountService = {
@@ -267,8 +269,12 @@ describe('Account Helpers', () => {
         });
 
         it('should throw error for empty handle', async () => {
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             const apCtx = {} as Context<any>;
             const site = {} as Site;
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             const accountService = {} as any;
 
             await expect(
@@ -281,8 +287,12 @@ describe('Account Helpers', () => {
                 lookupObject as unknown as ReturnType<typeof vi.fn>
             ).mockResolvedValue(null);
 
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             const apCtx = {} as Context<any>;
             const site = {} as Site;
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             const accountService = {} as any;
 
             await expect(

--- a/src/http/api/views/account.follows.view.ts
+++ b/src/http/api/views/account.follows.view.ts
@@ -195,6 +195,8 @@ export class AccountFollowsView {
             for await (const item of page.getItems()) {
                 const actor = (await item.toJsonLd({
                     format: 'compact',
+                    // TODO: Clean up the any type
+                    // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
                 })) as any;
 
                 const followeeAccount = await this.db('accounts')

--- a/src/kv-helpers.ts
+++ b/src/kv-helpers.ts
@@ -10,6 +10,8 @@ export function scopeKvStore(db: KvStore, scope: KvKey): KvStore {
         get(key: KvKey) {
             return db.get(scopeKvKey(scope, key));
         },
+        // TODO: Clean up the any type
+        // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
         set(key: KvKey, value: any) {
             return db.set(scopeKvKey(scope, key), value);
         },

--- a/src/lookup-helpers.unit.test.ts
+++ b/src/lookup-helpers.unit.test.ts
@@ -36,6 +36,8 @@ describe('lookupAPIdByHandle', () => {
         ).mockResolvedValue(mockWebFingerResponse);
 
         const result = await lookupAPIdByHandle(
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             mockCtx as any,
             '@user@example.com',
         );
@@ -54,6 +56,8 @@ describe('lookupAPIdByHandle', () => {
         ).mockResolvedValue(mockWebFingerResponse);
 
         const result = await lookupAPIdByHandle(
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             mockCtx as any,
             'user@example.com',
         );
@@ -77,6 +81,8 @@ describe('lookupAPIdByHandle', () => {
         ).mockResolvedValue(mockWebFingerResponse);
 
         const result = await lookupAPIdByHandle(
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             mockCtx as any,
             'user@example.com',
         );
@@ -90,6 +96,8 @@ describe('lookupAPIdByHandle', () => {
         ).mockRejectedValue(new Error('WebFinger lookup failed'));
 
         const result = await lookupAPIdByHandle(
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             mockCtx as any,
             'user@example.com',
         );
@@ -118,6 +126,8 @@ describe('lookupAPIdByHandle', () => {
         ).mockResolvedValue(mockWebFingerResponse);
 
         const result = await lookupAPIdByHandle(
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             mockCtx as any,
             'user@example.com',
         );

--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -152,6 +152,8 @@ export class Post extends BaseEntity {
     }
 
     private handleDeleted() {
+        // TODO: Clean up the any type
+        // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
         const self = this as any;
         self.type = PostType.Tombstone;
         self.title = null;

--- a/src/post/post.entity.unit.test.ts
+++ b/src/post/post.entity.unit.test.ts
@@ -190,6 +190,8 @@ describe('Post', () => {
         it('creates a note with html content', () => {
             const account = internalAccount();
             const inReplyTo = Post.createNote(account, 'Parent');
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             (inReplyTo as any).id = 'fake-id';
             const content = 'My first note';
 
@@ -203,6 +205,8 @@ describe('Post', () => {
         it('creates a note with line breaks', () => {
             const account = internalAccount();
             const inReplyTo = Post.createNote(account, 'Parent');
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             (inReplyTo as any).id = 'fake-id';
             const content = `My
                             first
@@ -218,6 +222,8 @@ describe('Post', () => {
         it('creates a note with escaped html', () => {
             const account = internalAccount();
             const inReplyTo = Post.createNote(account, 'Parent');
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             (inReplyTo as any).id = 'fake-id';
             const content = '<script>alert("hax")</script> Hello, world!';
 
@@ -233,6 +239,8 @@ describe('Post', () => {
         it('creates a note with links', () => {
             const account = internalAccount();
             const inReplyTo = Post.createNote(account, 'Parent');
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             (inReplyTo as any).id = 'fake-id';
             const content = 'Check out https://ghost.org it is super cool';
 
@@ -248,6 +256,8 @@ describe('Post', () => {
         it('does not convert handles to mailto', () => {
             const account = internalAccount();
             const inReplyTo = Post.createNote(account, 'Parent');
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             (inReplyTo as any).id = 'fake-id';
             const content =
                 'I wish I could mention someone like @index@activitypub.ghost.org';
@@ -264,6 +274,8 @@ describe('Post', () => {
         it('does not convert emails to mailto', () => {
             const account = internalAccount();
             const inReplyTo = Post.createNote(account, 'Parent');
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             (inReplyTo as any).id = 'fake-id';
             const content = 'Email me at support@ghost.org';
 

--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -104,10 +104,16 @@ export class KnexPostRepository {
 
         // Parse attachments and convert URL strings back to URL objects
         const attachments = row.attachments
-            ? row.attachments.map((attachment: any) => ({
-                  ...attachment,
-                  url: new URL(attachment.url),
-              }))
+            ? row.attachments.map(
+                  (
+                      // TODO: Clean up the any type
+                      // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
+                      attachment: any,
+                  ) => ({
+                      ...attachment,
+                      url: new URL(attachment.url),
+                  }),
+              )
             : [];
 
         const post = new Post(
@@ -353,10 +359,16 @@ export class KnexPostRepository {
             );
 
             const attachments = row.attachments
-                ? row.attachments.map((attachment: any) => ({
-                      ...attachment,
-                      url: new URL(attachment.url),
-                  }))
+                ? row.attachments.map(
+                      (
+                          // TODO: Clean up the any type
+                          // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
+                          attachment: any,
+                      ) => ({
+                          ...attachment,
+                          url: new URL(attachment.url),
+                      }),
+                  )
                 : [];
 
             const post = new Post(
@@ -430,6 +442,8 @@ export class KnexPostRepository {
                 );
 
                 // Hacks? Mutate the Post so `isNew` returns false.
+                // TODO: Clean up the any type
+                // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
                 (post as any).id = id;
 
                 if (isDuplicate) {

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -148,6 +148,8 @@ export class PostService {
      * @param accountId Current account ID
      * @returns PostDTO object
      */
+    // TODO: Clean up the any type
+    // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
     private mapActivityToPostDTO(activity: any): PostDTO {
         const object = activity.object;
         const actor = activity.actor;
@@ -658,6 +660,8 @@ export class PostService {
 
                 const activity = (await item.toJsonLd({
                     format: 'compact',
+                    // TODO: Clean up the any type
+                    // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
                 })) as any;
 
                 if (activity.object.inReplyTo) {

--- a/src/post/post.service.unit.test.ts
+++ b/src/post/post.service.unit.test.ts
@@ -97,6 +97,8 @@ describe('PostService', () => {
                 },
             };
 
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             const result = (postService as any).mapActivityToPostDTO(activity);
 
             expect(result).toEqual({
@@ -159,6 +161,8 @@ describe('PostService', () => {
                 },
             };
 
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
             const result = (postService as any).mapActivityToPostDTO(activity);
 
             expect(result).toEqual({


### PR DESCRIPTION
We had this set to warning to allow our legacy code to pass lint, but this has result in more uses of explicit any being added to the codebase. The approach here is to add comments to allow the existing cases but ban all new cases.