### PR TITLE
Stripped dubdubdub prefix from handles

### DIFF
--- a/src/account/utils.ts
+++ b/src/account/utils.ts
@@ -75,5 +75,5 @@ export async function mapActorToExternalAccountData(
  * @param username Username of the account
  */
 export function getAccountHandle(host?: string, username?: string) {
-    return `@${username || 'unknown'}@${host || 'unknown'}`;
+    return `@${username || 'unknown'}@${host?.replace(/^www\./, '') || 'unknown'}`;
 }

--- a/src/account/utils.unit.test.ts
+++ b/src/account/utils.unit.test.ts
@@ -70,13 +70,13 @@ describe('mapActorToExternalAccountData', () => {
 
 describe('getAccountHandle', () => {
     it('should return a handle for an account with a username', () => {
-        const handle = getAccountHandle('example.com', 'example');
+        const handle = getAccountHandle('www.example.com', 'example');
 
         expect(handle).toBe('@example@example.com');
     });
 
     it('should return a handle for an account with no username', () => {
-        const handle = getAccountHandle('example.com', '');
+        const handle = getAccountHandle('www.example.com', '');
 
         expect(handle).toBe('@unknown@example.com');
     });

--- a/src/http/api/views/account.follows.view.integration.test.ts
+++ b/src/http/api/views/account.follows.view.integration.test.ts
@@ -135,7 +135,7 @@ describe('AccountFollowsView', () => {
             expect(result.accounts[0]).toMatchObject({
                 id: String(following2.id),
                 name: 'Following Two',
-                handle: `@following2@${new URL(following2.ap_id).host}`,
+                handle: '@following2@example.com',
                 avatarUrl: following2.avatar_url,
                 isFollowing: false,
             });
@@ -183,7 +183,7 @@ describe('AccountFollowsView', () => {
             );
             expect(follower2Result).toMatchObject({
                 name: 'Follower Two',
-                handle: `@follower2@${new URL(follower2.ap_id).host}`,
+                handle: '@follower2@example.com',
                 avatarUrl: follower2.avatar_url,
                 isFollowing: true,
             });
@@ -192,7 +192,7 @@ describe('AccountFollowsView', () => {
             );
             expect(follower1Result).toMatchObject({
                 name: 'Follower One',
-                handle: `@follower1@${new URL(follower1.ap_id).host}`,
+                handle: '@follower1@example.com',
                 avatarUrl: follower1.avatar_url,
                 isFollowing: false,
             });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-963

All of the handles generated by us now no longer have a www. in the host. By updating this util we ensure that handles throughout the application have this www. prefix stripped.

This includes handles external to the our service, which means we may show incorrect handles in the UI for external sites, however we've deemed this to be an edge case for now, and in the case of a bug, it's purely a cosmetic one, those account can still be searched and interacted with using their handle.