### PR TITLE
Ensured follow relationship is removed when account is blocked

### DIFF
--- a/src/account/account.repository.knex.ts
+++ b/src/account/account.repository.knex.ts
@@ -42,6 +42,17 @@ export class KnexAccountRepository {
                         })
                         .onConflict(['blocker_id', 'blocked_id'])
                         .ignore();
+
+                    await transaction('follows')
+                        .where({
+                            follower_id: event.getBlockerId(),
+                            following_id: event.getAccountId(),
+                        })
+                        .orWhere({
+                            follower_id: event.getAccountId(),
+                            following_id: event.getBlockerId(),
+                        })
+                        .delete();
                 } else if (event instanceof AccountUnblockedEvent) {
                     await transaction('blocks')
                         .where({


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-1082

When an account blocks another account, any existing follow relationships between both accounts, in any direction, should be removed. This only removes the relationship on our system and does not federate the change (i.e we do not send an `Undo` of the original `Follow` activity).