### PR TITLE
Removed redundant post filtering from moderation service

### DIFF
--- a/src/moderation/moderation.service.integration.test.ts
+++ b/src/moderation/moderation.service.integration.test.ts
@@ -1,8 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import type { Knex } from 'knex';
-
-import { postToDTO } from 'http/api/helpers/post';
 import { createTestDb } from 'test/db';
 import { type FixtureManager, createFixtureManager } from 'test/fixtures';
 import { ModerationService } from './moderation.service';
@@ -20,105 +18,6 @@ describe('ModerationService', () => {
 
     beforeEach(async () => {
         await fixtureManager.reset();
-    });
-
-    it('should filter posts from blocked accounts', async () => {
-        const [[account], [blockedAccount]] = await Promise.all([
-            fixtureManager.createInternalAccount(null, 'example.com'),
-            fixtureManager.createInternalAccount(null, 'blocked.com'),
-        ]);
-
-        const [post1, post2, post3] = await Promise.all([
-            fixtureManager.createPost(account),
-            fixtureManager.createPost(blockedAccount),
-            fixtureManager.createPost(account),
-        ]);
-
-        await fixtureManager.createBlock(account, blockedAccount);
-
-        const posts = await moderationService.filterBlockedPostsForAccount(
-            account,
-            [postToDTO(post1), postToDTO(post2), postToDTO(post3)],
-        );
-
-        expect(posts).toHaveLength(2);
-        expect(posts[0].id).toBe(post1.apId.toString());
-        expect(posts[1].id).toBe(post3.apId.toString());
-    });
-
-    it('should filter posts from multiple blocked accounts', async () => {
-        const [[account], [blockedAccount1], [blockedAccount2]] =
-            await Promise.all([
-                fixtureManager.createInternalAccount(null, 'example.com'),
-                fixtureManager.createInternalAccount(null, 'blocked1.com'),
-                fixtureManager.createInternalAccount(null, 'blocked2.com'),
-            ]);
-
-        const [post1, post2, post3] = await Promise.all([
-            fixtureManager.createPost(account),
-            fixtureManager.createPost(blockedAccount1),
-            fixtureManager.createPost(blockedAccount2),
-        ]);
-
-        await fixtureManager.createBlock(account, blockedAccount1);
-        await fixtureManager.createBlock(account, blockedAccount2);
-
-        const posts = await moderationService.filterBlockedPostsForAccount(
-            account,
-            [postToDTO(post1), postToDTO(post2), postToDTO(post3)],
-        );
-
-        expect(posts).toHaveLength(1);
-        expect(posts[0].id).toBe(post1.apId.toString());
-    });
-
-    it('should filter reposts from blocked accounts', async () => {
-        const [[account], [unblockedAccount], [blockedAccount]] =
-            await Promise.all([
-                fixtureManager.createInternalAccount(null, 'example.com'),
-                fixtureManager.createInternalAccount(null, 'unblocked.com'),
-                fixtureManager.createInternalAccount(null, 'blocked.com'),
-            ]);
-
-        const [post1, post2, post3] = await Promise.all([
-            fixtureManager.createPost(account),
-            fixtureManager.createPost(unblockedAccount),
-            fixtureManager.createPost(account),
-        ]);
-
-        await fixtureManager.createBlock(account, blockedAccount);
-
-        const posts = await moderationService.filterBlockedPostsForAccount(
-            account,
-            [
-                postToDTO(post1),
-                postToDTO(post2, {
-                    authoredByMe: false,
-                    likedByMe: false,
-                    repostedByMe: false,
-                    repostedBy: blockedAccount,
-                }),
-                postToDTO(post3),
-            ],
-        );
-
-        expect(posts).toHaveLength(2);
-        expect(posts[0].id).toBe(post1.apId.toString());
-        expect(posts[1].id).toBe(post3.apId.toString());
-    });
-
-    it('should do nothing if there are no posts', async () => {
-        const [account] = await fixtureManager.createInternalAccount(
-            null,
-            'example.com',
-        );
-
-        const posts = await moderationService.filterBlockedPostsForAccount(
-            account,
-            [],
-        );
-
-        expect(posts).toEqual([]);
     });
 
     describe('filterUsersForPost', () => {

--- a/src/moderation/moderation.service.ts
+++ b/src/moderation/moderation.service.ts
@@ -1,32 +1,8 @@
-import type { Account } from 'account/account.entity';
-import type { PostDTO } from 'http/api/types';
 import type { Knex } from 'knex';
 import type { Post } from 'post/post.entity';
 
 export class ModerationService {
     constructor(private readonly db: Knex) {}
-
-    async filterBlockedPostsForAccount(account: Account, posts: PostDTO[]) {
-        if (posts.length === 0) {
-            return [];
-        }
-
-        const blockedAccountIds = new Set(
-            (
-                await this.db('blocks')
-                    .innerJoin('accounts', 'blocks.blocked_id', 'accounts.id')
-                    .select('accounts.ap_id')
-                    .where('blocks.blocker_id', account.id)
-            ).map((row) => row.ap_id),
-        );
-
-        return posts.filter(
-            (post) =>
-                !blockedAccountIds.has(post.author.id) &&
-                (post.repostedBy === null ||
-                    !blockedAccountIds.has(post.repostedBy.id)),
-        );
-    }
 
     async filterUsersForPost(
         userIds: number[],


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-1082

Removed the logic added for poster filtering from the moderation service as this is now redundant