### PR TITLE
Added helper for checking account can interact with another

### DIFF
--- a/src/moderation/moderation.service.integration.test.ts
+++ b/src/moderation/moderation.service.integration.test.ts
@@ -251,31 +251,32 @@ describe('ModerationService', () => {
         });
     });
 
-    describe('filterUsersForAccountInteraction', () => {
-        it('should filter out users that have blocked the interaction account', async () => {
-            const [
-                [aliceAccount, , aliceUserId],
-                [bobAccount, , bobUserId],
-                [, , charlieUserId],
-            ] = await Promise.all([
-                fixtureManager.createInternalAccount(),
-                fixtureManager.createInternalAccount(),
-                fixtureManager.createInternalAccount(),
-            ]);
+    describe('canInteractWithAccount', () => {
+        it('should return a boolean to indicate if the interaction account can interact with the target account', async () => {
+            const [[aliceAccount], [bobAccount], [charlieAccount]] =
+                await Promise.all([
+                    fixtureManager.createInternalAccount(),
+                    fixtureManager.createInternalAccount(),
+                    fixtureManager.createInternalAccount(),
+                ]);
 
-            await Promise.all([
-                // alice blocks bob
-                fixtureManager.createBlock(aliceAccount, bobAccount),
-            ]);
+            await fixtureManager.createBlock(aliceAccount, bobAccount);
 
-            const users =
-                await moderationService.filterUsersForAccountInteraction(
-                    [aliceUserId, bobUserId, charlieUserId],
-                    bobAccount.id!,
+            const bobCanInteractWithAlice =
+                await moderationService.canInteractWithAccount(
+                    bobAccount.id,
+                    aliceAccount.id,
                 );
 
-            // alice should be filtered out because she blocked bob
-            expect(users).toEqual([bobUserId, charlieUserId]);
+            expect(bobCanInteractWithAlice).toBe(false);
+
+            const charlieCanInteractWithAlice =
+                await moderationService.canInteractWithAccount(
+                    charlieAccount.id,
+                    aliceAccount.id,
+                );
+
+            expect(charlieCanInteractWithAlice).toBe(true);
         });
     });
 });

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -161,15 +161,12 @@ export class NotificationService {
             return;
         }
 
-        const notificationAllowed = (
-            await this.moderationService.filterUsersForAccountInteraction(
-                [user.id],
+        const notificationAllowed =
+            await this.moderationService.canInteractWithAccount(
                 followerAccount.id,
-            )
-        ).includes(user.id);
+                account.id,
+            );
 
-        // If the user is filtered out for the follower account interaction,
-        // do not create a notification
         if (!notificationAllowed) {
             return;
         }
@@ -206,15 +203,12 @@ export class NotificationService {
             return;
         }
 
-        const notificationAllowed = (
-            await this.moderationService.filterUsersForPost(
-                [user.id],
-                post,
+        const notificationAllowed =
+            await this.moderationService.canInteractWithAccount(
                 accountId,
-            )
-        ).includes(user.id);
+                post.author.id,
+            );
 
-        // If the user is filtered out for the post, do not create a notification
         if (!notificationAllowed) {
             return;
         }
@@ -251,15 +245,12 @@ export class NotificationService {
             return;
         }
 
-        const notificationAllowed = (
-            await this.moderationService.filterUsersForPost(
-                [user.id],
-                post,
+        const notificationAllowed =
+            await this.moderationService.canInteractWithAccount(
                 accountId,
-            )
-        ).includes(user.id);
+                post.author.id,
+            );
 
-        // If the user is filtered out for the post, do not create a notification
         if (!notificationAllowed) {
             return;
         }
@@ -310,11 +301,12 @@ export class NotificationService {
             return;
         }
 
-        const notificationAllowed = (
-            await this.moderationService.filterUsersForPost([user.id], post)
-        ).includes(user.id);
+        const notificationAllowed =
+            await this.moderationService.canInteractWithAccount(
+                post.author.id,
+                inReplyToPost.author_id,
+            );
 
-        // If the user is filtered out for the post, do not create a notification
         if (!notificationAllowed) {
             return;
         }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-1082

Added a helper to the moderation service to check if an account can interact with another account. This will be used in various places throughout the application (i.e checking account can follow another account, checking account can like a post by another account etc.). This helper replaces the previously implemented `filterUsersForAccountInteraction` as it was unnecessarily complex for its use case.