### PR TITLE
Stripped dubdubdub prefix from handles

### DIFF
--- a/src/helpers/activitypub/actor.ts
+++ b/src/helpers/activitypub/actor.ts
@@ -58,7 +58,7 @@ export async function getFollowingCount(actor: Actor): Promise<number> {
 }
 
 export function getHandle(actor: Actor): string {
-    const host = actor.id?.host || 'unknown';
+    const host = actor.id?.host?.replace(/^www./, '') || 'unknown';
 
     return `@${actor?.preferredUsername || 'unknown'}@${host}`;
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-963
ref 0935a1f551fafda3e74df4b58047bc3f200e774d

This was missed as part of the referenced commit

All of the handles generated by us now no longer have a www. in the host. By updating this util we ensure that handles throughout the application have this www. prefix stripped.

This includes handles external to the our service, which means we may show incorrect handles in the UI for external sites, however we've deemed this to be an edge case for now, and in the case of a bug, it's purely a cosmetic one, those account can still be searched and interacted with using their handle.