### PR TITLE
AP-982 | Attach images to notes/replies

### DIFF
--- a/features/create-note.feature
+++ b/features/create-note.feature
@@ -46,3 +46,19 @@ Feature: Creating a note
       Hello, world!
       """
     Then Activity "Note" is sent to all followers
+
+  Scenario: Creating a note with an image URL
+    When we create a note "Note" with imageUrl "http://localhost:4443/image.jpg" and content
+      """
+      Hello, world!
+      """
+    Then "Note" is in our Outbox
+    And "Note" has the content "<p>Hello, world!</p>"
+    And note "Note" has the image URL "http://localhost:4443/image.jpg"
+
+  Scenario: Creating a note with an invalid image URL
+    When we create a note "Note" with imageUrl "not-a-url" and content
+      """
+      Hello, world!
+      """
+    Then the request is rejected with a 400

--- a/features/create-reply.feature
+++ b/features/create-reply.feature
@@ -52,3 +52,19 @@ Feature: Creating a reply
       """
     Then Activity "Reply" is sent to "Alice"
     And Activity "Reply" is sent to "Bob"
+
+  Scenario: Creating a reply with an image URL
+    When we reply "Reply" to "Article" with imageUrl "http://localhost:4443/image.jpg" and content
+      """
+      This is a great article!
+      """
+    Then "Reply" is in our Outbox
+    And "Reply" has the content "<p>This is a great article!</p>"
+    And note "Reply" has the image URL "http://localhost:4443/image.jpg"
+
+  Scenario: Creating a reply with an invalid image URL
+    When we reply "Reply" to "Article" with imageUrl "not-a-url" and content
+      """
+      This is a great article!
+      """
+    Then the request is rejected with a 400

--- a/src/app.ts
+++ b/src/app.ts
@@ -958,6 +958,7 @@ app.post(
             accountRepository,
             postService,
             postRepository,
+            gcpStorageService
         ),
     ),
 );
@@ -989,7 +990,7 @@ app.post(
     '/.ghost/activitypub/actions/note',
     requireRole(GhostRole.Owner, GhostRole.Administrator),
     spanWrapper((ctx: AppContext) =>
-        handleCreateNote(ctx, accountRepository, postRepository),
+        handleCreateNote(ctx, accountRepository, postRepository, gcpStorageService),
     ),
 );
 app.get(

--- a/src/app.ts
+++ b/src/app.ts
@@ -958,7 +958,7 @@ app.post(
             accountRepository,
             postService,
             postRepository,
-            gcpStorageService
+            gcpStorageService,
         ),
     ),
 );
