### PR TITLE
Removed redundant `attachments` field on account DTO

### DIFF
--- a/src/http/api/__snapshots__/views/AccountView.viewByApId.internal-no-context.json
+++ b/src/http/api/__snapshots__/views/AccountView.viewByApId.internal-no-context.json
@@ -1,5 +1,4 @@
 {
-  "attachment": [],
   "avatarUrl": "Test site",
   "bannerImageUrl": "",
   "bio": "Test site",

--- a/src/http/api/__snapshots__/views/AccountView.viewById.no-context.json
+++ b/src/http/api/__snapshots__/views/AccountView.viewById.no-context.json
@@ -1,5 +1,4 @@
 {
-  "attachment": [],
   "avatarUrl": "Test site",
   "bannerImageUrl": "",
   "bio": "Test site",

--- a/src/http/api/types.ts
+++ b/src/http/api/types.ts
@@ -61,19 +61,6 @@ export interface AccountDTO {
      * Whether the account of the current user is following this account
      */
     followedByMe: boolean;
-    /**
-     * Attachments of the account
-     */
-    attachment: {
-        /**
-         * Name of the attachment
-         */
-        name: string;
-        /**
-         * Value of the attachment
-         */
-        value: string;
-    }[];
 }
 
 export type AuthorDTO = Pick<

--- a/src/http/api/views/account.view.ts
+++ b/src/http/api/views/account.view.ts
@@ -73,7 +73,6 @@ export class AccountView {
             followerCount: accountData.follower_count,
             followedByMe,
             followsMe,
-            attachment: [], // TODO: I don't think we need this
         };
     }
 
@@ -153,7 +152,6 @@ export class AccountView {
             followerCount: accountData.follower_count,
             followedByMe,
             followsMe,
-            attachment: [], // TODO: I don't think we need this
         };
     }
 
@@ -232,7 +230,6 @@ export class AccountView {
             followerCount: followerCount,
             followedByMe,
             followsMe,
-            attachment: [], // TODO: I don't think we need this
         };
     }
 


### PR DESCRIPTION
no refs

Removed redundant `attachments` field on account DTO. This was previously added in error as the data that would be stored in this is actually meant for the `customFields` field