### PR TITLE
Added handling for notification insertion prevention when an account is blocked

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -304,7 +304,7 @@ feedUpdateService.init();
 const fediverseBridge = new FediverseBridge(events, fedifyContextFactory);
 fediverseBridge.init();
 
-const notificationService = new NotificationService(client);
+const notificationService = new NotificationService(client, moderationService);
 const notificationEventService = new NotificationEventService(
     events,
     notificationService,

--- a/src/moderation/moderation.service.integration.test.ts
+++ b/src/moderation/moderation.service.integration.test.ts
@@ -250,4 +250,32 @@ describe('ModerationService', () => {
             expect(users).toEqual([bobUserId]);
         });
     });
+
+    describe('filterUsersForAccountInteraction', () => {
+        it('should filter out users that have blocked the interaction account', async () => {
+            const [
+                [aliceAccount, , aliceUserId],
+                [bobAccount, , bobUserId],
+                [, , charlieUserId],
+            ] = await Promise.all([
+                fixtureManager.createInternalAccount(),
+                fixtureManager.createInternalAccount(),
+                fixtureManager.createInternalAccount(),
+            ]);
+
+            await Promise.all([
+                // alice blocks bob
+                fixtureManager.createBlock(aliceAccount, bobAccount),
+            ]);
+
+            const users =
+                await moderationService.filterUsersForAccountInteraction(
+                    [aliceUserId, bobUserId, charlieUserId],
+                    bobAccount.id!,
+                );
+
+            // alice should be filtered out because she blocked bob
+            expect(users).toEqual([bobUserId, charlieUserId]);
+        });
+    });
 });

--- a/src/moderation/moderation.service.ts
+++ b/src/moderation/moderation.service.ts
@@ -31,7 +31,7 @@ export class ModerationService {
     async filterUsersForPost(
         userIds: number[],
         post: Post,
-        repostedBy?: number,
+        interactionAccountId?: number,
     ): Promise<number[]> {
         // Map user ids to their corresponding account ids
         const userAccountMap = new Map<number, number>();
@@ -44,14 +44,14 @@ export class ModerationService {
             userAccountMap.set(row.id, row.account_id);
         }
 
-        // If the post has been reposted by an account, check if the reposter
-        // has blocked the author, and if so, filter out everybody but the
-        // reposter
-        if (repostedBy) {
+        // If the post has been interacted with by an account (liked, reposted
+        // etc), check if the interaction account has been blocked by the post
+        // author, and if so, filter out everybody but the interaction account
+        if (interactionAccountId) {
             const block = await this.db('blocks')
                 .innerJoin('users', 'blocks.blocked_id', 'users.account_id')
                 .where('blocker_id', post.author.id)
-                .andWhere('blocked_id', repostedBy)
+                .andWhere('blocked_id', interactionAccountId)
                 .select('users.id as blocked_user_id')
                 .first();
 
@@ -61,22 +61,54 @@ export class ModerationService {
         }
 
         // Filter out accounts that have either blocked the author or the
-        // reposter
+        // interaction account
         const accountIdsToBeFilteredOut = (
             await this.db('blocks')
                 .whereIn('blocker_id', Array.from(userAccountMap.values()))
                 .andWhere(
                     'blocked_id',
                     'in',
-                    [repostedBy, post.author.id].filter(
+                    [interactionAccountId, post.author.id].filter(
                         (id) => id !== undefined,
                     ),
                 )
                 .select('blocker_id')
         ).map((row) => row.blocker_id);
 
-        // Of the users provided, filter out the ones do not have an account
-        // that has been blocked by the author or the reposter
+        // Of the users provided, filter out the ones that do not have an account
+        // that has blocked the author or the interaction account
+        return userIds.filter((userId) => {
+            const accountId = userAccountMap.get(userId);
+
+            return !accountIdsToBeFilteredOut.includes(accountId);
+        });
+    }
+
+    async filterUsersForAccountInteraction(
+        userIds: number[],
+        interactionAccountId: number,
+    ): Promise<number[]> {
+        // Map user ids to their corresponding account ids
+        const userAccountMap = new Map<number, number>();
+
+        const rows = await this.db('users')
+            .whereIn('id', userIds)
+            .select('id', 'account_id');
+
+        for (const row of rows) {
+            userAccountMap.set(row.id, row.account_id);
+        }
+
+        // Filter out accounts that have blocked the interaction account
+        const accountIdsToBeFilteredOut = (
+            await this.db('blocks')
+                .whereIn('blocker_id', Array.from(userAccountMap.values()))
+                .andWhere('blocked_id', interactionAccountId)
+                .select('blocker_id')
+        ).map((row) => row.blocker_id);
+
+        // Of the users provided, filter out the ones that do not have an account
+        // that has blocked the interaction account
         return userIds.filter((userId) => {
             const accountId = userAccountMap.get(userId);
 

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -106,12 +106,15 @@ export class FixtureManager {
         account: Account,
         {
             type = PostType.Note,
+            inReplyTo,
         }: {
             type?: CreatePostType;
+            inReplyTo?: Post;
         } = {},
     ) {
         const post = Post.createFromData(account, {
             type,
+            inReplyTo,
             content:
                 type === PostType.Article
                     ? faker.lorem.paragraph()
@@ -122,6 +125,15 @@ export class FixtureManager {
         await this.postRepository.save(post);
 
         return post;
+    }
+
+    async createReply(account: Account, inReplyTo: Post) {
+        const reply = await this.createPost(account, {
+            type: PostType.Note,
+            inReplyTo,
+        });
+
+        return reply;
     }
 
     async createBlock(blocker: Account, blocked: Account) {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-1082

Added handling for notification insertion prevention when an account is blocked:
- When a blocked account has attempted to follow the blocking account, ensure no notifications are not inserted for the blocking account
- When a blocked account has liked a post from the blocking account, ensure no notifications are not inserted for the blocking account
- When a blocked account has reposted a post from the blocking account, ensure no notifications are not inserted for the blocking account
- When a blocked account has replied to a post from the blocking account, ensure no notifications are not inserted for the blocking account