### PR TITLE
Added handling for feed post removal when account blocked

### DIFF
--- a/src/account/account-blocked.event.ts
+++ b/src/account/account-blocked.event.ts
@@ -2,16 +2,16 @@ import type { Account } from 'account/account.entity';
 
 export class AccountBlockedEvent {
     constructor(
-        private readonly actor: Account,
-        private readonly blocked: Account,
+        private readonly account: Account,
+        private readonly blocker: Account,
     ) {}
 
-    getActor(): Account {
-        return this.actor;
+    getAccount(): Account {
+        return this.account;
     }
 
-    getBlocked(): Account {
-        return this.blocked;
+    getBlocker(): Account {
+        return this.blocker;
     }
 
     static getName(): string {

--- a/src/account/account-blocked.event.ts
+++ b/src/account/account-blocked.event.ts
@@ -1,0 +1,20 @@
+import type { Account } from 'account/account.entity';
+
+export class AccountBlockedEvent {
+    constructor(
+        private readonly actor: Account,
+        private readonly blocked: Account,
+    ) {}
+
+    getActor(): Account {
+        return this.actor;
+    }
+
+    getBlocked(): Account {
+        return this.blocked;
+    }
+
+    static getName(): string {
+        return 'account.blocked';
+    }
+}

--- a/src/feed/feed-update.service.ts
+++ b/src/feed/feed-update.service.ts
@@ -1,5 +1,6 @@
 import type { EventEmitter } from 'node:events';
 
+import { AccountBlockedEvent } from 'account/account-blocked.event';
 import type { FeedService } from 'feed/feed.service';
 import { PostCreatedEvent } from 'post/post-created.event';
 import { PostDeletedEvent } from 'post/post-deleted.event';
@@ -29,6 +30,10 @@ export class FeedUpdateService {
         this.events.on(
             PostDerepostedEvent.getName(),
             this.handlePostDerepostedEvent.bind(this),
+        );
+        this.events.on(
+            AccountBlockedEvent.getName(),
+            this.handleAccountBlockedEvent.bind(this),
         );
     }
 
@@ -60,5 +65,15 @@ export class FeedUpdateService {
         const derepostedBy = event.getAccountId();
 
         await this.feedService.removePostFromFeeds(post, derepostedBy);
+    }
+
+    private async handleAccountBlockedEvent(event: AccountBlockedEvent) {
+        const feedAccount = event.getActor();
+        const blockedAccount = event.getBlocked();
+
+        await this.feedService.removeBlockedAccountPostsFromFeed(
+            feedAccount,
+            blockedAccount,
+        );
     }
 }

--- a/src/feed/feed-update.service.ts
+++ b/src/feed/feed-update.service.ts
@@ -68,11 +68,11 @@ export class FeedUpdateService {
     }
 
     private async handleAccountBlockedEvent(event: AccountBlockedEvent) {
-        const feedAccount = event.getActor();
-        const blockedAccount = event.getBlocked();
+        const blockerAccount = event.getBlocker();
+        const blockedAccount = event.getAccount();
 
         await this.feedService.removeBlockedAccountPostsFromFeed(
-            feedAccount,
+            blockerAccount,
             blockedAccount,
         );
     }

--- a/src/feed/feed-update.service.unit.test.ts
+++ b/src/feed/feed-update.service.unit.test.ts
@@ -206,7 +206,7 @@ describe('FeedUpdateService', () => {
 
             events.emit(
                 AccountBlockedEvent.getName(),
-                new AccountBlockedEvent(account, blockedAccount),
+                new AccountBlockedEvent(blockedAccount, account),
             );
 
             expect(

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -2,6 +2,7 @@ import { chunk } from 'es-toolkit';
 import { sanitizeHtml } from 'helpers/html';
 import type { Knex } from 'knex';
 
+import type { Account } from 'account/account.entity';
 import {
     type FollowersOnlyPost,
     type Post,
@@ -342,5 +343,20 @@ export class FeedService {
             .delete();
 
         return updatedFeedUserIds;
+    }
+
+    async removeBlockedAccountPostsFromFeed(
+        feedAccount: Account,
+        blockedAccount: Account,
+    ) {
+        await this.db('feeds')
+            .where((qb) => {
+                qb.where('author_id', blockedAccount.id).orWhere(
+                    'reposted_by_id',
+                    blockedAccount.id,
+                );
+            })
+            .andWhere('user_id', feedAccount.id)
+            .delete();
     }
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-1082

Added handling for feed post removal when an account is blocked:

- When an account is blocked remove any posts by the blocked account from the blocking users feed
- When an account is blocked remove any reposts by the blocked account from the blocking users feed