### PR TITLE
Fixed flaky moderation service test

### DIFF
--- a/src/moderation/moderation.service.ts
+++ b/src/moderation/moderation.service.ts
@@ -48,15 +48,15 @@ export class ModerationService {
         // has blocked the author, and if so, filter out everybody but the
         // reposter
         if (repostedBy) {
-            const authorHasBlockedReposter = await this.db('blocks')
-                .innerJoin('accounts', 'blocks.blocked_id', 'accounts.id')
+            const block = await this.db('blocks')
+                .innerJoin('users', 'blocks.blocked_id', 'users.account_id')
                 .where('blocker_id', post.author.id)
                 .andWhere('blocked_id', repostedBy)
-                .select('blocked_id')
+                .select('users.id as blocked_user_id')
                 .first();
 
-            if (authorHasBlockedReposter) {
-                return [authorHasBlockedReposter.blocked_id];
+            if (block) {
+                return [block.blocked_user_id];
             }
         }
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-1082

Added fix for a flaky moderation service test - The flakiness was being caused due to using the wrong field when returning the list of filtered out users when the author of a post has blocked the reposter. The previously returned field would just happen to match the expected value most of the time, which caused the test to fail intermittently. This fix ensures that the correct field is used to filter out users and prevents the test from failing intermittently.