### PR TITLE
Fixed feed items not being removed on block

### DIFF
--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -352,6 +352,15 @@ export class FeedService {
         feedAccountId: number,
         blockedAccountId: number,
     ) {
+        const user = await this.db('users')
+            .where('account_id', feedAccountId)
+            .select('id')
+            .first();
+
+        if (!user) {
+            return;
+        }
+
         await this.db('feeds')
             .where((qb) => {
                 qb.where('author_id', blockedAccountId).orWhere(
@@ -359,7 +368,7 @@ export class FeedService {
                     blockedAccountId,
                 );
             })
-            .andWhere('user_id', feedAccountId)
+            .andWhere('user_id', user.id)
             .delete();
     }
 }

--- a/src/feed/feed.service.unit.test.ts
+++ b/src/feed/feed.service.unit.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Knex } from 'knex';
+
+import type { ModerationService } from 'moderation/moderation.service';
+
+import { FeedService } from './feed.service';
+
+describe('FeedService', () => {
+    describe('removeBlockedAccountPostsFromFeed', () => {
+        it('should do nothing if the user associated with the feed account does not exist', async () => {
+            const mockKnex = {
+                where: vi.fn().mockReturnThis(),
+                andWhere: vi.fn().mockReturnThis(),
+                delete: vi.fn().mockReturnThis(),
+                select: vi.fn().mockReturnThis(),
+                first: vi.fn(),
+            };
+            const db = () => mockKnex;
+            const moderationService = {} as ModerationService;
+            const feedService = new FeedService(
+                db as unknown as Knex,
+                moderationService,
+            );
+
+            await feedService.removeBlockedAccountPostsFromFeed(123, 456);
+
+            expect(mockKnex.delete).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
ref https://github.com/ghost/ghost/issues/1082

When an account was blocked, the feed items were not being removed from the feed as expected. This was due to a bug where the account id was being used to reference the feed owner instead of the user id associated with the account