### PR TITLE
Refactored cucumber setup to allow for multiple step definition files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,6 +174,8 @@ services:
       - GCP_BUCKET_NAME=activitypub
       - GCP_STORAGE_EMULATOR_HOST=http://fake-gcs:4443
       - TAGS
+      - URL_GHOST_ACTIVITY_PUB=http://fake-ghost-activitypub.test
+      - URL_EXTERNAL_ACTIVITY_PUB=http://fake-external-activitypub.test
     command: /opt/activitypub/node_modules/.bin/cucumber-js
     depends_on:
       fake-ghost-activitypub:

--- a/features/step_definitions/block_steps.js
+++ b/features/step_definitions/block_steps.js
@@ -1,0 +1,14 @@
+import { When } from '@cucumber/cucumber';
+
+import { fetchActivityPub } from '../support/request.js';
+
+When('we block {string}', async function (actorName) {
+    const actor = this.actors[actorName];
+
+    this.response = await fetchActivityPub(
+        `${process.env.URL_GHOST_ACTIVITY_PUB}/.ghost/activitypub/actions/block/${encodeURIComponent(actor.id)}`,
+        {
+            method: 'POST',
+        },
+    );
+});

--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -15,497 +15,28 @@ import {
 } from '@cucumber/cucumber';
 import { exportJwk, generateCryptoKeyPair } from '@fedify/fedify';
 import { merge } from 'es-toolkit';
-import jwt from 'jsonwebtoken';
-import Knex from 'knex';
 import jose from 'node-jose';
-import { v4 as uuidv4 } from 'uuid';
-import { WireMock } from 'wiremock-captain';
 
