### PR TITLE
Fixed performance of queries using ap_id

### DIFF
--- a/src/account/account.repository.knex.ts
+++ b/src/account/account.repository.knex.ts
@@ -87,7 +87,7 @@ export class KnexAccountRepository {
 
     async getByApId(apId: URL): Promise<Account | null> {
         const accountRow = await this.db('accounts')
-            .where('accounts.ap_id', apId.href)
+            .whereRaw('ap_id_hash = UNHEX(SHA2(?, 256))', [apId.href])
             .leftJoin('users', 'users.account_id', 'accounts.id')
             .select(
                 'accounts.id',

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -149,7 +149,7 @@ export class AccountService {
             } catch (error) {
                 if (isDuplicateEntryError(error)) {
                     const existingAccount = await tx('accounts')
-                        .where({ ap_id: apId })
+                        .whereRaw('ap_id_hash = UNHEX(SHA2(?, 256))', [apId])
                         .first<AccountType>();
 
                     if (!existingAccount) {
@@ -194,7 +194,9 @@ export class AccountService {
         } catch (error) {
             if (isDuplicateEntryError(error)) {
                 const existingAccount = await this.db('accounts')
-                    .where({ ap_id: accountData.ap_id })
+                    .whereRaw('ap_id_hash = UNHEX(SHA2(?, 256))', [
+                        accountData.ap_id,
+                    ])
                     .first<AccountType>();
 
                 if (!existingAccount) {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-677

- The `ap_id` column is not indexed due to the size of it, instead we have
the `ap_id_hash` column which contains the SHA256 of the `ap_id` and is indexed. We should never be adding WHERE conditions on the `ap_id` columns in the codebase, it should always be via the indexed hash instead.