### PR TITLE
Fixed image uploads being rejected in local dev with 413 Content Too Large

### DIFF
--- a/nginx/server.conf
+++ b/nginx/server.conf
@@ -1,4 +1,6 @@
 server {
+    client_max_body_size 25M;
+
     location /.ghost/activitypub {
         proxy_pass http://activitypub:8080;
     }


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C06TE92R3JR/p1745461514388069

- by default, nginx has a 1MB limit for client uploads, which is quite low for image uploads
- we are now bumped this limit to 25MB, which is more suitable for image uploads