### PR TITLE
Added handling for feed post insertion prevention 

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -40,6 +40,7 @@ import { AsyncEvents } from 'core/events';
 import { Hono, type Context as HonoContext, type Next } from 'hono';
 import { cors } from 'hono/cors';
 import jwt from 'jsonwebtoken';
+import { ModerationService } from 'moderation/moderation.service';
 import jose from 'node-jose';
 import { NotificationEventService } from 'notification/notification-event.service';
 import { NotificationService } from 'notification/notification.service';
@@ -295,7 +296,8 @@ const accountPostsView = new AccountPostsView(client, fedifyContextFactory);
 const siteService = new SiteService(client, accountService, {
     getSiteSettings: getSiteSettings,
 });
-const feedService = new FeedService(client);
+const moderationService = new ModerationService(client);
+const feedService = new FeedService(client, moderationService);
 const feedUpdateService = new FeedUpdateService(events, feedService);
 feedUpdateService.init();
 

--- a/src/feed/feed.service.integration.test.ts
+++ b/src/feed/feed.service.integration.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import { AsyncEvents } from 'core/events';
 import type { Knex } from 'knex';
+import { ModerationService } from 'moderation/moderation.service';
 import { generateTestCryptoKeyPair } from 'test/crypto-key-pair';
 import { createTestDb } from 'test/db';
 import type { Account } from '../account/account.entity';