-// Get the current file's URL and convert it to a path
+import { getClient, reset as resetDatabase } from '../support/db.js';
+import {
+    createActivity,
+    createActor,
+    createObject,
+    createWebhookPost,
+} from '../support/fixtures.js';
+import { fetchActivityPub, waitForRequest } from '../support/request.js';
+import { parseActivityString, parseActorString } from '../support/steps.js';
+import {
+    getGhostActivityPub,
+    reset as resetWiremock,
+} from '../support/wiremock.js';
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const URL_EXTERNAL_ACTIVITY_PUB = 'http://fake-external-activitypub.test';
-const URL_GHOST_ACTIVITY_PUB = 'http://fake-ghost-activitypub.test';
-
-async function createActivity(type, object, actor) {
-    let activity;
-
-    if (type === 'Follow') {
-        activity = {
-            '@context': [
-                'https://www.w3.org/ns/activitystreams',
-                'https://w3id.org/security/data-integrity/v1',
-            ],
-            type: 'Follow',
-            id: `${URL_EXTERNAL_ACTIVITY_PUB}/follow/${uuidv4()}`,
-            to: 'as:Public',
-            object: object,
-            actor: actor,
-        };
-    }
-
-    if (type === 'Accept') {
-        activity = {
-            '@context': [
-                'https://www.w3.org/ns/activitystreams',
-                'https://w3id.org/security/data-integrity/v1',
-            ],
-            type: 'Accept',
-            id: `${URL_EXTERNAL_ACTIVITY_PUB}/accept/${uuidv4()}`,
-            to: 'as:Public',
-            object: object,
-            actor: actor,
-        };
-    }
-
-    if (type === 'Reject') {
-        activity = {
-            '@context': [
-                'https://www.w3.org/ns/activitystreams',
-                'https://w3id.org/security/data-integrity/v1',
-            ],
-            type: 'Reject',
-            id: `${URL_EXTERNAL_ACTIVITY_PUB}/reject/${uuidv4()}`,
-            to: 'as:Public',
-            object: object,
-            actor: actor,
-        };
-    }
-
-    if (type === 'Create') {
-        activity = {
-            '@context': [
-                'https://www.w3.org/ns/activitystreams',
-                'https://w3id.org/security/data-integrity/v1',
-            ],
-            type: 'Create',
-            id: `${URL_EXTERNAL_ACTIVITY_PUB}/create/${uuidv4()}`,
-            to: 'as:Public',
-            object: object,
-            actor: actor,
-        };
-    }
-
-    if (type === 'Announce') {
-        activity = {
-            '@context': [
-                'https://www.w3.org/ns/activitystreams',
-                'https://w3id.org/security/data-integrity/v1',
-            ],
-            type: 'Announce',
-            id: `${URL_EXTERNAL_ACTIVITY_PUB}/announce/${uuidv4()}`,
-            to: 'as:Public',
-            object: object,
-            actor: actor,
-        };
-    }
-
-    if (type === 'Like') {
-        activity = {
-            '@context': [
-                'https://www.w3.org/ns/activitystreams',
-                'https://w3id.org/security/data-integrity/v1',
-            ],
-            type: 'Like',
-            id: `${URL_EXTERNAL_ACTIVITY_PUB}/like/${uuidv4()}`,
-            to: 'as:Public',
-            object: object,
-            actor: actor,
-        };
-    }
-
-    if (type === 'Undo') {
-        activity = {
-            '@context': [
-                'https://www.w3.org/ns/activitystreams',
-                'https://w3id.org/security/data-integrity/v1',
-            ],
-            type: 'Undo',
-            id: `${URL_EXTERNAL_ACTIVITY_PUB}/undo/${uuidv4()}`,
-            to: 'as:Public',
-            object: object,
-            actor: actor,
-        };
-    }
-
-    if (type === 'Delete') {
-        activity = {
-            '@context': [
-                'https://www.w3.org/ns/activitystreams',
-                'https://w3id.org/security/data-integrity/v1',
-            ],
-            type: 'Delete',
-            id: `${URL_EXTERNAL_ACTIVITY_PUB}/delete/${uuidv4()}`,
-            to: 'as:Public',
-            object: object,
-            actor: actor,
-        };
-    }
-
-    externalActivityPub.register(
-        {
-            method: 'GET',
-            endpoint: activity.id.replace(URL_EXTERNAL_ACTIVITY_PUB, ''),
-        },
-        {
-            status: 200,
-            body: activity,
-            headers: {
-                'Content-Type': 'application/activity+json',
-            },
-        },
-    );
-
-    return activity;
-}
-
-async function createActor(name, { remote = true, type = 'Person' } = {}) {
-    if (remote === false) {
-        return {
-            '@context': [
-                'https://www.w3.org/ns/activitystreams',
-                'https://w3id.org/security/data-integrity/v1',
-            ],
-            id: 'http://fake-ghost-activitypub.test/.ghost/activitypub/users/index',
-            url: 'http://fake-ghost-activitypub.test/.ghost/activitypub/users/index',
-            type,
-
-            handle: '@index@fake-ghost-activitypub.test',
-
-            preferredUsername: 'index',
-            name,
-            summary: 'A test actor for testing',
-
-            inbox: 'http://fake-ghost-activitypub.test/.ghost/activitypub/inbox/index',
-            outbox: 'http://fake-ghost-activitypub.test/.ghost/activitypub/outbox/index',
-            followers:
-                'http://fake-ghost-activitypub.test/.ghost/activitypub/followers/index',
-            following:
-                'http://fake-ghost-activitypub.test/.ghost/activitypub/following/index',
-            liked: 'http://fake-ghost-activitypub.test/.ghost/activitypub/liked/index',
-
-            'https://w3id.org/security#publicKey': {
-                id: 'http://fake-ghost-activitypub.test/.ghost/activitypub/users/index#main-key',
-                type: 'https://w3id.org/security#Key',
-                'https://w3id.org/security#owner': {
-                    id: 'http://fake-ghost-activitypub.test/.ghost/activitypub/users/index',
-                },
-                'https://w3id.org/security#publicKeyPem':
-                    '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtSc3IqGjRaO3vcFdQ15D\nF90WVJC6tb2QwYBh9kQYVlQ1VhBiF6E4GK2okvyvukIL5PHLCgfQrfJmSiopk9Xo\n46Qri6rJbcPoWoZz/jWN0pfmU20hNuTQx6ebSoSkg6rHv1MKuy5LmDGLFC2ze3kU\nsY8u7X6TOBrifs/N+goLaH3+SkT2hZDKWJrmDyHzj043KLvXs/eiyu50M+ERoSlg\n70uO7QAXQFuLMILdy0UNJFM4xjlK6q4Jfbm4MC8QRG+i31AkmNvpY9JqCLqu0mGD\nBrdfJeN8PN+7DHW/Pzspf5RlJtlvBx1dS8Bxo2xteUyLGIaTZ9HZFhHc3IrmmKeW\naQIDAQAB\n-----END PUBLIC KEY-----\n',
-            },
-        };
-    }
-
-    const user = {
-        '@context': [
-            'https://www.w3.org/ns/activitystreams',
-            'https://w3id.org/security/data-integrity/v1',
-        ],
-        id: `http://fake-external-activitypub.test/user/${name}`,
-        url: `http://fake-external-activitypub.test/user/${name}`,
-        type,
-
-        handle: `@${name}@fake-external-activitypub.test`,
-
-        preferredUsername: name,
-        name,
-        summary: 'A test actor for testing',
-
-        inbox: `http://fake-external-activitypub.test/inbox/${name}`,
-        outbox: `http://fake-external-activitypub.test/inbox/${name}`,
-        followers: `http://fake-external-activitypub.test/followers/${name}`,
-        following: `http://fake-external-activitypub.test/following/${name}`,
-        liked: `http://fake-external-activitypub.test/liked/${name}`,
-
-        'https://w3id.org/security#publicKey': {
-            id: 'http://fake-external-activitypub.test/user#main-key',
-            type: 'https://w3id.org/security#Key',
-            'https://w3id.org/security#owner': {
-                id: 'http://fake-external-activitypub.test/user',
-            },
-            'https://w3id.org/security#publicKeyPem':
-                '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtSc3IqGjRaO3vcFdQ15D\nF90WVJC6tb2QwYBh9kQYVlQ1VhBiF6E4GK2okvyvukIL5PHLCgfQrfJmSiopk9Xo\n46Qri6rJbcPoWoZz/jWN0pfmU20hNuTQx6ebSoSkg6rHv1MKuy5LmDGLFC2ze3kU\nsY8u7X6TOBrifs/N+goLaH3+SkT2hZDKWJrmDyHzj043KLvXs/eiyu50M+ERoSlg\n70uO7QAXQFuLMILdy0UNJFM4xjlK6q4Jfbm4MC8QRG+i31AkmNvpY9JqCLqu0mGD\nBrdfJeN8PN+7DHW/Pzspf5RlJtlvBx1dS8Bxo2xteUyLGIaTZ9HZFhHc3IrmmKeW\naQIDAQAB\n-----END PUBLIC KEY-----\n',
-        },
-    };
-
-    externalActivityPub.register(
-        {
-            method: 'POST',
-            endpoint: `/inbox/${name}`,
-        },
-        {
-            status: 202,
-        },
-    );
-
-    externalActivityPub.register(
-        {
-            method: 'GET',
-            endpoint: `/user/${name}`,
-        },
-        {
-            status: 200,
-            body: user,
-            headers: {
-                'Content-Type': 'application/activity+json',
-            },
-        },
-    );
-
-    externalActivityPub.register(
-        {
-            method: 'GET',
-            endpoint: `/followers/${name}`,
-        },
-        {
-            status: 200,
-            body: {
-                '@context': 'https://www.w3.org/ns/activitystreams',
-                type: 'OrderedCollection',
-                totalItems: 0,
-                orderedItems: [],
-            },
-            headers: {
-                'Content-Type': 'application/activity+json',
-            },
-        },
-    );
-
-    externalActivityPub.register(
-        {
-            method: 'GET',
-            endpoint: `/following/${name}`,
-        },
-        {
-            status: 200,
-            body: {
-                '@context': 'https://www.w3.org/ns/activitystreams',
-                type: 'OrderedCollection',
-                totalItems: 0,
-                orderedItems: [],
-            },
-            headers: {
-                'Content-Type': 'application/activity+json',
-            },
-        },
-    );
-
-    externalActivityPub.register(
-        {
-            method: 'GET',
-            endpoint: `/.well-known/webfinger?resource=${encodeURIComponent(`acct:${name}@fake-external-activitypub.test`)}`,
-        },
-        {
-            status: 200,
-            body: {
-                subject: `acct:${name}@fake-external-activitypub.test`,
-                aliases: [`http://fake-external-activitypub.test/user/${name}`],
-                links: [
-                    {
-                        rel: 'self',
-                        href: `http://fake-external-activitypub.test/user/${name}`,
-                        type: 'application/activity+json',
-                    },
-                    {
-                        rel: 'http://webfinger.net/rel/profile-page',
-                        href: 'https://activitypub.ghost.org/',
-                    },
-                    {
-                        rel: 'http://webfinger.net/rel/avatar',
-                        href: 'https://activitypub.ghost.org/content/images/2024/09/ghost-orb-white-squircle-07.png',
-                    },
-                ],
-            },
-        },
-    );
-
-    return user;
-}
-
-function generateObject(type, content) {
-    if (type === 'Article') {
-        const uuid = uuidv4();
-        return {
-            '@context': [
-                'https://www.w3.org/ns/activitystreams',
-                'https://w3id.org/security/data-integrity/v1',
-            ],
-            type: 'Article',
-            id: `http://fake-external-activitypub.test/article/${uuid}`,
-            url: `http://fake-external-activitypub.test/article/${uuid}`,
-            to: 'as:Public',
-            cc: 'http://fake-external-activitypub.test/followers',
-            content: content ?? '<p>This is a test article</p>',
-            published: new Date(),
-            attributedTo: 'http://fake-external-activitypub.test/user',
-        };
-    }
-
-    if (type === 'Note') {
-        const uuid = uuidv4();
-        return {
-            '@context': [
-                'https://www.w3.org/ns/activitystreams',
-                'https://w3id.org/security/data-integrity/v1',
-            ],
-            type: 'Note',
-            id: `http://fake-external-activitypub.test/note/${uuid}`,
-            url: `http://fake-external-activitypub.test/note/${uuid}`,
-            to: 'as:Public',
-            cc: 'http://fake-external-activitypub.test/followers',
-            content: content ?? '<p>This is a test note</p>',
-            published: new Date(),
-            attributedTo: 'http://fake-external-activitypub.test/user',
-        };
-    }
-
-    if (type === 'Accept') {
-        const uuid = uuidv4();
-        return {
-            '@context': [
-                'https://www.w3.org/ns/activitystreams',
-                'https://w3id.org/security/data-integrity/v1',
-            ],
-            type: 'Accept',
-            id: `http://fake-external-activitypub.test/accept/${uuid}`,
-            url: `http://fake-external-activitypub.test/accept/${uuid}`,
-        };
-    }
-}
-
-async function createObject(type, actor, content) {
-    const object = generateObject(type, content);
-
-    if (!object) {
-        throw new Error(`Cannot create objects of type ${type}`);
-    }
-
-    object.attributedTo = actor.id;
-
-    const url = new URL(object.id);
-
-    externalActivityPub.register(
-        {
-            method: 'GET',
-            endpoint: url.pathname,
-        },
-        {
-            status: 200,
-            body: object,
-            headers: {
-                'Content-Type': 'application/activity+json',
-            },
-        },
-    );
-
-    return object;
-}
-
-function createWebhookPost() {
-    const uuid = uuidv4();
-
-    return {
-        post: {
-            current: {
-                uuid,
-                title: 'Test Post',
-                html: '<p>This is a test post</p>',
-                excerpt: 'This is a test post',
-                custom_excerpt: null,
-                feature_image: null,
-                published_at: new Date().toISOString(),
-                url: `http://fake-external-activitypub.test/post/${uuid}`,
-                visibility: 'public',
-                authors: [
-                    {
-                        name: 'Testing',
-                        profile_image: '//gravatar.com/avatar/blah',
-                    },
-                ],
-            },
-        },
-    };
-}
-
-/**
- *
- * Splits a string like `Create(Note)` or `Like(A)` into its activity and object parts
- *
- * @param {string} string
- * @returns {{activity: string, object: string} | {activity: null, object: null}}
- */
-function parseActivityString(string) {
-    const [match, activity, object] = string.match(/(\w+)\((.+)\)/) || [null];
-    if (!match) {
-        return {
-            activity: null,
-            object: null,
-        };
-    }
-    return {
-        activity,
-        object,
-    };
-}
-
-/**
- *
- * Splits a string like `Person(Alice)` or `Group(Wonderland)` into its type and name parts
- *
- * @param {string} string
- * @returns {{type: string, name: string} | {type: null, name: null}}
- */
-function parseActorString(string) {
-    const [match, type, name] = string.match(/(\w+)\((.+)\)/) || [null];
-    if (!match) {
-        return {
-            type: null,
-            name: null,
-        };
-    }
-    return {
-        type,
-        name,
-    };
-}
-
-let /* @type Knex */ client;
-let /* @type WireMock */ externalActivityPub;
-let /* @type WireMock */ ghostActivityPub;
 let webhookSecret;
 
