### PR TITLE
Removed redundant `PostType` type

### DIFF
--- a/src/feed/types.ts
+++ b/src/feed/types.ts
@@ -1,4 +1,0 @@
-export enum PostType {
-    Article = 1,
-    Note = 2,
-}


### PR DESCRIPTION
no ref

Removed redundant `PostType` type that was left over from previous feed implementation. This type has been superseded by the `PostType` that is colocated with the `Post` entity → https://github.com/TryGhost/ActivityPub/blob/main/src/post/post.entity.ts#L8-L12