@@ -28,6 +29,7 @@ describe('FeedService', () => {
     let accountService: AccountService;
     let siteService: SiteService;
     let postRepository: KnexPostRepository;
+    let moderationService: ModerationService;
     let client: Knex;
 
     beforeAll(async () => {
@@ -141,11 +143,12 @@ describe('FeedService', () => {
             },
         });
         postRepository = new KnexPostRepository(client, events);
+        moderationService = new ModerationService(client);
     });
 
     describe('getFeedData', () => {
         it('should get the posts for a users feed, and make sure the content is sanitised', async () => {
-            const feedService = new FeedService(client);
+            const feedService = new FeedService(client, moderationService);
 
             // Initialise an internal account for user
             const userAccount = await createInternalAccount('foo.com');
@@ -189,7 +192,7 @@ describe('FeedService', () => {
         });
 
         it('should sort feed items by published_at', async () => {
-            const feedService = new FeedService(client);
+            const feedService = new FeedService(client, moderationService);
 
             const userAccount =
                 await createInternalAccount('sort-test-user.com');
@@ -265,7 +268,7 @@ describe('FeedService', () => {
 
     describe('addPostToFeeds', () => {
         it('should add a post to the feeds of the users that should see it', async () => {
-            const feedService = new FeedService(client);
+            const feedService = new FeedService(client, moderationService);
 
             // Initialise an internal account for user
             const userAccount =
@@ -373,7 +376,7 @@ describe('FeedService', () => {
         }, 10000);
 
         it('should add reposted posts to the feeds of the users that should see it', async () => {
-            const feedService = new FeedService(client);
+            const feedService = new FeedService(client, moderationService);
 
             // Initialise an internal account for user
             const userAccount = await createInternalAccount(
@@ -460,7 +463,7 @@ describe('FeedService', () => {
         }, 10000);
 
         it('should not add replies to feeds', async () => {
-            const feedService = new FeedService(client);
+            const feedService = new FeedService(client, moderationService);
 
             // Initialise an internal account for user
             const userAccount = await createInternalAccount(
@@ -517,7 +520,7 @@ describe('FeedService', () => {
         }, 10000);
 
         it('should use repost timestamp as published_at when post is a reposted', async () => {
-            const feedService = new FeedService(client);
+            const feedService = new FeedService(client, moderationService);
             const originalPublishDate = new Date('2024-01-01T00:00:00Z');
             const repostDate = new Date('2024-02-01T00:00:00Z');
 
@@ -560,7 +563,7 @@ describe('FeedService', () => {
         }, 10000);
 
         it('should use original published_at timestamp when post is not reposted', async () => {
-            const feedService = new FeedService(client);
+            const feedService = new FeedService(client, moderationService);
             const originalPublishDate = new Date('2024-01-01T00:00:00Z');
 
             // Create test account
@@ -592,7 +595,7 @@ describe('FeedService', () => {
 
     describe('removePostFromFeeds', () => {
         it('should remove a post from the feeds of the users that can already see it', async () => {
-            const feedService = new FeedService(client);
+            const feedService = new FeedService(client, moderationService);
 
             // Initialise an internal account for user
             const userAccount =
@@ -660,7 +663,7 @@ describe('FeedService', () => {
         }, 10000);
 
         it('should remove dereposted post from feeds', async () => {
-            const feedService = new FeedService(client);
+            const feedService = new FeedService(client, moderationService);
 
             // Initialise accounts
             const userAccount = await createInternalAccount(
@@ -714,7 +717,7 @@ describe('FeedService', () => {
         }, 10000);
 
         it('should not affect other reposts when removing a specific derepost', async () => {
-            const feedService = new FeedService(client);
+            const feedService = new FeedService(client, moderationService);
 
             // Initialise accounts
             const userAccount =
@@ -778,7 +781,7 @@ describe('FeedService', () => {
 
     describe('removeBlockedAccountPostsFromFeed', () => {
         it('should remove posts from feeds when an account is blocked', async () => {
-            const feedService = new FeedService(client);
+            const feedService = new FeedService(client, moderationService);
 
             // Initialise an internal account for user
             const userAccount = await createInternalAccount('user.com');
@@ -883,7 +886,7 @@ describe('FeedService', () => {
         }, 10000);
 
         it('should remove reposts from feeds when an account is blocked', async () => {
-            const feedService = new FeedService(client);
+            const feedService = new FeedService(client, moderationService);
 
             // Initialise an internal account for user
             const userAccount = await createInternalAccount('user.com');

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -3,6 +3,7 @@ import { sanitizeHtml } from 'helpers/html';
 import type { Knex } from 'knex';
 
 import type { Account } from 'account/account.entity';
+import type { ModerationService } from 'moderation/moderation.service';
 import {
     type FollowersOnlyPost,
     type Post,
@@ -86,10 +87,10 @@ export interface GetFeedDataResult {
 }
 
 export class FeedService {
-    /**
-     * @param db Database client
-     */
-    constructor(private readonly db: Knex) {}
+    constructor(
+        private readonly db: Knex,
+        private readonly moderationService: ModerationService,
+    ) {}
 
     /**
      * Get data for a feed based on the provided options
@@ -273,7 +274,11 @@ export class FeedService {
         }
 
         // Add the post to the feeds
-        const userIds = Array.from(targetUserIds).map(Number);
+        const userIds = await this.moderationService.filterUsersForPost(
+            Array.from(targetUserIds).map(Number),
+            post,
+            repostedBy ?? undefined,
+        );
 
         if (userIds.length === 0) {
             return [];

--- a/src/moderation/moderation.service.integration.test.ts
+++ b/src/moderation/moderation.service.integration.test.ts
@@ -1,19 +1,21 @@
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import type { Knex } from 'knex';
-import { createTestDb } from 'test/db';
-import { type FixtureManager, createFixtureManager } from 'test/fixtures';
 
 import { postToDTO } from 'http/api/helpers/post';
+import { createTestDb } from 'test/db';
+import { type FixtureManager, createFixtureManager } from 'test/fixtures';
 import { ModerationService } from './moderation.service';
 
 describe('ModerationService', () => {
     let client: Knex;
     let fixtureManager: FixtureManager;
+    let moderationService: ModerationService;
 
     beforeAll(async () => {
         client = await createTestDb();
         fixtureManager = createFixtureManager(client);
+        moderationService = new ModerationService(client);
     });
 
     beforeEach(async () => {
@@ -21,8 +23,6 @@ describe('ModerationService', () => {
     });
 
     it('should filter posts from blocked accounts', async () => {
-        const moderationService = new ModerationService(client);
-
         const [[account], [blockedAccount]] = await Promise.all([
             fixtureManager.createInternalAccount(null, 'example.com'),
             fixtureManager.createInternalAccount(null, 'blocked.com'),
@@ -47,8 +47,6 @@ describe('ModerationService', () => {
     });
 
     it('should filter posts from multiple blocked accounts', async () => {
-        const moderationService = new ModerationService(client);
-
         const [[account], [blockedAccount1], [blockedAccount2]] =
             await Promise.all([
                 fixtureManager.createInternalAccount(null, 'example.com'),
@@ -75,8 +73,6 @@ describe('ModerationService', () => {
     });
 
     it('should filter reposts from blocked accounts', async () => {
-        const moderationService = new ModerationService(client);
-
         const [[account], [unblockedAccount], [blockedAccount]] =
             await Promise.all([
                 fixtureManager.createInternalAccount(null, 'example.com'),
@@ -112,8 +108,6 @@ describe('ModerationService', () => {
     });
 
     it('should do nothing if there are no posts', async () => {
-        const moderationService = new ModerationService(client);
-
         const [account] = await fixtureManager.createInternalAccount(
             null,
             'example.com',
@@ -125,5 +119,135 @@ describe('ModerationService', () => {
         );
 
         expect(posts).toEqual([]);
+    });
+
+    describe('filterUsersForPost', () => {
+        it('should filter out users that have blocked the author', async () => {
+            const [
+                [aliceAccount, , aliceUserId],
+                [bobAccount, , bobUserId],
+                [charlieAccount, , charlieUserId],
+            ] = await Promise.all([
+                fixtureManager.createInternalAccount(),
+                fixtureManager.createInternalAccount(),
+                fixtureManager.createInternalAccount(),
+            ]);
+
+            const [, , , post] = await Promise.all([
+                // alice follows bob and charlie
+                fixtureManager.createFollow(aliceAccount, bobAccount),
+                fixtureManager.createFollow(aliceAccount, charlieAccount),
+                // alice blocks bob
+                fixtureManager.createBlock(aliceAccount, bobAccount),
+                // bob creates a post
+                fixtureManager.createPost(bobAccount),
+            ]);
+
+            const users = await moderationService.filterUsersForPost(
+                [aliceUserId, bobUserId, charlieUserId],
+                post,
+            );
+
+            // alice should not see the post
+            expect(users).toEqual([bobUserId, charlieUserId]);
+        });
+
+        it('should filter out users that have blocked the reposter', async () => {
+            const [
+                [aliceAccount, , aliceUserId],
+                [bobAccount, , bobUserId],
+                [charlieAccount, , charlieUserId],
+            ] = await Promise.all([
+                fixtureManager.createInternalAccount(),
+                fixtureManager.createInternalAccount(),
+                fixtureManager.createInternalAccount(),
+            ]);
+
+            const [, , , post] = await Promise.all([
+                // alice follows bob and charlie
+                fixtureManager.createFollow(aliceAccount, bobAccount),
+                fixtureManager.createFollow(aliceAccount, charlieAccount),
+                // alice blocks charlie
+                fixtureManager.createBlock(aliceAccount, charlieAccount),
+                // bob creates a post
+                fixtureManager.createPost(bobAccount),
+            ]);
+
+            const users = await moderationService.filterUsersForPost(
+                [aliceUserId, bobUserId, charlieUserId],
+                post,
+                charlieAccount.id!, // charlie reposted bob's post
+            );
+
+            // alice should not see the post
+            expect(users).toEqual([bobUserId, charlieUserId]);
+        });
+
+        it('should filter out users that have blocked the author of a post that has been reposted by a followed account', async () => {
+            const [
+                [aliceAccount, , aliceUserId],
+                [bobAccount, , bobUserId],
+                [charlieAccount, , charlieUserId],
+            ] = await Promise.all([
+                fixtureManager.createInternalAccount(),
+                fixtureManager.createInternalAccount(),
+                fixtureManager.createInternalAccount(),
+            ]);
+
+            const [, , , post] = await Promise.all([
+                // alice follows bob and charlie
+                fixtureManager.createFollow(aliceAccount, bobAccount),
+                fixtureManager.createFollow(aliceAccount, charlieAccount),
+                // alice blocks bob
+                fixtureManager.createBlock(aliceAccount, bobAccount),
+                // bob creates a post
+                fixtureManager.createPost(bobAccount),
+            ]);
+
+            const users = await moderationService.filterUsersForPost(
+                [aliceUserId, bobUserId, charlieUserId],
+                post,
+                charlieAccount.id!, // charlie reposted bob's post
+            );
+
+            // alice should not see the post
+            expect(users).toEqual([bobUserId, charlieUserId]);
+        });
+
+        it('should filter out users that are followers of an account that has reposted a post but has been blocked by the author', async () => {
+            const [
+                [aliceAccount, , aliceUserId],
+                [bobAccount, , bobUserId],
+                [charlieAccount, , charlieUserId],
+            ] = await Promise.all([
+                fixtureManager.createInternalAccount(),
+                fixtureManager.createInternalAccount(),
+                fixtureManager.createInternalAccount(),
+            ]);
+
+            const [, , , , post] = await Promise.all([
+                // alice follows bob and charlie
+                fixtureManager.createFollow(aliceAccount, bobAccount),
+                fixtureManager.createFollow(aliceAccount, charlieAccount),
+                // charlie follows bob
+                fixtureManager.createFollow(charlieAccount, bobAccount),
+                // alice blocks bob
+                fixtureManager.createBlock(aliceAccount, bobAccount),
+                // alice creates a post
+                fixtureManager.createPost(aliceAccount),
+            ]);
+
+            const users = await moderationService.filterUsersForPost(
+                [aliceUserId, bobUserId, charlieUserId],
+                post,
+                bobAccount.id!, // bob reposted alice's post
+            );
+
+            // - alice should not see the post because she blocked bob
+            //   (the reposter)
+            // - charlie should not see the post because the author (alice)
+            //   blocked the reposter (bob), even though charlie follows bob
+            expect(users).toEqual([bobUserId]);
+        });
     });
 });

--- a/src/moderation/moderation.service.ts
+++ b/src/moderation/moderation.service.ts
@@ -32,7 +32,7 @@ export class ModerationService {
         userIds: number[],
         post: Post,
         repostedBy?: number,
-    ) {
+    ): Promise<number[]> {
         // Map user ids to their corresponding account ids
         const userAccountMap = new Map<number, number>();
 
@@ -47,12 +47,14 @@ export class ModerationService {
         // reposter
         if (repostedBy) {
             const authorHasBlockedReposter = await this.db('blocks')
+                .innerJoin('accounts', 'blocks.blocked_id', 'accounts.id')
                 .where('blocker_id', post.author.id)
                 .andWhere('blocked_id', repostedBy)
+                .select('blocked_id')
                 .first();
 
             if (authorHasBlockedReposter) {
-                return [userAccountMap.get(repostedBy)];
+                return [authorHasBlockedReposter.blocked_id];
             }
         }
 

--- a/src/moderation/moderation.service.ts
+++ b/src/moderation/moderation.service.ts
@@ -36,9 +36,11 @@ export class ModerationService {
         // Map user ids to their corresponding account ids
         const userAccountMap = new Map<number, number>();
 
-        for (const row of await this.db('users')
+        const rows = await this.db('users')
             .whereIn('id', userIds)
-            .select('id', 'account_id')) {
+            .select('id', 'account_id');
+
+        for (const row of rows) {
             userAccountMap.set(row.id, row.account_id);
         }
 

--- a/src/post/post.repository.knex.integration.test.ts
+++ b/src/post/post.repository.knex.integration.test.ts
@@ -4,6 +4,7 @@ import { AsyncEvents } from 'core/events';
 import { FeedUpdateService } from 'feed/feed-update.service';
 import { FeedService } from 'feed/feed.service';
 import type { Knex } from 'knex';
+import { ModerationService } from 'moderation/moderation.service';
 import { generateTestCryptoKeyPair } from 'test/crypto-key-pair';
 import { createTestDb } from 'test/db';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -70,7 +71,8 @@ describe('KnexPostRepository', () => {
             },
         });
         postRepository = new KnexPostRepository(client, events);
-        const feedService = new FeedService(client);
+        const moderationService = new ModerationService(client);
+        const feedService = new FeedService(client, moderationService);
         const feedUpdateService = new FeedUpdateService(events, feedService);
         feedUpdateService.init();
     });

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -131,6 +131,13 @@ export class FixtureManager {
         });
     }
 
+    async createFollow(follower: Account, following: Account) {
+        await this.db('follows').insert({
+            follower_id: follower.id,
+            following_id: following.id,
+        });
+    }
+
     async createNotification(
         userAccount: Account,
         fromAccount: Account,
@@ -154,6 +161,7 @@ export class FixtureManager {
 
     async reset() {
         await this.db.raw('SET FOREIGN_KEY_CHECKS = 0');
+        await this.db('follows').truncate();
         await this.db('notifications').truncate();
         await this.db('blocks').truncate();
         await this.db('posts').truncate();


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-1082

Added handling for feed post insertion prevention when an account is blocked:
- When a post is created by a blocked account, ensure it is not put into the feeds of any users that have blocked the author
- When a post is reposted by a blocked account, ensure it is not put into the feeds of any users that have blocked the reposter
- When a post is reposted by an account, ensure it is not put into the feeds of any users that have blocked the author
- When a post is created by a an account and then reposted by a blocked account, ensure it is not put into the feeds of any users except for the reposter