### PR TITLE
Fixed performance of getFollowsByRemoteLookUp and getAccountById

### DIFF
--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -262,7 +262,9 @@ export class AccountService {
             return null;
         }
 
-        return await this.db('accounts').where('ap_id', apId).first();
+        return await this.db('accounts')
+            .whereRaw('ap_id_hash = UNHEX(SHA2(?, 256))', [apId])
+            .first();
     }
 
     /**

--- a/src/http/api/views/account.follows.view.ts
+++ b/src/http/api/views/account.follows.view.ts
@@ -164,7 +164,9 @@ export class AccountFollowsView {
                 }
 
                 const followeeAccount = await this.db('accounts')
-                    .where('ap_id', followsActorObj.id?.toString() || '')
+                    .whereRaw('ap_id_hash = UNHEX(SHA2(?, 256))', [
+                        followsActorObj.id?.toString() || '',
+                    ])
                     .first();
 
                 const followsActor = (await followsActorObj.toJsonLd({


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-677

- The `ap_id` column is not indexed due to the size of it, instead we have
the `ap_id_hash` column which contains the SHA256 of the `ap_id` and is indexed. We should never be adding WHERE conditions on the `ap_id` columns in the codebase, it should always be via the indexed hash instead.