### PR TITLE
Added handling for saving an account with `null` values for images

### DIFF
--- a/src/account/account.repository.knex.ts
+++ b/src/account/account.repository.knex.ts
@@ -24,12 +24,8 @@ export class KnexAccountRepository {
                 name: account.name,
                 bio: account.bio,
                 username: account.username,
-                avatar_url:
-                    account.avatarUrl == null ? null : account.avatarUrl?.href,
-                banner_image_url:
-                    account.bannerImageUrl == null
-                        ? null
-                        : account.bannerImageUrl?.href,
+                avatar_url: account.avatarUrl?.href ?? null,
+                banner_image_url: account.bannerImageUrl?.href ?? null,
             })
             .where({ id: account.id });
 

--- a/src/account/account.repository.knex.ts
+++ b/src/account/account.repository.knex.ts
@@ -24,8 +24,12 @@ export class KnexAccountRepository {
                 name: account.name,
                 bio: account.bio,
                 username: account.username,
-                avatar_url: account.avatarUrl?.href,
-                banner_image_url: account.bannerImageUrl?.href,
+                avatar_url:
+                    account.avatarUrl == null ? null : account.avatarUrl?.href,
+                banner_image_url:
+                    account.bannerImageUrl == null
+                        ? null
+                        : account.bannerImageUrl?.href,
             })
             .where({ id: account.id });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-1097

When trying to save an account with `null` values for `avatarUrl` or `bannerImageUrl` the underlying db record would not be correctly updated due to the logic for saving the account expecting the provided values to be a URL. `null` is a valid value for these fields so we should handle it accordingly