### PR TITLE
Fixed performance of viewByApIdRemote

### DIFF
--- a/src/http/api/views/account.view.ts
+++ b/src/http/api/views/account.view.ts
@@ -181,7 +181,7 @@ export class AccountView {
 
         if (context.requestUserAccount?.id) {
             const externalAccount = await this.db('accounts')
-                .where('ap_id', apId)
+                .whereRaw('ap_id_hash = UNHEX(SHA2(?, 256))', [apId])
                 .select('id')
                 .first();
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-677

The `ap_id` column is not indexed due to the size of it, instead we have the `ap_id_hash` column which contains the SHA256 of the `ap_id` and is indexed. We should never be adding WHERE conditions on the `ap_id` columns in the codebase, it should always be via the indexed hash instead.