@@ -990,7 +990,12 @@ app.post(
     '/.ghost/activitypub/actions/note',
     requireRole(GhostRole.Owner, GhostRole.Administrator),
     spanWrapper((ctx: AppContext) =>
-        handleCreateNote(ctx, accountRepository, postRepository, gcpStorageService),
+        handleCreateNote(
+            ctx,
+            accountRepository,
+            postRepository,
+            gcpStorageService,
+        ),
     ),
 );
 app.get(

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -4,6 +4,7 @@ import {
     Announce,
     Create,
     Follow,
+    Image,
     Like,
     Mention,
     Note,
@@ -293,6 +294,7 @@ export function createLikeAction(
 
 const ReplyActionSchema = z.object({
     content: z.string(),
+    imageUrl: z.string().url().optional(),
 });
 
 export function createReplyActionHandler(
@@ -419,7 +421,12 @@ export function createReplyActionHandler(
 
         const parentPost = getValue(parentPostResult);
 
-        const newReply = Post.createReply(account, data.content, parentPost);
+        const newReply = Post.createReply(
+            account,
+            data.content,
+            parentPost,
+            data.imageUrl,
+        );
 
         await postRepository.save(newReply);
 
@@ -428,6 +435,14 @@ export function createReplyActionHandler(
             attribution: actor,
             replyTarget: objectToReplyTo,
             content: newReply.content,
+            image: newReply.imageUrl,
+            attachments: newReply.imageUrl
+                ? [
+                      new Image({
+                          url: newReply.imageUrl
+                      }),
+                  ]
+                : undefined,
             summary: null,
             published: Temporal.Now.instant(),
             contexts: [conversation],

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -438,7 +438,7 @@ export function createReplyActionHandler(
             account,
             data.content,
             parentPost,
-            data.imageUrl,
+            data.imageUrl ? new URL(data.imageUrl) : undefined,
         );
 
         await postRepository.save(newReply);

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -435,7 +435,6 @@ export function createReplyActionHandler(
             attribution: actor,
             replyTarget: objectToReplyTo,
             content: newReply.content,
-            image: newReply.imageUrl,
             attachments: newReply.imageUrl
                 ? [
                       new Image({

--- a/src/http/api/note.ts
+++ b/src/http/api/note.ts
@@ -41,7 +41,11 @@ export async function handleCreateNote(
 
     // Save to posts table when a note is created
     const account = await accountRepository.getBySite(ctx.get('site'));
-    const post = Post.createNote(account, data.content, data.imageUrl);
+    const post = Post.createNote(
+        account,
+        data.content,
+        data.imageUrl ? new URL(data.imageUrl) : undefined,
+    );
     await postRepository.save(post);
 
     let result: ActivityJsonLd | null = null;

--- a/src/http/api/note.ts
+++ b/src/http/api/note.ts
@@ -10,6 +10,7 @@ import type { ActivityJsonLd } from '../../publishing/service';
 
 const NoteSchema = z.object({
     content: z.string(),
+    imageUrl: z.string().url().optional(),
 });
 
 export async function handleCreateNote(
@@ -27,7 +28,7 @@ export async function handleCreateNote(
 
     // Save to posts table when a note is created
     const account = await accountRepository.getBySite(ctx.get('site'));
-    const post = Post.createNote(account, data.content);
+    const post = Post.createNote(account, data.content, data.imageUrl);
     await postRepository.save(post);
 
     let result: ActivityJsonLd | null = null;
@@ -39,6 +40,8 @@ export async function handleCreateNote(
                 handle: ACTOR_DEFAULT_HANDLE,
             },
             apId: post.apId,
+            imageUrl: post.imageUrl
+
         });
     } catch (err) {
         ctx.get('logger').error('Failed to publish note: {error}', {

--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -324,7 +324,11 @@ export class Post extends BaseEntity {
         );
     }
 
-    static createNote(account: Account, noteContent: string): Post {
+    static createNote(
+        account: Account,
+        noteContent: string,
+        imageUrl?: string,
+    ): Post {
         if (!account.isInternal) {
             throw new Error('createNote is for use with internal accounts');
         }
@@ -348,7 +352,7 @@ export class Post extends BaseEntity {
             null,
             content,
             null,
-            null,
+            imageUrl ? new URL(imageUrl) : null,
             new Date(),
             null,
             0,
@@ -366,6 +370,7 @@ export class Post extends BaseEntity {
         account: Account,
         replyContent: string,
         inReplyTo: Post,
+        imageUrl?: string,
     ): Post {
         if (!account.isInternal) {
             throw new Error('createReply is for use with internal accounts');
@@ -397,7 +402,7 @@ export class Post extends BaseEntity {
             null,
             content,
             null,
-            null,
+            imageUrl ? new URL(imageUrl) : null,
             new Date(),
             null,
             0,

--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -327,7 +327,7 @@ export class Post extends BaseEntity {
     static createNote(
         account: Account,
         noteContent: string,
-        imageUrl?: string,
+        imageUrl?: URL,
     ): Post {
         if (!account.isInternal) {
             throw new Error('createNote is for use with internal accounts');
@@ -352,7 +352,7 @@ export class Post extends BaseEntity {
             null,
             content,
             null,
-            imageUrl ? new URL(imageUrl) : null,
+            imageUrl ?? null,
             new Date(),
             null,
             0,
@@ -370,7 +370,7 @@ export class Post extends BaseEntity {
         account: Account,
         replyContent: string,
         inReplyTo: Post,
-        imageUrl?: string,
+        imageUrl?: URL,
     ): Post {
         if (!account.isInternal) {
             throw new Error('createReply is for use with internal accounts');
@@ -402,7 +402,7 @@ export class Post extends BaseEntity {
             null,
             content,
             null,
-            imageUrl ? new URL(imageUrl) : null,
+            imageUrl ?? null,
             new Date(),
             null,
             0,

--- a/src/post/post.entity.unit.test.ts
+++ b/src/post/post.entity.unit.test.ts
@@ -309,6 +309,18 @@ describe('Post', () => {
             expect(note.content).toBe('<p>My first note</p>');
         });
 
+        it('creates a note with an image URL', () => {
+            const account = internalAccount();
+            const content = 'My first note';
+            const imageUrl = 'https://example.com/image.jpg';
+
+            const note = Post.createNote(account, content, imageUrl);
+
+            expect(note.type).toBe(PostType.Note);
+            expect(note.content).toBe('<p>My first note</p>');
+            expect(note.imageUrl?.toString()).toBe(imageUrl);
+        });
+
         it('creates a note with line breaks', () => {
             const account = internalAccount();
             const content = `My

--- a/src/post/post.entity.unit.test.ts
+++ b/src/post/post.entity.unit.test.ts
@@ -314,7 +314,7 @@ describe('Post', () => {
             const content = 'My first note';
             const imageUrl = 'https://example.com/image.jpg';
 
-            const note = Post.createNote(account, content, imageUrl);
+            const note = Post.createNote(account, content, new URL(imageUrl));
 
             expect(note.type).toBe(PostType.Note);
             expect(note.content).toBe('<p>My first note</p>');

--- a/src/publishing/service.ts
+++ b/src/publishing/service.ts
@@ -143,7 +143,6 @@ export class FedifyPublishingService implements PublishingService {
             content: note.content,
             summary: null,
             published: Temporal.Now.instant(),
-            image: note.imageUrl,
             attachments: note.imageUrl
                 ? [
                       new Image({

--- a/src/publishing/service.ts
+++ b/src/publishing/service.ts
@@ -3,6 +3,7 @@ import {
     type Actor,
     Article,
     Create,
+    Image,
     Note as FedifyNote,
     type Object as FedifyObject,
     PUBLIC_COLLECTION,
@@ -142,6 +143,14 @@ export class FedifyPublishingService implements PublishingService {
             content: note.content,
             summary: null,
             published: Temporal.Now.instant(),
+            image: note.imageUrl,
+            attachments: note.imageUrl
+                ? [
+                      new Image({
+                          url: note.imageUrl
+                      }),
+                  ]
+                : undefined,
             to: to,
             ccs: cc,
         });

--- a/src/publishing/service.ts
+++ b/src/publishing/service.ts
@@ -3,9 +3,9 @@ import {
     type Actor,
     Article,
     Create,
-    Image,
     Note as FedifyNote,
     type Object as FedifyObject,
+    Image,
     PUBLIC_COLLECTION,
 } from '@fedify/fedify';
 import { Temporal } from '@js-temporal/polyfill';
@@ -146,7 +146,7 @@ export class FedifyPublishingService implements PublishingService {
             attachments: note.imageUrl
                 ? [
                       new Image({
-                          url: note.imageUrl
+                          url: note.imageUrl,
                       }),
                   ]
                 : undefined,

--- a/src/publishing/types.ts
+++ b/src/publishing/types.ts
@@ -103,4 +103,8 @@ export interface Note {
      * The AP ID of the post
      */
     apId?: URL;
+    /**
+     * The image URL if an image is attached with the note
+     */
+    imageUrl: URL | null;
 }

--- a/src/publishing/types.ts
+++ b/src/publishing/types.ts
@@ -106,5 +106,5 @@ export interface Note {
     /**
      * The image URL if an image is attached with the note
      */
-    imageUrl: URL | null;
+    imageUrl?: URL | null;
 }

--- a/src/storage/gcloud-storage/gcp-storage.service.ts
+++ b/src/storage/gcloud-storage/gcp-storage.service.ts
@@ -109,4 +109,36 @@ export class GCPStorageService {
 
         return ok(true);
     }
+
+    async verifyImageUrl(url: string): Promise<boolean> {
+        try {
+            // Check if we're using the GCS emulator and verify the URL matches the emulator's base URL pattern
+            if (this.emulatorHost) {
+                const emulatorBaseUrl = `${this.emulatorHost.replace('fake-gcs', 'localhost')}/storage/v1/b/${this.bucketName}`;
+                return url.startsWith(emulatorBaseUrl);
+            }
+
+            // Verify if the URL matches the standard Google Cloud Storage public URL pattern for our bucket
+            const gcsUrlPattern = new RegExp(
+                `https://storage.googleapis.com/${this.bucketName}/`,
+            );
+            if (!gcsUrlPattern.test(url)) {
+                return false;
+            }
+
+            // Extract the file path from the URL by removing the bucket prefix
+            const filePath = url.split(
+                `https://storage.googleapis.com/${this.bucketName}/`,
+            )[1];
+            if (!filePath) {
+                return false;
+            }
+
+            // Verify that the file actually exists in our bucket
+            const [exists] = await this.bucket.file(filePath).exists();
+            return exists;
+        } catch (error) {
+            return false;
+        }
+    }
 }

--- a/src/storage/gcloud-storage/gcp-storage.service.ts
+++ b/src/storage/gcloud-storage/gcp-storage.service.ts
@@ -114,7 +114,7 @@ export class GCPStorageService {
         try {
             // Check if we're using the GCS emulator and verify the URL matches the emulator's base URL pattern
             if (this.emulatorHost) {
-                const emulatorBaseUrl = `${this.emulatorHost.replace('fake-gcs', 'localhost')}/storage/v1/b/${this.bucketName}`;
+                const emulatorBaseUrl = `${this.emulatorHost.replace('fake-gcs', 'localhost')}`;
                 return url.startsWith(emulatorBaseUrl);
             }
 

--- a/src/storage/gcloud-storage/gcp-storage.service.unit.test.ts
+++ b/src/storage/gcloud-storage/gcp-storage.service.unit.test.ts
@@ -136,15 +136,8 @@ describe('GCPStorageService', () => {
                 expect(result).toBe(true);
             });
 
-            it('returns false for invalid emulator URL with wrong bucket', async () => {
-                const invalidUrl =
-                    'http://localhost:4443/storage/v1/b/wrong-bucket/o/images/test-uuid/test.png?alt=media';
-                const result = await service.verifyImageUrl(invalidUrl);
-                expect(result).toBe(false);
-            });
-
             it('returns false for malformed emulator URL', async () => {
-                const invalidUrl = 'http://localhost:4443/invalid-path';
+                const invalidUrl = 'http://invalid-domain/test.png';
                 const result = await service.verifyImageUrl(invalidUrl);
                 expect(result).toBe(false);
             });


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/AP-982 https://linear.app/ghost/issue/AP-1084

- Store the image url on the PostEntity in `imageUrl`. This is easier to work with for a single image
- Set the imageUrl on the attachment properties
-- Tested this will many options and setting it to the attachments using Image obj works. By works I mean image correctly shows up on mastodon. 
- Updated /note API to accept an image URL
-- Verifing the image url
- Updated /reply API to accept image
-- Verifing the image url