### PR TITLE
Fixed performance of viewByApId

### DIFF
--- a/src/http/api/views/account.view.ts
+++ b/src/http/api/views/account.view.ts
@@ -111,7 +111,8 @@ export class AccountView {
         context: ViewContext = {},
     ): Promise<AccountDTO | null> {
         const accountData = await this.getAccountByQuery(
-            (qb: Knex.QueryBuilder) => qb.where('accounts.ap_id', apId),
+            (qb: Knex.QueryBuilder) =>
+                qb.whereRaw('ap_id_hash = UNHEX(SHA2(?, 256))', [apId]),
         );
 
         if (!accountData) {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-677

- The `ap_id` column is not indexed due to the size of it, instead we have
the `ap_id_hash` column which contains the SHA256 of the `ap_id` and is indexed. We should never be adding WHERE conditions on the `ap_id` columns in the codebase, it should always be via the indexed hash instead.