### PR TITLE
Moved `follow` handler to dedicated class

### DIFF
--- a/src/activity-handlers/follow.handler.ts
+++ b/src/activity-handlers/follow.handler.ts
@@ -1,0 +1,78 @@
+import { Accept, type Context, type Follow } from '@fedify/fedify';
+import { v4 as uuidv4 } from 'uuid';
+
+import type { AccountService } from 'account/account.service';
+import { mapActorToExternalAccountData } from 'account/utils';
+import type { ContextData } from 'app';
+import { addToList } from 'kv-helpers';
+
+export class FollowHandler {
+    constructor(private readonly accountService: AccountService) {}
+
+    async handle(ctx: Context<ContextData>, follow: Follow) {
+        ctx.data.logger.info('Handling Follow');
+        if (!follow.id) {
+            return;
+        }
+        const parsed = ctx.parseUri(follow.objectId);
+        if (parsed?.type !== 'actor') {
+            // TODO Log
+            return;
+        }
+        const sender = await follow.getActor(ctx);
+        if (sender === null || sender.id === null) {
+            return;
+        }
+
+        // Add follow activity to inbox
+        const followJson = await follow.toJsonLd();
+
+        ctx.data.globaldb.set([follow.id.href], followJson);
+        await addToList(ctx.data.db, ['inbox'], follow.id.href);
+
+        // Record follower in followers list
+        const senderJson = await sender.toJsonLd();
+
+        // Store or update sender in global db
+        ctx.data.globaldb.set([sender.id.href], senderJson);
+
+        // Record the account of the sender as well as the follow
+        const followeeAccount = await this.accountService.getAccountByApId(
+            follow.objectId?.href ?? '',
+        );
+        if (followeeAccount) {
+            let followerAccount = await this.accountService.getAccountByApId(
+                sender.id.href,
+            );
+
+            if (!followerAccount) {
+                ctx.data.logger.info(
+                    `Follower account "${sender.id.href}" not found, creating`,
+                );
+
+                followerAccount =
+                    await this.accountService.createExternalAccount(
+                        await mapActorToExternalAccountData(sender),
+                    );
+            }
+
+            await this.accountService.recordAccountFollow(
+                followeeAccount,
+                followerAccount,
+            );
+        }
+
+        // Send accept activity to sender
+        const acceptId = ctx.getObjectUri(Accept, { id: uuidv4() });
+        const accept = new Accept({
+            id: acceptId,
+            actor: follow.objectId,
+            object: follow,
+        });
+        const acceptJson = await accept.toJsonLd();
+
+        await ctx.data.globaldb.set([accept.id!.href], acceptJson);
+
+        await ctx.sendActivity({ handle: parsed.handle }, sender, accept);
+    }
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -35,6 +35,7 @@ import * as Sentry from '@sentry/node';
 import type { Account } from 'account/account.entity';
 import { KnexAccountRepository } from 'account/account.repository.knex';
 import { CreateHandler } from 'activity-handlers/create.handler';
+import { FollowHandler } from 'activity-handlers/follow.handler';
 import { FollowersService } from 'activitypub/followers.service';
 import { DeleteDispatcher } from 'activitypub/object-dispatchers/delete.dispatcher';
 import { AsyncEvents } from 'core/events';
@@ -61,7 +62,6 @@ import {
     createAcceptHandler,
     createAnnounceHandler,
     createDispatcher,
-    createFollowHandler,
     createFollowersCounter,
     createFollowersDispatcher,
     createFollowingCounter,
@@ -377,12 +377,16 @@ const deleteHandler = new DeleteHandler(
     postRepository,
 );
 
+const followHandler = new FollowHandler(accountService);
+
 const deleteDispatcher = new DeleteDispatcher();
 
 inboxListener
     .on(
         Follow,
-        ensureCorrectContext(spanWrapper(createFollowHandler(accountService))),
+        ensureCorrectContext(
+            spanWrapper(followHandler.handle.bind(followHandler)),
+        ),
     )
     .onError(inboxErrorHandler)
     .on(

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -22,7 +22,6 @@ import * as Sentry from '@sentry/node';
 import type { KnexAccountRepository } from 'account/account.repository.knex';
 import type { FollowersService } from 'activitypub/followers.service';
 import { exhaustiveCheck, getError, getValue, isError } from 'core/result';
-import { v4 as uuidv4 } from 'uuid';
 import type { AccountService } from './account/account.service';
 import { mapActorToExternalAccountData } from './account/utils';
 import { type ContextData, fedify } from './app';
@@ -109,77 +108,6 @@ export const keypairDispatcher = (
             return [];
         }
     };
-
-export function createFollowHandler(accountService: AccountService) {
-    return async function handleFollow(
-        ctx: Context<ContextData>,
-        follow: Follow,
-    ) {
-        ctx.data.logger.info('Handling Follow');
-        if (!follow.id) {
-            return;
-        }
-        const parsed = ctx.parseUri(follow.objectId);
-        if (parsed?.type !== 'actor') {
-            // TODO Log
-            return;
-        }
-        const sender = await follow.getActor(ctx);
-        if (sender === null || sender.id === null) {
-            return;
-        }
-
-        // Add follow activity to inbox
-        const followJson = await follow.toJsonLd();
-
-        ctx.data.globaldb.set([follow.id.href], followJson);
-        await addToList(ctx.data.db, ['inbox'], follow.id.href);
-
-        // Record follower in followers list
-        const senderJson = await sender.toJsonLd();
-
-        // Store or update sender in global db
-        ctx.data.globaldb.set([sender.id.href], senderJson);
-
-        // Record the account of the sender as well as the follow
-        const followeeAccount = await accountService.getAccountByApId(
-            follow.objectId?.href ?? '',
-        );
-        if (followeeAccount) {
-            let followerAccount = await accountService.getAccountByApId(
-                sender.id.href,
-            );
-
-            if (!followerAccount) {
-                ctx.data.logger.info(
-                    `Follower account "${sender.id.href}" not found, creating`,
-                );
-
-                followerAccount = await accountService.createExternalAccount(
-                    await mapActorToExternalAccountData(sender),
-                );
-            }
-
-            await accountService.recordAccountFollow(
-                followeeAccount,
-                followerAccount,
-            );
-        }
-
-        // Send accept activity to sender
-        const acceptId = ctx.getObjectUri(Accept, { id: uuidv4() });
-        const accept = new Accept({
-            id: acceptId,
-            actor: follow.objectId,
-            object: follow,
-        });
-        const acceptJson = await accept.toJsonLd();
-
-        await ctx.data.globaldb.set([accept.id!.href], acceptJson);
-
-        await ctx.sendActivity({ handle: parsed.handle }, sender, accept);
-    };
-}
 
 export function createAcceptHandler(accountService: AccountService) {
     return async function handleAccept(


### PR DESCRIPTION
no ref

Moved `follow` handler to dedicated class to follow the same pattern as the `create` & `delete` handlers in preparation for further work re: rejecting follow requests for blocked accounts