### PR TITLE
Allowed invalid URI for authors.profile_image

### DIFF
--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -403,7 +403,12 @@ function createWebhookPost() {
                 published_at: new Date().toISOString(),
                 url: `http://fake-external-activitypub.test/post/${uuid}`,
                 visibility: 'public',
-                authors: [],
+                authors: [
+                    {
+                        name: 'Testing',
+                        profile_image: '//gravatar.com/avatar/blah',
+                    },
+                ],
             },
         },
     };

--- a/src/http/api/webhook.ts
+++ b/src/http/api/webhook.ts
@@ -23,7 +23,7 @@ const PostInputSchema = z.object({
         .array(
             z.object({
                 name: z.string(),
-                profile_image: z.string().url().nullable(),
+                profile_image: z.string().nullable(),
             }),
         )
         .nullable()


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1572

Ghost sometimes uses a schemaless URL for the profile_image of authors and we weren't able to handle it. This removes the validation entirely and just trusts what Ghost sends.