-async function resetDatabase() {
-    await client.raw('SET FOREIGN_KEY_CHECKS = 0');
-    await client('key_value').truncate();
-    await client('notifications').truncate();
-    await client('feeds').truncate();
-    await client('blocks').truncate();
-    await client('follows').truncate();
-    await client('likes').truncate();
-    await client('reposts').truncate();
-    await client('posts').truncate();
-    await client('accounts').truncate();
-    await client('users').truncate();
-    await client('sites').truncate();
-    await client.raw('SET FOREIGN_KEY_CHECKS = 1');
-}
-
 BeforeAll(async () => {
-    client = Knex({
-        client: 'mysql2',
-        connection: {
-            host: process.env.MYSQL_HOST,
-            port: Number.parseInt(process.env.MYSQL_PORT),
-            user: process.env.MYSQL_USER,
-            password: process.env.MYSQL_PASSWORD,
-            database: process.env.MYSQL_DATABASE,
-            timezone: '+00:00',
-        },
-    });
-
-    await resetDatabase();
-
     webhookSecret = fs.readFileSync(
         resolve(__dirname, '../fixtures/webhook_secret.txt'),
         'utf8',
@@ -513,8 +44,7 @@ BeforeAll(async () => {
 });
 
 BeforeAll(async () => {
-    externalActivityPub = new WireMock(URL_EXTERNAL_ACTIVITY_PUB);
-    ghostActivityPub = new WireMock(URL_GHOST_ACTIVITY_PUB);
+    const ghostActivityPub = getGhostActivityPub();
 
     const publicKey = fs.readFileSync(
         resolve(__dirname, '../fixtures/private.key'),
@@ -566,15 +96,15 @@ BeforeAll(async () => {
 });
 
 AfterAll(async () => {
-    await client.destroy();
+    await getClient().destroy();
 });
 
 Before(async function () {
-    await externalActivityPub.clearAllRequests();
+    await resetWiremock();
     await resetDatabase();
 
-    const [siteId] = await client('sites').insert({
-        host: new URL(URL_GHOST_ACTIVITY_PUB).host,
+    const [siteId] = await getClient()('sites').insert({
+        host: new URL(process.env.URL_GHOST_ACTIVITY_PUB).host,
         webhook_secret: webhookSecret,
     });
 
@@ -593,7 +123,7 @@ Before(async function () {
 
         const keypair = await generateCryptoKeyPair();
 
-        const [accountId] = await client('accounts').insert({
+        const [accountId] = await getClient()('accounts').insert({
             username: actor.preferredUsername,
             name: actor.name,
             bio: actor.summary,
@@ -612,7 +142,7 @@ Before(async function () {
             ap_private_key: JSON.stringify(await exportJwk(keypair.privateKey)),
         });
 
-        await client('users').insert({
+        await getClient()('users').insert({
             account_id: accountId,
             site_id: this.SITE_ID,
         });
@@ -623,36 +153,8 @@ Before(async function () {
     }
 });
 
-async function fetchActivityPub(url, options = {}, auth = true) {
-    if (!options.headers) {
-        options.headers = {};
-    }
-
-    const privateKey = fs.readFileSync(
-        resolve(__dirname, '../fixtures/private.key'),
-    );
-    const token = jwt.sign(
-        {
-            sub: 'test@user.com',
-            role: 'Owner',
-        },
-        privateKey,
-        {
-            algorithm: 'RS256',
-            keyid: 'test-key-id',
-            expiresIn: '5m',
-        },
-    );
-
-    if (auth) {
-        options.headers.Authorization = `Bearer ${token}`;
-    }
-
-    return fetch(url, options);
-}
-
 Given('there is no entry in the sites table', async function () {
-    await client('sites').del();
+    await getClient()('sites').del();
 
     this.SITE_ID = null;
 });
@@ -1207,32 +709,6 @@ When(
         );
     },
 );
-
-async function wait(n) {
-    return new Promise((resolve) => setTimeout(resolve, n));
-}
-
-async function waitForRequest(
-    method,
-    path,
-    matcher,
-    step = 100,
-    milliseconds = 1000,
-) {
-    const calls = await externalActivityPub.getRequestsForAPI(method, path);
-    const found = calls.find(matcher);
-
-    if (found) {
-        return found;
-    }
-
-    if (milliseconds <= 0) {
-        return null;
-    }
-
-    await wait(step);
-    return waitForRequest(method, path, matcher, step, milliseconds - step);
-}
 
 async function waitForInboxActivity(
     activity,
@@ -2147,18 +1623,4 @@ Then('the response contains the account details:', async function (data) {
             `Expected ${key} to be "${value}" but got "${responseJson[key]}"`,
         );
     }
-});
-
-When('we block {string}', async function (actorName) {
-    const actor = this.actors[actorName];
-
-    this.response = await fetchActivityPub(
-        `http://fake-ghost-activitypub.test/.ghost/activitypub/actions/block/${encodeURIComponent(actor.id)}`,
-        {
-            method: 'POST',
-            headers: {
-                Accept: 'application/ld+json',
-            },
-        },
-    );
 });

--- a/features/support/db.js
+++ b/features/support/db.js
@@ -1,0 +1,40 @@
+import Knex from 'knex';
+
+/** @type {import('knex').Knex} */
+let client;
+
+export function getClient() {
+    if (!client) {
+        client = Knex({
+            client: 'mysql2',
+            connection: {
+                host: process.env.MYSQL_HOST,
+                port: Number.parseInt(process.env.MYSQL_PORT),
+                user: process.env.MYSQL_USER,
+                password: process.env.MYSQL_PASSWORD,
+                database: process.env.MYSQL_DATABASE,
+                timezone: '+00:00',
+            },
+        });
+    }
+
+    return client;
+}
+
+export async function reset() {
+    const db = getClient();
+
+    await db.raw('SET FOREIGN_KEY_CHECKS = 0');
+    await db('key_value').truncate();
+    await db('notifications').truncate();
+    await db('feeds').truncate();
+    await db('blocks').truncate();
+    await db('follows').truncate();
+    await db('likes').truncate();
+    await db('reposts').truncate();
+    await db('posts').truncate();
+    await db('accounts').truncate();
+    await db('users').truncate();
+    await db('sites').truncate();
+    await db.raw('SET FOREIGN_KEY_CHECKS = 1');
+}

--- a/features/support/fixtures.js
+++ b/features/support/fixtures.js
@@ -1,0 +1,412 @@
+import { v4 as uuidv4 } from 'uuid';
+import { getExternalActivityPub } from './wiremock.js';
+
+function generateObject(type, content) {
+    if (type === 'Article') {
+        const uuid = uuidv4();
+        return {
+            '@context': [
+                'https://www.w3.org/ns/activitystreams',
+                'https://w3id.org/security/data-integrity/v1',
+            ],
+            type: 'Article',
+            id: `http://fake-external-activitypub.test/article/${uuid}`,
+            url: `http://fake-external-activitypub.test/article/${uuid}`,
+            to: 'as:Public',
+            cc: 'http://fake-external-activitypub.test/followers',
+            content: content ?? '<p>This is a test article</p>',
+            published: new Date(),
+            attributedTo: 'http://fake-external-activitypub.test/user',
+        };
+    }
+
+    if (type === 'Note') {
+        const uuid = uuidv4();
+        return {
+            '@context': [
+                'https://www.w3.org/ns/activitystreams',
+                'https://w3id.org/security/data-integrity/v1',
+            ],
+            type: 'Note',
+            id: `http://fake-external-activitypub.test/note/${uuid}`,
+            url: `http://fake-external-activitypub.test/note/${uuid}`,
+            to: 'as:Public',
+            cc: 'http://fake-external-activitypub.test/followers',
+            content: content ?? '<p>This is a test note</p>',
+            published: new Date(),
+            attributedTo: 'http://fake-external-activitypub.test/user',
+        };
+    }
+
+    if (type === 'Accept') {
+        const uuid = uuidv4();
+        return {
+            '@context': [
+                'https://www.w3.org/ns/activitystreams',
+                'https://w3id.org/security/data-integrity/v1',
+            ],
+            type: 'Accept',
+            id: `http://fake-external-activitypub.test/accept/${uuid}`,
+            url: `http://fake-external-activitypub.test/accept/${uuid}`,
+        };
+    }
+}
+
+export async function createObject(type, actor, content) {
+    const object = generateObject(type, content);
+
+    if (!object) {
+        throw new Error(`Cannot create objects of type ${type}`);
+    }
+
+    object.attributedTo = actor.id;
+
+    const url = new URL(object.id);
+
+    getExternalActivityPub().register(
+        {
+            method: 'GET',
+            endpoint: url.pathname,
+        },
+        {
+            status: 200,
+            body: object,
+            headers: {
+                'Content-Type': 'application/activity+json',
+            },
+        },
+    );
+
+    return object;
+}
+
+export async function createActivity(type, object, actor) {
+    let activity;
+
+    if (type === 'Follow') {
+        activity = {
+            '@context': [
+                'https://www.w3.org/ns/activitystreams',
+                'https://w3id.org/security/data-integrity/v1',
+            ],
+            type: 'Follow',
+            id: `${process.env.URL_EXTERNAL_ACTIVITY_PUB}/follow/${uuidv4()}`,
+            to: 'as:Public',
+            object: object,
+            actor: actor,
+        };
+    }
+
+    if (type === 'Accept') {
+        activity = {
+            '@context': [
+                'https://www.w3.org/ns/activitystreams',
+                'https://w3id.org/security/data-integrity/v1',
+            ],
+            type: 'Accept',
+            id: `${process.env.URL_EXTERNAL_ACTIVITY_PUB}/accept/${uuidv4()}`,
+            to: 'as:Public',
+            object: object,
+            actor: actor,
+        };
+    }
+
+    if (type === 'Reject') {
+        activity = {
+            '@context': [
+                'https://www.w3.org/ns/activitystreams',
+                'https://w3id.org/security/data-integrity/v1',
+            ],
+            type: 'Reject',
+            id: `${process.env.URL_EXTERNAL_ACTIVITY_PUB}/reject/${uuidv4()}`,
+            to: 'as:Public',
+            object: object,
+            actor: actor,
+        };
+    }
+
+    if (type === 'Create') {
+        activity = {
+            '@context': [
+                'https://www.w3.org/ns/activitystreams',
+                'https://w3id.org/security/data-integrity/v1',
+            ],
+            type: 'Create',
+            id: `${process.env.URL_EXTERNAL_ACTIVITY_PUB}/create/${uuidv4()}`,
+            to: 'as:Public',
+            object: object,
+            actor: actor,
+        };
+    }
+
+    if (type === 'Announce') {
+        activity = {
+            '@context': [
+                'https://www.w3.org/ns/activitystreams',
+                'https://w3id.org/security/data-integrity/v1',
+            ],
+            type: 'Announce',
+            id: `${process.env.URL_EXTERNAL_ACTIVITY_PUB}/announce/${uuidv4()}`,
+            to: 'as:Public',
+            object: object,
+            actor: actor,
+        };
+    }
+
+    if (type === 'Like') {
+        activity = {
+            '@context': [
+                'https://www.w3.org/ns/activitystreams',
+                'https://w3id.org/security/data-integrity/v1',
+            ],
+            type: 'Like',
+            id: `${process.env.URL_EXTERNAL_ACTIVITY_PUB}/like/${uuidv4()}`,
+            to: 'as:Public',
+            object: object,
+            actor: actor,
+        };
+    }
+
+    if (type === 'Undo') {
+        activity = {
+            '@context': [
+                'https://www.w3.org/ns/activitystreams',
+                'https://w3id.org/security/data-integrity/v1',
+            ],
+            type: 'Undo',
+            id: `${process.env.URL_EXTERNAL_ACTIVITY_PUB}/undo/${uuidv4()}`,
+            to: 'as:Public',
+            object: object,
+            actor: actor,
+        };
+    }
+
+    if (type === 'Delete') {
+        activity = {
+            '@context': [
+                'https://www.w3.org/ns/activitystreams',
+                'https://w3id.org/security/data-integrity/v1',
+            ],
+            type: 'Delete',
+            id: `${process.env.URL_EXTERNAL_ACTIVITY_PUB}/delete/${uuidv4()}`,
+            to: 'as:Public',
+            object: object,
+            actor: actor,
+        };
+    }
+
+    const externalActivityPub = getExternalActivityPub();
+
+    externalActivityPub.register(
+        {
+            method: 'GET',
+            endpoint: activity.id.replace(
+                process.env.URL_EXTERNAL_ACTIVITY_PUB,
+                '',
+            ),
+        },
+        {
+            status: 200,
+            body: activity,
+            headers: {
+                'Content-Type': 'application/activity+json',
+            },
+        },
+    );
+
+    return activity;
+}
+
+export async function createActor(
+    name,
+    { remote = true, type = 'Person' } = {},
+) {
+    if (remote === false) {
+        return {
+            '@context': [
+                'https://www.w3.org/ns/activitystreams',
+                'https://w3id.org/security/data-integrity/v1',
+            ],
+            id: 'http://fake-ghost-activitypub.test/.ghost/activitypub/users/index',
+            url: 'http://fake-ghost-activitypub.test/.ghost/activitypub/users/index',
+            type,
+
+            handle: '@index@fake-ghost-activitypub.test',
+
+            preferredUsername: 'index',
+            name,
+            summary: 'A test actor for testing',
+
+            inbox: 'http://fake-ghost-activitypub.test/.ghost/activitypub/inbox/index',
+            outbox: 'http://fake-ghost-activitypub.test/.ghost/activitypub/outbox/index',
+            followers:
+                'http://fake-ghost-activitypub.test/.ghost/activitypub/followers/index',
+            following:
+                'http://fake-ghost-activitypub.test/.ghost/activitypub/following/index',
+            liked: 'http://fake-ghost-activitypub.test/.ghost/activitypub/liked/index',
+
+            'https://w3id.org/security#publicKey': {
+                id: 'http://fake-ghost-activitypub.test/.ghost/activitypub/users/index#main-key',
+                type: 'https://w3id.org/security#Key',
+                'https://w3id.org/security#owner': {
+                    id: 'http://fake-ghost-activitypub.test/.ghost/activitypub/users/index',
+                },
+                'https://w3id.org/security#publicKeyPem':
+                    '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtSc3IqGjRaO3vcFdQ15D\nF90WVJC6tb2QwYBh9kQYVlQ1VhBiF6E4GK2okvyvukIL5PHLCgfQrfJmSiopk9Xo\n46Qri6rJbcPoWoZz/jWN0pfmU20hNuTQx6ebSoSkg6rHv1MKuy5LmDGLFC2ze3kU\nsY8u7X6TOBrifs/N+goLaH3+SkT2hZDKWJrmDyHzj043KLvXs/eiyu50M+ERoSlg\n70uO7QAXQFuLMILdy0UNJFM4xjlK6q4Jfbm4MC8QRG+i31AkmNvpY9JqCLqu0mGD\nBrdfJeN8PN+7DHW/Pzspf5RlJtlvBx1dS8Bxo2xteUyLGIaTZ9HZFhHc3IrmmKeW\naQIDAQAB\n-----END PUBLIC KEY-----\n',
+            },
+        };
+    }
+
+    const user = {
+        '@context': [
+            'https://www.w3.org/ns/activitystreams',
+            'https://w3id.org/security/data-integrity/v1',
+        ],
+        id: `http://fake-external-activitypub.test/user/${name}`,
+        url: `http://fake-external-activitypub.test/user/${name}`,
+        type,
+
+        handle: `@${name}@fake-external-activitypub.test`,
+
+        preferredUsername: name,
+        name,
+        summary: 'A test actor for testing',
+
+        inbox: `http://fake-external-activitypub.test/inbox/${name}`,
+        outbox: `http://fake-external-activitypub.test/inbox/${name}`,
+        followers: `http://fake-external-activitypub.test/followers/${name}`,
+        following: `http://fake-external-activitypub.test/following/${name}`,
+        liked: `http://fake-external-activitypub.test/liked/${name}`,
+
+        'https://w3id.org/security#publicKey': {
+            id: 'http://fake-external-activitypub.test/user#main-key',
+            type: 'https://w3id.org/security#Key',
+            'https://w3id.org/security#owner': {
+                id: 'http://fake-external-activitypub.test/user',
+            },
+            'https://w3id.org/security#publicKeyPem':
+                '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtSc3IqGjRaO3vcFdQ15D\nF90WVJC6tb2QwYBh9kQYVlQ1VhBiF6E4GK2okvyvukIL5PHLCgfQrfJmSiopk9Xo\n46Qri6rJbcPoWoZz/jWN0pfmU20hNuTQx6ebSoSkg6rHv1MKuy5LmDGLFC2ze3kU\nsY8u7X6TOBrifs/N+goLaH3+SkT2hZDKWJrmDyHzj043KLvXs/eiyu50M+ERoSlg\n70uO7QAXQFuLMILdy0UNJFM4xjlK6q4Jfbm4MC8QRG+i31AkmNvpY9JqCLqu0mGD\nBrdfJeN8PN+7DHW/Pzspf5RlJtlvBx1dS8Bxo2xteUyLGIaTZ9HZFhHc3IrmmKeW\naQIDAQAB\n-----END PUBLIC KEY-----\n',
+        },
+    };
+
+    const externalActivityPub = getExternalActivityPub();
+
+    externalActivityPub.register(
+        {
+            method: 'POST',
+            endpoint: `/inbox/${name}`,
+        },
+        {
+            status: 202,
+        },
+    );
+
+    externalActivityPub.register(
+        {
+            method: 'GET',
+            endpoint: `/user/${name}`,
+        },
+        {
+            status: 200,
+            body: user,
+            headers: {
+                'Content-Type': 'application/activity+json',
+            },
+        },
+    );
+
+    externalActivityPub.register(
+        {
+            method: 'GET',
+            endpoint: `/followers/${name}`,
+        },
+        {
+            status: 200,
+            body: {
+                '@context': 'https://www.w3.org/ns/activitystreams',
+                type: 'OrderedCollection',
+                totalItems: 0,
+                orderedItems: [],
+            },
+            headers: {
+                'Content-Type': 'application/activity+json',
+            },
+        },
+    );
+
+    externalActivityPub.register(
+        {
+            method: 'GET',
+            endpoint: `/following/${name}`,
+        },
+        {
+            status: 200,
+            body: {
+                '@context': 'https://www.w3.org/ns/activitystreams',
+                type: 'OrderedCollection',
+                totalItems: 0,
+                orderedItems: [],
+            },
+            headers: {
+                'Content-Type': 'application/activity+json',
+            },
+        },
+    );
+
+    externalActivityPub.register(
+        {
+            method: 'GET',
+            endpoint: `/.well-known/webfinger?resource=${encodeURIComponent(`acct:${name}@fake-external-activitypub.test`)}`,
+        },
+        {
+            status: 200,
+            body: {
+                subject: `acct:${name}@fake-external-activitypub.test`,
+                aliases: [`http://fake-external-activitypub.test/user/${name}`],
+                links: [
+                    {
+                        rel: 'self',
+                        href: `http://fake-external-activitypub.test/user/${name}`,
+                        type: 'application/activity+json',
+                    },
+                    {
+                        rel: 'http://webfinger.net/rel/profile-page',
+                        href: 'https://activitypub.ghost.org/',
+                    },
+                    {
+                        rel: 'http://webfinger.net/rel/avatar',
+                        href: 'https://activitypub.ghost.org/content/images/2024/09/ghost-orb-white-squircle-07.png',
+                    },
+                ],
+            },
+        },
+    );
+
+    return user;
+}
+
+export function createWebhookPost() {
+    const uuid = uuidv4();
+
+    return {
+        post: {
+            current: {
+                uuid,
+                title: 'Test Post',
+                html: '<p>This is a test post</p>',
+                excerpt: 'This is a test post',
+                custom_excerpt: null,
+                feature_image: null,
+                published_at: new Date().toISOString(),
+                url: `http://fake-external-activitypub.test/post/${uuid}`,
+                visibility: 'public',
+                authors: [
+                    {
+                        name: 'Testing',
+                        profile_image: '//gravatar.com/avatar/blah',
+                    },
+                ],
+            },
+        },
+    };
+}

--- a/features/support/request.js
+++ b/features/support/request.js
@@ -1,0 +1,64 @@
+import fs from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import jwt from 'jsonwebtoken';
+
+import { wait } from './utils.js';
+import { getExternalActivityPub } from './wiremock.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export async function fetchActivityPub(url, options = {}, auth = true) {
+    if (!options.headers) {
+        options.headers = {};
+    }
+
+    const privateKey = fs.readFileSync(
+        resolve(__dirname, '../fixtures/private.key'),
+    );
+
+    const token = jwt.sign(
+        {
+            sub: 'test@user.com',
+            role: 'Owner',
+        },
+        privateKey,
+        {
+            algorithm: 'RS256',
+            keyid: 'test-key-id',
+            expiresIn: '5m',
+        },
+    );
+
+    if (auth) {
+        options.headers.Authorization = `Bearer ${token}`;
+    }
+
+    return fetch(url, options);
+}
+
+export async function waitForRequest(
+    method,
+    path,
+    matcher,
+    step = 100,
+    milliseconds = 1000,
+) {
+    const externalActivityPub = getExternalActivityPub();
+
+    const calls = await externalActivityPub.getRequestsForAPI(method, path);
+    const found = calls.find(matcher);
+
+    if (found) {
+        return found;
+    }
+
+    if (milliseconds <= 0) {
+        return null;
+    }
+
+    await wait(step);
+
+    return waitForRequest(method, path, matcher, step, milliseconds - step);
+}

--- a/features/support/steps.js
+++ b/features/support/steps.js
@@ -1,0 +1,41 @@
+/**
+ * Splits a string like `Create(Note)` or `Like(A)` into its activity and object parts
+ *
+ * @param {string} string
+ *
+ * @returns {{activity: string, object: string} | {activity: null, object: null}}
+ */
+export function parseActivityString(string) {
+    const [match, activity, object] = string.match(/(\w+)\((.+)\)/) || [null];
+    if (!match) {
+        return {
+            activity: null,
+            object: null,
+        };
+    }
+    return {
+        activity,
+        object,
+    };
+}
+
+/**
+ * Splits a string like `Person(Alice)` or `Group(Wonderland)` into its type and name parts
+ *
+ * @param {string} string
+ *
+ * @returns {{type: string, name: string} | {type: null, name: null}}
+ */
+export function parseActorString(string) {
+    const [match, type, name] = string.match(/(\w+)\((.+)\)/) || [null];
+    if (!match) {
+        return {
+            type: null,
+            name: null,
+        };
+    }
+    return {
+        type,
+        name,
+    };
+}

--- a/features/support/utils.js
+++ b/features/support/utils.js
@@ -1,0 +1,3 @@
+export async function wait(n) {
+    return new Promise((resolve) => setTimeout(resolve, n));
+}

--- a/features/support/wiremock.js
+++ b/features/support/wiremock.js
@@ -1,0 +1,30 @@
+import { WireMock } from 'wiremock-captain';
+
+/** @type {WireMock} */
+let externalActivityPub;
+
+/** @type {WireMock} */
+let ghostActivityPub;
+
+export function getExternalActivityPub() {
+    if (!externalActivityPub) {
+        externalActivityPub = new WireMock(
+            process.env.URL_EXTERNAL_ACTIVITY_PUB,
+        );
+    }
+
+    return externalActivityPub;
+}
+
+export function getGhostActivityPub() {
+    if (!ghostActivityPub) {
+        ghostActivityPub = new WireMock(process.env.URL_GHOST_ACTIVITY_PUB);
+    }
+
+    return ghostActivityPub;
+}
+
+export function reset() {
+    getExternalActivityPub().clearAllRequests();
+    getGhostActivityPub().clearAllRequests();
+}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
-    "@cucumber/cucumber": "10.9.0",
+    "@cucumber/cucumber": "11.2.0",
     "@faker-js/faker": "9.7.0",
     "@fedify/cli": "1.5.1",
     "@types/html-to-text": "9.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,13 +10,14 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@babel/code-frame@^7.0.0":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.24.7.tgz#882fd9e09e8ee324e496bd040401c6f046ef4465"
-  integrity sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==
+"@babel/code-frame@^7.26.2":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
+  integrity sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==
   dependencies:
-    "@babel/highlight" "^7.24.7"
-    picocolors "^1.0.0"
+    "@babel/helper-validator-identifier" "^7.27.1"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
 
 "@babel/helper-string-parser@^7.24.8":
   version "7.24.8"
@@ -28,15 +29,10 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz#75b889cfaf9e35c2aaf42cf0d72c8e91719251db"
   integrity sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==
 
-"@babel/highlight@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.24.7.tgz#a05ab1df134b286558aae0ed41e6c5f731bf409d"
-  integrity sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.24.7"
-    chalk "^2.4.2"
-    js-tokens "^4.0.0"
-    picocolors "^1.0.0"
+"@babel/helper-validator-identifier@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz#a7054dcc145a967dd4dc8fee845a57c1316c9df8"
+  integrity sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==
 
 "@babel/parser@^7.25.4":
   version "7.25.6"
@@ -123,27 +119,28 @@
   resolved "https://registry.yarnpkg.com/@cucumber/ci-environment/-/ci-environment-10.0.1.tgz#c8584f1d4a619e4318cf60c01b838db096d72ccd"
   integrity sha512-/+ooDMPtKSmvcPMDYnMZt4LuoipfFfHaYspStI4shqw8FyKcfQAmekz6G+QKWjQQrvM+7Hkljwx58MEwPCwwzg==
 
-"@cucumber/cucumber-expressions@17.1.0":
-  version "17.1.0"
-  resolved "https://registry.yarnpkg.com/@cucumber/cucumber-expressions/-/cucumber-expressions-17.1.0.tgz#1a428548a2c98ef3224bd484fc5666b4f7153a72"
-  integrity sha512-PCv/ppsPynniKPWJr5v566daCVe+pbxQpHGrIu/Ev57cCH9Rv+X0F6lio4Id3Z64TaG7btCRLUGewIgLwmrwOA==
+"@cucumber/cucumber-expressions@18.0.1":
+  version "18.0.1"
+  resolved "https://registry.yarnpkg.com/@cucumber/cucumber-expressions/-/cucumber-expressions-18.0.1.tgz#0899cbda2ed5546dbaa0e40f0c754b6e3bd1bb69"
+  integrity sha512-NSid6bI+7UlgMywl5octojY5NXnxR9uq+JisjOrO52VbFsQM6gTWuQFE8syI10KnIBEdPzuEUSVEeZ0VFzRnZA==
   dependencies:
     regexp-match-indices "1.0.2"
 
-"@cucumber/cucumber@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@cucumber/cucumber/-/cucumber-10.9.0.tgz#1ee505b3fc513367d2ddc651ad71059c3fd544c8"
-  integrity sha512-7XHJ6nmr9IkIag0nv6or82HfelbSInrEe3H4aT6dMHyTehwFLUifG6eQQ+uE4LZIOXAnzLPH37YmqygEO67vCA==
+"@cucumber/cucumber@11.2.0":
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/@cucumber/cucumber/-/cucumber-11.2.0.tgz#6f38ecd0c71717d646b99eb4fe2595f81c8b179a"
+  integrity sha512-F69uIPTc7dfgU7/TGAaQaWUz7r/DzoPW39AfJoKQOC7IvBiPQwpvSIo6QEd+63pdpdKNRbtQoVl5vP9IclhhuA==
   dependencies:
     "@cucumber/ci-environment" "10.0.1"
-    "@cucumber/cucumber-expressions" "17.1.0"
-    "@cucumber/gherkin" "28.0.0"
+    "@cucumber/cucumber-expressions" "18.0.1"
+    "@cucumber/gherkin" "30.0.4"
     "@cucumber/gherkin-streams" "5.0.1"
     "@cucumber/gherkin-utils" "9.0.0"
-    "@cucumber/html-formatter" "21.6.0"
+    "@cucumber/html-formatter" "21.7.0"
+    "@cucumber/junit-xml-formatter" "0.7.1"
     "@cucumber/message-streams" "4.0.1"
-    "@cucumber/messages" "24.1.0"
-    "@cucumber/tag-expressions" "6.1.0"
+    "@cucumber/messages" "27.0.2"
+    "@cucumber/tag-expressions" "6.1.1"
     assertion-error-formatter "^3.0.0"
     capital-case "^1.0.4"
     chalk "^4.1.2"
@@ -165,16 +162,14 @@
     mkdirp "^2.1.5"
     mz "^2.7.0"
     progress "^2.0.3"
-    read-pkg-up "^7.0.1"
+    read-package-up "^11.0.0"
     resolve-pkg "^2.0.0"
     semver "7.5.3"
     string-argv "0.3.1"
-    strip-ansi "6.0.1"
     supports-color "^8.1.1"
     tmp "0.2.3"
     type-fest "^4.8.3"
     util-arity "^1.1.0"
-    xmlbuilder "^15.1.1"
     yaml "^2.2.2"
     yup "1.2.0"
 
@@ -197,24 +192,51 @@
     commander "12.0.0"
     source-map-support "^0.5.21"
 
-"@cucumber/gherkin@28.0.0", "@cucumber/gherkin@^28.0.0":
+"@cucumber/gherkin@30.0.4":
+  version "30.0.4"
+  resolved "https://registry.yarnpkg.com/@cucumber/gherkin/-/gherkin-30.0.4.tgz#047071b3122a9fb25e073aabdbc0132e98db4ee4"
+  integrity sha512-pb7lmAJqweZRADTTsgnC3F5zbTh3nwOB1M83Q9ZPbUKMb3P76PzK6cTcPTJBHWy3l7isbigIv+BkDjaca6C8/g==
+  dependencies:
+    "@cucumber/messages" ">=19.1.4 <=26"
+
+"@cucumber/gherkin@^28.0.0":
   version "28.0.0"
   resolved "https://registry.yarnpkg.com/@cucumber/gherkin/-/gherkin-28.0.0.tgz#91246da622524807b21430c1692bedd319d3d4bb"
   integrity sha512-Ee6zJQq0OmIUPdW0mSnsCsrWA2PZAELNDPICD2pLfs0Oz7RAPgj80UsD2UCtqyAhw2qAR62aqlktKUlai5zl/A==
   dependencies:
     "@cucumber/messages" ">=19.1.4 <=24"
 
-"@cucumber/html-formatter@21.6.0":
-  version "21.6.0"
-  resolved "https://registry.yarnpkg.com/@cucumber/html-formatter/-/html-formatter-21.6.0.tgz#bfd8c4db31c6c96a8520332efba2ea9838ca36f0"
-  integrity sha512-Qw1tdObBJrgXgXwVjKVjB3hFhFPI8WhIFb+ULy8g5lDl5AdnKDiyDXAMvAWRX+pphnRMMNdkPCt6ZXEfWvUuAA==
+"@cucumber/html-formatter@21.7.0":
+  version "21.7.0"
+  resolved "https://registry.yarnpkg.com/@cucumber/html-formatter/-/html-formatter-21.7.0.tgz#a4413738c4476836c9917bf9652aa0a45b93ab81"
+  integrity sha512-bv211aY8mErp6CdmhN426E+7KIsVIES4fGx5ASMlUzYWiMus6NhSdI9UL3Vswx8JXJMgySeIcJJKfznREUFLNA==
+
+"@cucumber/junit-xml-formatter@0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@cucumber/junit-xml-formatter/-/junit-xml-formatter-0.7.1.tgz#a94cb7bc9f567bf2718605dc571712e69d4a0721"
+  integrity sha512-AzhX+xFE/3zfoYeqkT7DNq68wAQfBcx4Dk9qS/ocXM2v5tBv6eFQ+w8zaSfsktCjYzu4oYRH/jh4USD1CYHfaQ==
+  dependencies:
+    "@cucumber/query" "^13.0.2"
+    "@teppeis/multimaps" "^3.0.0"
+    luxon "^3.5.0"
+    xmlbuilder "^15.1.1"
 
 "@cucumber/message-streams@4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@cucumber/message-streams/-/message-streams-4.0.1.tgz#a5339d3504594bb2edb5732aaae94dddb24d0970"
   integrity sha512-Kxap9uP5jD8tHUZVjTWgzxemi/0uOsbGjd4LBOSxcJoOCRbESFwemUzilJuzNTB8pcTQUh8D5oudUyxfkJOKmA==
 
-"@cucumber/messages@24.1.0", "@cucumber/messages@>=19.1.4 <=24", "@cucumber/messages@^24.0.0":
+"@cucumber/messages@27.0.2":
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/@cucumber/messages/-/messages-27.0.2.tgz#9b5ed8b6cf7b95e43576f6af1af9f5205f69e2a1"
+  integrity sha512-jo2B+vYXmpuLOKh6Gc8loHl2E8svCkLvEXLVgFwVHqKWZJWBTa9yTRCPmZIxrz4fnO7Pr3N3vKQCPu73/gjlVQ==
+  dependencies:
+    "@types/uuid" "10.0.0"
+    class-transformer "0.5.1"
+    reflect-metadata "0.2.2"
+    uuid "10.0.0"
+
+"@cucumber/messages@>=19.1.4 <=24", "@cucumber/messages@^24.0.0":
   version "24.1.0"
   resolved "https://registry.yarnpkg.com/@cucumber/messages/-/messages-24.1.0.tgz#a212c97b0548144c3ccfae021a96d6c56d3841d3"
   integrity sha512-hxVHiBurORcobhVk80I9+JkaKaNXkW6YwGOEFIh/2aO+apAN+5XJgUUWjng9NwqaQrW1sCFuawLB1AuzmBaNdQ==
@@ -224,10 +246,27 @@
     reflect-metadata "0.2.1"
     uuid "9.0.1"
 
-"@cucumber/tag-expressions@6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@cucumber/tag-expressions/-/tag-expressions-6.1.0.tgz#cb7af908bdb43669b7574c606f71fa707196e962"
-  integrity sha512-+3DwRumrCJG27AtzCIL37A/X+A/gSfxOPLg8pZaruh5SLumsTmpvilwroVWBT2fPzmno/tGXypeK5a7NHU4RzA==
+"@cucumber/messages@>=19.1.4 <=26":
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/@cucumber/messages/-/messages-26.0.1.tgz#18765481cf2580066977cbe26af111458e05c424"
+  integrity sha512-DIxSg+ZGariumO+Lq6bn4kOUIUET83A4umrnWmidjGFl8XxkBieUZtsmNbLYgH/gnsmP07EfxxdTr0hOchV1Sg==
+  dependencies:
+    "@types/uuid" "10.0.0"
+    class-transformer "0.5.1"
+    reflect-metadata "0.2.2"
+    uuid "10.0.0"
+
+"@cucumber/query@^13.0.2":
+  version "13.2.0"
+  resolved "https://registry.yarnpkg.com/@cucumber/query/-/query-13.2.0.tgz#d7a7db6affdae8f56a934e8f40041d1a7db42e50"
+  integrity sha512-S3g4u+2u/vo444bR1xL0+oVZmF8zb9QZ3MoiNF4GjBt6gG7Kf4S3NyJKjGUAQfESTb8oumOR1YMKHbv79FzA5w==
+  dependencies:
+    "@teppeis/multimaps" "3.0.0"
+
+"@cucumber/tag-expressions@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@cucumber/tag-expressions/-/tag-expressions-6.1.1.tgz#36bebd6af0870e03f71b5a34436b95f3c70ef7e8"
+  integrity sha512-0oj5KTzf2DsR3DhL3hYeI9fP3nyKzs7TQdpl54uJelJ3W3Hlyyet2Hib+8LK7kNnqJsXENnJg9zahRYyrtvNEg==
 
 "@deno/shim-crypto@~0.3.1":
   version "0.3.1"
@@ -1445,7 +1484,7 @@
   dependencies:
     "@sentry/core" "8.49.0"
 
-"@teppeis/multimaps@3.0.0":
+"@teppeis/multimaps@3.0.0", "@teppeis/multimaps@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@teppeis/multimaps/-/multimaps-3.0.0.tgz#bb9c3f8d569f589e548586fa0bbf423010ddfdc5"
   integrity sha512-ID7fosbc50TbT0MK0EG12O+gAP3W3Aa/Pz4DaTtQtEvlc9Odaqi0de+xuZ7Li2GtK4HzEX7IuRWS/JmZLksR3Q==
@@ -1523,7 +1562,7 @@
   dependencies:
     undici-types "~6.19.2"
 
-"@types/normalize-package-data@^2.4.0":
+"@types/normalize-package-data@^2.4.3":
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz#56e2cc26c397c038fab0e3a917a12d5c5909e901"
   integrity sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==
@@ -1732,13 +1771,6 @@ ansi-regex@^6.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
   integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
-ansi-styles@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
-  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
-  dependencies:
-    color-convert "^1.9.0"
-
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
@@ -1890,15 +1922,6 @@ chai@^5.1.2:
     loupe "^3.1.0"
     pathval "^2.0.0"
 
-chalk@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
-  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
-
 chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -1940,24 +1963,12 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
-color-convert@^1.9.0:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
-  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
-  dependencies:
-    color-name "1.1.3"
-
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
   integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
     color-name "~1.1.4"
-
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
 color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
@@ -2152,13 +2163,6 @@ entities@^4.2.0, entities@^4.4.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
-error-ex@^1.3.1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
-  integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
-  dependencies:
-    is-arrayish "^0.2.1"
-
 error-stack-parser@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.1.4.tgz#229cb01cdbfa84440bfa91876285b94680188286"
@@ -2305,13 +2309,10 @@ figures@^3.2.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
-find-up@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
-  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
-  dependencies:
-    locate-path "^5.0.0"
-    path-exists "^4.0.0"
+find-up-simple@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/find-up-simple/-/find-up-simple-1.0.1.tgz#18fb90ad49e45252c4d7fca56baade04fa3fca1e"
+  integrity sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==
 
 follow-redirects@^1.15.6:
   version "1.15.6"
@@ -2477,11 +2478,6 @@ has-ansi@^4.0.1:
   dependencies:
     ansi-regex "^4.1.0"
 
-has-flag@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
-  integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
-
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
@@ -2509,10 +2505,12 @@ hono@4.7.8:
   resolved "https://registry.yarnpkg.com/hono/-/hono-4.7.8.tgz#f84ffd39b69f1c851fe0b58efb207ee2b2cdac3a"
   integrity sha512-PCibtFdxa7/Ldud9yddl1G81GjYaeMYYTq4ywSaNsYbB1Lug4mwtOMJf2WXykL0pntYwmpRJeOI3NmoDgD+Jxw==
 
-hosted-git-info@^2.1.4:
-  version "2.8.9"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
-  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
+hosted-git-info@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-7.0.2.tgz#9b751acac097757667f30114607ef7b661ff4f17"
+  integrity sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==
+  dependencies:
+    lru-cache "^10.0.1"
 
 html-entities@^2.5.2:
   version "2.6.0"
@@ -2597,6 +2595,11 @@ indent-string@^4.0.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
+index-to-position@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/index-to-position/-/index-to-position-1.1.0.tgz#2e50bd54c8040bdd6d9b3d95ec2a8fedf86b4d44"
+  integrity sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg==
+
 inherits@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
@@ -2611,11 +2614,6 @@ interpret@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
-
-is-arrayish@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
-  integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
 
 is-arrayish@^0.3.1:
   version "0.3.2"
@@ -2739,11 +2737,6 @@ json-canon@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-canon/-/json-canon-1.0.1.tgz#ce815a1d02e1b02c97b21154c7a844321e314184"
   integrity sha512-PQcj4PFOTAQxE8PgoQ4KrM0DcKWZd7S3ELOON8rmysl9I8JuFMgxu1H9v+oZsTPjjkpeS3IHPwLjr7d+gKygnw==
 
-json-parse-even-better-errors@^2.3.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
-  integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
-
 jsonld@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/jsonld/-/jsonld-8.3.2.tgz#7033f8994aed346b536e9046025f7f1fe9669934"
@@ -2854,11 +2847,6 @@ leac@^0.6.0:
   resolved "https://registry.yarnpkg.com/leac/-/leac-0.6.0.tgz#dcf136e382e666bd2475f44a1096061b70dc0912"
   integrity sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==
 
-lines-and-columns@^1.1.6:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
-  integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
-
 linkify-html@4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/linkify-html/-/linkify-html-4.2.0.tgz#06f78780827d90433424e412976d656912b13fb8"
@@ -2868,13 +2856,6 @@ linkifyjs@4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/linkifyjs/-/linkifyjs-4.2.0.tgz#9dd30222b9cbabec9c950e725ec00031c7fa3f08"
   integrity sha512-pCj3PrQyATaoTYKHrgWRF3SJwsm61udVh+vuls/Rl6SptiDhgE7ziUIudAedRY9QEfynmM7/RmLEfPUyw1HPCw==
-
-locate-path@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
-  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
-  dependencies:
-    p-locate "^4.1.0"
 
 lodash.camelcase@^4.3.0:
   version "4.3.0"
@@ -2953,7 +2934,7 @@ lower-case@^2.0.2:
   dependencies:
     tslib "^2.0.3"
 
-lru-cache@^10.2.0:
+lru-cache@^10.0.1, lru-cache@^10.2.0:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
@@ -2979,6 +2960,11 @@ luxon@3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.2.1.tgz#14f1af209188ad61212578ea7e3d518d18cee45f"
   integrity sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==
+
+luxon@^3.5.0:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.6.1.tgz#d283ffc4c0076cb0db7885ec6da1c49ba97e47b0"
+  integrity sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==
 
 magic-string@^0.30.12:
   version "0.30.12"
@@ -3150,15 +3136,14 @@ node-jose@2.2.0:
     process "^0.11.10"
     uuid "^9.0.0"
 
-normalize-package-data@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
-  integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
+normalize-package-data@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-6.0.2.tgz#a7bc22167fe24025412bcff0a9651eb768b03506"
+  integrity sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==
   dependencies:
-    hosted-git-info "^2.1.4"
-    resolve "^1.10.0"
-    semver "2 || 3 || 4 || 5"
-    validate-npm-package-license "^3.0.1"
+    hosted-git-info "^7.0.0"
+    semver "^7.3.5"
+    validate-npm-package-license "^3.0.4"
 
 object-assign@^4.0.1:
   version "4.1.1"
@@ -3187,31 +3172,12 @@ p-defer@^3.0.0:
   resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-3.0.0.tgz#d1dceb4ee9b2b604b1d94ffec83760175d4e6f83"
   integrity sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==
 
-p-limit@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
-  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
-  dependencies:
-    p-try "^2.0.0"
-
 p-limit@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
   dependencies:
     yocto-queue "^0.1.0"
-
-p-locate@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
-  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
-  dependencies:
-    p-limit "^2.2.0"
-
-p-try@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
-  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
 package-json-from-dist@^1.0.0:
   version "1.0.0"
@@ -3230,15 +3196,14 @@ pako@^2.0.4:
   resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
   integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
 
-parse-json@^5.0.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
-  integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
+parse-json@^8.0.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-8.3.0.tgz#88a195a2157025139a2317a4f2f9252b61304ed5"
+  integrity sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==
   dependencies:
-    "@babel/code-frame" "^7.0.0"
-    error-ex "^1.3.1"
-    json-parse-even-better-errors "^2.3.0"
-    lines-and-columns "^1.1.6"
+    "@babel/code-frame" "^7.26.2"
+    index-to-position "^1.1.0"
+    type-fest "^4.39.1"
 
 parse-srcset@^1.0.2:
   version "1.0.2"
@@ -3252,11 +3217,6 @@ parseley@^0.12.0:
   dependencies:
     leac "^0.6.0"
     peberminta "^0.9.0"
-
-path-exists@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
-  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
 path-key@^3.1.0:
   version "3.1.1"
@@ -3335,7 +3295,7 @@ pg-types@^4.0.1:
     postgres-interval "^3.0.0"
     postgres-range "^1.1.1"
 
-picocolors@^1.0.0, picocolors@^1.1.1:
+picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -3474,24 +3434,25 @@ rdf-canonize@^3.4.0:
   dependencies:
     setimmediate "^1.0.5"
 
-read-pkg-up@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
-  integrity sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==
+read-package-up@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/read-package-up/-/read-package-up-11.0.0.tgz#71fb879fdaac0e16891e6e666df22de24a48d5ba"
+  integrity sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==
   dependencies:
-    find-up "^4.1.0"
-    read-pkg "^5.2.0"
-    type-fest "^0.8.1"
+    find-up-simple "^1.0.0"
+    read-pkg "^9.0.0"
+    type-fest "^4.6.0"
 
-read-pkg@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
-  integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
+read-pkg@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-9.0.1.tgz#b1b81fb15104f5dbb121b6bbdee9bbc9739f569b"
+  integrity sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==
   dependencies:
-    "@types/normalize-package-data" "^2.4.0"
-    normalize-package-data "^2.5.0"
-    parse-json "^5.0.0"
-    type-fest "^0.6.0"
+    "@types/normalize-package-data" "^2.4.3"
+    normalize-package-data "^6.0.0"
+    parse-json "^8.0.0"
+    type-fest "^4.6.0"
+    unicorn-magic "^0.1.0"
 
 readable-stream@^3.1.1:
   version "3.6.2"
@@ -3513,6 +3474,11 @@ reflect-metadata@0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.2.1.tgz#8d5513c0f5ef2b4b9c3865287f3c0940c1f67f74"
   integrity sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw==
+
+reflect-metadata@0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.2.2.tgz#400c845b6cba87a21f2c65c4aeb158f4fa4d9c5b"
+  integrity sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==
 
 regexp-match-indices@1.0.2:
   version "1.0.2"
@@ -3557,7 +3523,7 @@ resolve-pkg@^2.0.0:
   dependencies:
     resolve-from "^5.0.0"
 
-resolve@^1.10.0, resolve@^1.20.0, resolve@^1.22.8:
+resolve@^1.20.0, resolve@^1.22.8:
   version "1.22.8"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
   integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
@@ -3648,11 +3614,6 @@ selderee@^0.11.0:
   dependencies:
     parseley "^0.12.0"
 
-"semver@2 || 3 || 4 || 5":
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
-  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
-
 semver@7.5.3:
   version "7.5.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
@@ -3660,15 +3621,15 @@ semver@7.5.3:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.3.5, semver@^7.7.1:
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
+  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
+
 semver@^7.5.2, semver@^7.5.3, semver@^7.5.4:
   version "7.6.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.2.tgz#1e3b34759f896e8f14d6134732ce798aeb0c6e13"
   integrity sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==
-
-semver@^7.7.1:
-  version "7.7.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
-  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
 
 seq-queue@^0.0.5:
   version "0.0.5"
@@ -3830,16 +3791,7 @@ string-argv@0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3864,14 +3816,7 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3894,13 +3839,6 @@ stubs@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/stubs/-/stubs-3.0.0.tgz#e8d2ba1fa9c90570303c030b6900f7d5f89abe5b"
   integrity sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==
-
-supports-color@^5.3.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
-  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
-  dependencies:
-    has-flag "^3.0.0"
 
 supports-color@^7.1.0:
   version "7.2.0"
@@ -4030,20 +3968,15 @@ tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.1, tslib@^2.6.3, tslib@^2.7
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
-type-fest@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
-  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
-
-type-fest@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
-  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
-
 type-fest@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
   integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
+
+type-fest@^4.39.1, type-fest@^4.6.0:
+  version "4.40.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.40.1.tgz#d78a09f08dd1081a434dd377967650cfd565401d"
+  integrity sha512-9YvLNnORDpI+vghLU/Nf+zSv0kL47KbVJ1o3sKgoTefl6i+zebxbiDQWoe/oWWqPhIgQdRZRT1KA9sCPL810SA==
 
 type-fest@^4.8.3:
   version "4.21.0"
@@ -4073,6 +4006,11 @@ undici@^5.21.2:
   integrity sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==
   dependencies:
     "@fastify/busboy" "^2.0.0"
+
+unicorn-magic@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.1.0.tgz#1bb9a51c823aaf9d73a8bfcd3d1a23dde94b0ce4"
+  integrity sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==
 
 upper-case-first@^2.0.2:
   version "2.0.2"
@@ -4121,7 +4059,7 @@ uuid@^8.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-validate-npm-package-license@^3.0.1:
+validate-npm-package-license@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
   integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
@@ -4238,16 +4176,7 @@ wiremock-captain@3.5.0:
   dependencies:
     axios "1.7.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
no refs

Miscellaneous refactorings to allow us to move to using multiple step definition files instead of one large file:

- Introduced `support` directory to organize support files
    - Moved generic helper functions out of `stepdefs.js` and into their respective support files
- Removed nearly all global state from `stepdefs.js`
    - Support files keep track of there global state (i.e `db.js` keeping track of database client instance)
- Added `block_steps.js` to organize block related step definitions
- Moved global static constants to environment variables

I opted to just use the built in `World` rather than a custom one - We could maybe move to this at a later point and use it to keep track of global state etc