### PR TITLE
AP-1092 | 2 | Added error handling for fetching follows

### DIFF
--- a/src/http/api/account.ts
+++ b/src/http/api/account.ts
@@ -100,6 +100,7 @@ export function createGetAccountFollowsHandler(
      * @param ctx App context
      */
     return async function handleGetAccountFollows(ctx: AppContext) {
+        const logger = ctx.get('logger');
         const site = ctx.get('site');
 
         const handle = ctx.req.param('handle') || '';
@@ -112,7 +113,9 @@ export function createGetAccountFollowsHandler(
             return new Response(null, { status: 400 });
         }
 
-        const siteDefaultAccount = await accountRepository.getBySite(site);
+        const siteDefaultAccount = (await accountRepository.getBySite(
+            site,
+        )) as PersistedAccount;
 
         const queryNext = ctx.req.query('next');
         const next = queryNext ? decodeURIComponent(queryNext) : null;
@@ -139,13 +142,47 @@ export function createGetAccountFollowsHandler(
                 return new Response(null, { status: 400 });
             }
 
-            accountFollows = await accountFollowsView.getFollowsByHandle(
-                handle,
+            const result = await accountFollowsView.getFollowsByApId(
+                new URL(apId),
                 account,
                 type,
                 next,
                 siteDefaultAccount,
             );
+            if (isError(result)) {
+                const error = getError(result);
+                switch (error) {
+                    case 'invalid-next-parameter':
+                        logger.error('Invalid next parameter');
+                        return new Response(null, { status: 400 });
+                    case 'not-an-actor':
+                        logger.error(`Actor not found for ${handle}`);
+                        return new Response(null, { status: 404 });
+                    case 'error-getting-follows':
+                        logger.error(`Error getting follows for ${handle}`);
+                        return new Response(
+                            JSON.stringify({
+                                accounts: [],
+                                total: 0,
+                                next: null,
+                            }),
+                            { status: 200 },
+                        );
+                    case 'no-page-found':
+                        logger.error(`No page found in outbox for ${handle}`);
+                        return new Response(
+                            JSON.stringify({
+                                accounts: [],
+                                total: 0,
+                                next: null,
+                            }),
+                            { status: 200 },
+                        );
+                    default:
+                        return exhaustiveCheck(error);
+                }
+            }
+            accountFollows = getValue(result);
         }
 
         // Return response

--- a/src/http/api/account.ts
+++ b/src/http/api/account.ts
@@ -139,45 +139,56 @@ export function createGetAccountFollowsHandler(
 
             const account = await accountRepository.getByApId(new URL(apId));
 
-            const result = await accountFollowsView.getFollowsByApId(
-                new URL(apId),
-                account,
-                type,
-                next,
-                siteDefaultAccount,
-            );
-            if (isError(result)) {
-                const error = getError(result);
-                switch (error) {
-                    case 'invalid-next-parameter':
-                        logger.error('Invalid next parameter');
-                        return new Response(null, { status: 400 });
-                    case 'not-an-actor':
-                        logger.error(`Actor not found for ${handle}`);
-                        return new Response(null, { status: 404 });
-                    case 'error-getting-follows':
-                        logger.error(`Error getting follows for ${handle}`);
-                        return new Response(
-                            JSON.stringify({
-                                accounts: [],
-                                next: null,
-                            }),
-                            { status: 200 },
-                        );
-                    case 'no-page-found':
-                        logger.error(`No page found in outbox for ${handle}`);
-                        return new Response(
-                            JSON.stringify({
-                                accounts: [],
-                                next: null,
-                            }),
-                            { status: 200 },
-                        );
-                    default:
-                        return exhaustiveCheck(error);
+            if (account?.isInternal) {
+                accountFollows = await accountFollowsView.getFollowsByAccount(
+                    account,
+                    type,
+                    Number.parseInt(next || '0'),
+                    siteDefaultAccount,
+                );
+            } else {
+                const result =
+                    await accountFollowsView.getFollowsByRemoteLookUp(
+                        new URL(apId),
+                        next || '',
+                        type,
+                        siteDefaultAccount,
+                    );
+                if (isError(result)) {
+                    const error = getError(result);
+                    switch (error) {
+                        case 'invalid-next-parameter':
+                            logger.error('Invalid next parameter');
+                            return new Response(null, { status: 400 });
+                        case 'not-an-actor':
+                            logger.error(`Actor not found for ${handle}`);
+                            return new Response(null, { status: 404 });
+                        case 'error-getting-follows':
+                            logger.error(`Error getting follows for ${handle}`);
+                            return new Response(
+                                JSON.stringify({
+                                    accounts: [],
+                                    next: null,
+                                }),
+                                { status: 200 },
+                            );
+                        case 'no-page-found':
+                            logger.error(
+                                `No page found in outbox for ${handle}`,
+                            );
+                            return new Response(
+                                JSON.stringify({
+                                    accounts: [],
+                                    next: null,
+                                }),
+                                { status: 200 },
+                            );
+                        default:
+                            return exhaustiveCheck(error);
+                    }
                 }
+                accountFollows = getValue(result);
             }
-            accountFollows = getValue(result);
         }
 
         // Return response

--- a/src/http/api/account.ts
+++ b/src/http/api/account.ts
@@ -160,7 +160,6 @@ export function createGetAccountFollowsHandler(
                         return new Response(
                             JSON.stringify({
                                 accounts: [],
-                                total: 0,
                                 next: null,
                             }),
                             { status: 200 },
@@ -170,7 +169,6 @@ export function createGetAccountFollowsHandler(
                         return new Response(
                             JSON.stringify({
                                 accounts: [],
-                                total: 0,
                                 next: null,
                             }),
                             { status: 200 },
@@ -186,7 +184,6 @@ export function createGetAccountFollowsHandler(
         return new Response(
             JSON.stringify({
                 accounts: accountFollows?.accounts,
-                total: accountFollows?.total,
                 next: accountFollows?.next,
             }),
             {

--- a/src/http/api/views/account.follows.view.integration.test.ts
+++ b/src/http/api/views/account.follows.view.integration.test.ts
@@ -1,3 +1,4 @@
+import { type Actor, isActor, lookupObject } from '@fedify/fedify';
 import type { Account, PersistedAccount } from 'account/account.entity';
 import { KnexAccountRepository } from 'account/account.repository.knex';
 import { AccountService } from 'account/account.service';
@@ -7,12 +8,30 @@ import type {
     Site,
 } from 'account/types';
 import { FedifyContextFactory } from 'activitypub/fedify-context.factory';
+import type { FedifyContext } from 'app';
 import { AsyncEvents } from 'core/events';
+import { ok } from 'core/result';
 import type { Knex } from 'knex';
 import { generateTestCryptoKeyPair } from 'test/crypto-key-pair';
 import { createTestDb } from 'test/db';
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AccountFollowsView } from './account.follows.view';
+
+vi.mock('@fedify/fedify', async () => {
+    // generateCryptoKeyPair is a slow operation so we generate a key pair
+    // upfront and re-use it for all tests
+    const original = await vi.importActual('@fedify/fedify');
+
+    // @ts-expect-error - generateCryptoKeyPair is not typed
+    const keyPair = await original.generateCryptoKeyPair();
+
+    return {
+        ...original,
+        generateCryptoKeyPair: vi.fn().mockReturnValue(keyPair),
+        lookupObject: vi.fn(),
+        isActor: vi.fn(),
+    };
+});
 
 describe('AccountFollowsView', () => {
     let viewer: AccountFollowsView;
@@ -26,6 +45,35 @@ describe('AccountFollowsView', () => {
     let siteDefaultAccount: PersistedAccount | null;
     let account: AccountType;
     let accountEntity: Account | null;
+    let fedifyContextFactory: FedifyContextFactory;
+
+    const mockContext = {
+        getDocumentLoader: vi.fn().mockResolvedValue({}),
+        data: {
+            db: {
+                get: vi.fn(),
+                set: vi.fn(),
+            },
+            logger: {
+                info: vi.fn(),
+                error: vi.fn(),
+            },
+        },
+    } as unknown as FedifyContext;
+
+    const mockActor = {
+        id: new URL('https://example.com/accounts/123'),
+        name: 'Test User',
+        isActor: () => true,
+        getFollowing: async () => null,
+        toJsonLd: async () => ({
+            id: 'https://example.com/accounts/123',
+            name: 'Test User',
+        }),
+        _documentLoader: {},
+        _contextLoader: {},
+        _tracerProvider: {},
+    } as unknown as Actor;
 
     beforeAll(async () => {
         db = await createTestDb();
@@ -60,7 +108,7 @@ describe('AccountFollowsView', () => {
 
         events = new AsyncEvents();
         accountRepository = new KnexAccountRepository(db, events);
-        const fedifyContextFactory = new FedifyContextFactory();
+        fedifyContextFactory = new FedifyContextFactory();
 
         accountService = new AccountService(
             db,
@@ -128,7 +176,6 @@ describe('AccountFollowsView', () => {
             );
 
             expect(result).toHaveProperty('accounts');
-            expect(result).toHaveProperty('total', 2);
             expect(result).toHaveProperty('next', null);
 
             expect(result.accounts).toHaveLength(2);
@@ -174,7 +221,6 @@ describe('AccountFollowsView', () => {
             );
 
             expect(result).toHaveProperty('accounts');
-            expect(result).toHaveProperty('total', 2);
             expect(result).toHaveProperty('next', null);
 
             expect(result.accounts).toHaveLength(2);
@@ -215,9 +261,207 @@ describe('AccountFollowsView', () => {
 
             expect(result).toMatchObject({
                 accounts: [],
-                total: 0,
                 next: null,
             });
+        });
+
+        it('remote lookup should handle invalid next parameter error', async () => {
+            vi.mocked(lookupObject).mockResolvedValue(mockActor);
+            vi.mocked(isActor).mockReturnValue(true);
+
+            await fedifyContextFactory.registerContext(
+                mockContext,
+                async () => {
+                    const result = await viewer.getFollowsByRemoteLookUp(
+                        new URL('https://example.com/accounts/123'),
+                        'https://different-domain.com/next',
+                        'following',
+                        siteDefaultAccount!,
+                    );
+
+                    expect(result).toEqual(['invalid-next-parameter', null]);
+                },
+            );
+        });
+
+        it('remote lookup should handle not-an-actor error', async () => {
+            vi.mocked(lookupObject).mockResolvedValue(mockActor);
+            vi.mocked(isActor).mockReturnValue(false);
+
+            await fedifyContextFactory.registerContext(
+                mockContext,
+                async () => {
+                    const result = await viewer.getFollowsByRemoteLookUp(
+                        new URL('https://example.com/accounts/123'),
+                        '',
+                        'following',
+                        siteDefaultAccount!,
+                    );
+
+                    expect(result).toEqual(['not-an-actor', null]);
+                },
+            );
+        });
+
+        it('remote lookup should handle error-getting-follows error', async () => {
+            const errorActor = {
+                ...mockActor,
+                getFollowing: async () => {
+                    throw new Error('Error getting follows');
+                },
+            } as unknown as Actor;
+
+            vi.mocked(lookupObject).mockResolvedValue(errorActor);
+            vi.mocked(isActor).mockReturnValue(true);
+
+            await fedifyContextFactory.registerContext(
+                mockContext,
+                async () => {
+                    const result = await viewer.getFollowsByRemoteLookUp(
+                        new URL('https://example.com/accounts/123'),
+                        '',
+                        'following',
+                        siteDefaultAccount!,
+                    );
+
+                    expect(result).toEqual(['error-getting-follows', null]);
+                },
+            );
+        });
+
+        it('remote lookup should handle no-page-found error', async () => {
+            vi.mocked(lookupObject).mockResolvedValue(mockActor);
+            vi.mocked(isActor).mockReturnValue(true);
+
+            await fedifyContextFactory.registerContext(
+                mockContext,
+                async () => {
+                    const result = await viewer.getFollowsByRemoteLookUp(
+                        new URL('https://example.com/accounts/123'),
+                        '',
+                        'following',
+                        siteDefaultAccount!,
+                    );
+
+                    expect(result).toEqual(['no-page-found', null]);
+                },
+            );
+        });
+
+        it('remote lookup should return follows collection when available', async () => {
+            const mockCollection = {
+                id: new URL('https://example.com/accounts/123/following'),
+                type: 'Collection',
+                totalItems: 2,
+                getFirst: async () => ({
+                    id: new URL(
+                        'https://example.com/accounts/123/following?page=1',
+                    ),
+                    type: 'CollectionPage',
+                    totalItems: 2,
+                    itemIds: [
+                        {
+                            href: new URL(
+                                'https://example.com/accounts/follower1',
+                            ),
+                        },
+                        {
+                            href: new URL(
+                                'https://example.com/accounts/follower2',
+                            ),
+                        },
+                    ],
+                }),
+            };
+
+            const collectionActor = {
+                ...mockActor,
+                getFollowing: async () => mockCollection,
+            } as unknown as Actor;
+
+            // Mock lookupObject to return actor objects for each item
+            vi.mocked(lookupObject).mockImplementation(async (url) => {
+                if (url.toString() === 'https://example.com/accounts/123') {
+                    return collectionActor;
+                }
+                if (
+                    url.toString() === 'https://example.com/accounts/follower1'
+                ) {
+                    return {
+                        id: 'https://example.com/accounts/follower1',
+                        type: 'Person',
+                        name: 'Follower One',
+                        preferredUsername: 'follower1',
+                        icon: { url: 'https://example.com/avatar1.jpg' },
+                        isActor: () => true,
+                        toJsonLd: async () => ({
+                            id: 'https://example.com/accounts/follower1',
+                            type: 'Person',
+                            name: 'Follower One',
+                            preferredUsername: 'follower1',
+                            icon: { url: 'https://example.com/avatar1.jpg' },
+                        }),
+                    } as unknown as Actor;
+                }
+                if (
+                    url.toString() === 'https://example.com/accounts/follower2'
+                ) {
+                    return {
+                        id: 'https://example.com/accounts/follower2',
+                        type: 'Person',
+                        name: 'Follower Two',
+                        preferredUsername: 'follower2',
+                        icon: { url: 'https://example.com/avatar2.jpg' },
+                        isActor: () => true,
+                        toJsonLd: async () => ({
+                            id: 'https://example.com/accounts/follower2',
+                            type: 'Person',
+                            name: 'Follower Two',
+                            preferredUsername: 'follower2',
+                            icon: { url: 'https://example.com/avatar2.jpg' },
+                        }),
+                    } as unknown as Actor;
+                }
+                throw new Error('Unexpected URL');
+            });
+
+            vi.mocked(isActor).mockReturnValue(true);
+
+            await fedifyContextFactory.registerContext(
+                mockContext,
+                async () => {
+                    const result = await viewer.getFollowsByRemoteLookUp(
+                        new URL('https://example.com/accounts/123'),
+                        '',
+                        'following',
+                        siteDefaultAccount!,
+                    );
+
+                    expect(result).toEqual(
+                        ok({
+                            accounts: [
+                                {
+                                    id: 'https://example.com/accounts/follower1',
+                                    name: 'Follower One',
+                                    handle: '@follower1@example.com',
+                                    avatarUrl:
+                                        'https://example.com/avatar1.jpg',
+                                    isFollowing: false,
+                                },
+                                {
+                                    id: 'https://example.com/accounts/follower2',
+                                    name: 'Follower Two',
+                                    handle: '@follower2@example.com',
+                                    avatarUrl:
+                                        'https://example.com/avatar2.jpg',
+                                    isFollowing: false,
+                                },
+                            ],
+                            next: null,
+                        }),
+                    );
+                },
+            );
         });
     });
 });

--- a/src/http/api/views/account.follows.view.integration.test.ts
+++ b/src/http/api/views/account.follows.view.integration.test.ts
@@ -1,4 +1,4 @@
-import type { Account } from 'account/account.entity';
+import type { Account, PersistedAccount } from 'account/account.entity';
 import { KnexAccountRepository } from 'account/account.repository.knex';
 import { AccountService } from 'account/account.service';
 import type {
@@ -23,7 +23,7 @@ describe('AccountFollowsView', () => {
     let internalAccountData: InternalAccountData;
     let db: Knex;
     let defaultAccount: AccountType;
-    let siteDefaultAccount: Account | null;
+    let siteDefaultAccount: PersistedAccount | null;
     let account: AccountType;
     let accountEntity: Account | null;
 
@@ -86,9 +86,9 @@ describe('AccountFollowsView', () => {
             ...internalAccountData,
             username: 'default',
         });
-        siteDefaultAccount = await accountRepository.getByApId(
+        siteDefaultAccount = (await accountRepository.getByApId(
             new URL(defaultAccount.ap_id),
-        );
+        )) as PersistedAccount;
     });
 
     describe('getFollows', () => {

--- a/src/http/api/views/account.follows.view.integration.test.ts
+++ b/src/http/api/views/account.follows.view.integration.test.ts
@@ -139,7 +139,7 @@ describe('AccountFollowsView', () => {
         )) as PersistedAccount;
     });
 
-    describe('getFollows', () => {
+    describe('getFollowsByAccount', () => {
         it('should return following accounts with correct format', async () => {
             const following1 = await accountService.createInternalAccount(
                 site,
@@ -264,8 +264,10 @@ describe('AccountFollowsView', () => {
                 next: null,
             });
         });
+    });
 
-        it('remote lookup should handle invalid next parameter error', async () => {
+    describe('getFollowsByRemoteLookUp', () => {
+        it('should handle invalid next parameter error', async () => {
             vi.mocked(lookupObject).mockResolvedValue(mockActor);
             vi.mocked(isActor).mockReturnValue(true);
 
@@ -284,7 +286,7 @@ describe('AccountFollowsView', () => {
             );
         });
 
-        it('remote lookup should handle not-an-actor error', async () => {
+        it('should handle not-an-actor error', async () => {
             vi.mocked(lookupObject).mockResolvedValue(mockActor);
             vi.mocked(isActor).mockReturnValue(false);
 
@@ -303,7 +305,7 @@ describe('AccountFollowsView', () => {
             );
         });
 
-        it('remote lookup should handle error-getting-follows error', async () => {
+        it('should handle error-getting-follows error', async () => {
             const errorActor = {
                 ...mockActor,
                 getFollowing: async () => {
@@ -329,7 +331,7 @@ describe('AccountFollowsView', () => {
             );
         });
 
-        it('remote lookup should handle no-page-found error', async () => {
+        it('should handle no-page-found error', async () => {
             vi.mocked(lookupObject).mockResolvedValue(mockActor);
             vi.mocked(isActor).mockReturnValue(true);
 
@@ -348,7 +350,7 @@ describe('AccountFollowsView', () => {
             );
         });
 
-        it('remote lookup should return follows collection when available', async () => {
+        it('should return follows collection when available', async () => {
             const mockCollection = {
                 id: new URL('https://example.com/accounts/123/following'),
                 type: 'Collection',

--- a/src/http/api/views/account.follows.view.ts
+++ b/src/http/api/views/account.follows.view.ts
@@ -196,7 +196,7 @@ export class AccountFollowsView {
                 }
 
                 const followeeAccount = await this.db('accounts')
-                    .where('ap_id', actor.id?.toString() || '')
+                    .where('ap_id', followsActorObj.id?.toString() || '')
                     .first();
 
                 const followsActor = (await followsActorObj.toJsonLd({


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/AP-1092

- Used PersistedAccount type for siteDefaultAccount - the current site account cannot be null.
- Used `Result` pattern for fetching follows
- Used `apId` instead of `handle` - same as we have for fetching posts
- If fetching any one follow fails, skipping that so that we can still return the other valid follows in the collection
- Removed getFollowsByApId, the controller now decides if we want to do a local lookup or a remote lookup.
- Modified tests to test getFollowsByAccount and getFollowsByRemoteLookUp separately