### PR TITLE
Improved error responses from HTTP API

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -37,9 +37,12 @@ export function createUnlikeAction(
 
         const objectToLike = await lookupObject(apCtx, id);
         if (!objectToLike) {
-            return new Response(null, {
-                status: 404,
-            });
+            return new Response(
+                JSON.stringify({ error: 'Object to like not found' }),
+                {
+                    status: 404,
+                },
+            );
         }
 
         const likeId = apCtx.getObjectUri(Like, {
@@ -54,17 +57,23 @@ export function createUnlikeAction(
 
         const likeToUndoJson = await ctx.get('globaldb').get([likeId.href]);
         if (!likeToUndoJson) {
-            return new Response(null, {
-                status: 409,
-            });
+            return new Response(
+                JSON.stringify({ error: 'Like activity not found' }),
+                {
+                    status: 409,
+                },
+            );
         }
 
         const idAsUrl = parseURL(id);
 
         if (!idAsUrl) {
-            return new Response(null, {
-                status: 400,
-            });
+            return new Response(
+                JSON.stringify({ error: 'ID should be a valid URL' }),
+                {
+                    status: 400,
+                },
+            );
         }
 
         const account = await accountRepository.getBySite(ctx.get('site'));
@@ -171,17 +180,23 @@ export function createLikeAction(
 
         const objectToLike = await lookupObject(apCtx, id);
         if (!objectToLike) {
-            return new Response(null, {
-                status: 404,
-            });
+            return new Response(
+                JSON.stringify({ error: 'Object to like not found' }),
+                {
+                    status: 404,
+                },
+            );
         }
 
         const idAsUrl = parseURL(id);
 
         if (!idAsUrl) {
-            return new Response(null, {
-                status: 400,
-            });
+            return new Response(
+                JSON.stringify({ error: 'ID should be a valid URL' }),
+                {
+                    status: 400,
+                },
+            );
         }
 
         const account = await accountRepository.getBySite(ctx.get('site'));
@@ -226,9 +241,12 @@ export function createLikeAction(
         });
 
         if (await ctx.get('globaldb').get([likeId.href])) {
-            return new Response(null, {
-                status: 409,
-            });
+            return new Response(
+                JSON.stringify({ error: 'Post already liked' }),
+                {
+                    status: 409,
+                },
+            );
         }
 
         const actor = await apCtx.getActor(ACTOR_DEFAULT_HANDLE); // TODO This should be the actor making the request
@@ -287,7 +305,7 @@ export const getSiteDataHandler =
         const host = request.header('host');
         if (!host) {
             ctx.get('logger').info('No Host header');
-            return new Response('No Host header', {
+            return new Response(JSON.stringify({ error: 'No Host header' }), {
                 status: 401,
             });
         }
@@ -397,7 +415,7 @@ export function createRepostActionHandler(
 
         const post = await lookupObject(apCtx, id);
         if (!post) {
-            return new Response(null, {
+            return new Response(JSON.stringify({ error: 'Post not found' }), {
                 status: 404,
             });
         }
@@ -407,9 +425,12 @@ export function createRepostActionHandler(
         });
 
         if (await ctx.get('globaldb').get([announceId.href])) {
-            return new Response(null, {
-                status: 409,
-            });
+            return new Response(
+                JSON.stringify({ error: 'Post already reposted' }),
+                {
+                    status: 409,
+                },
+            );
         }
 
         await post.getAttribution();
@@ -502,7 +523,7 @@ export function createDerepostActionHandler(
 
         const post = await lookupObject(apCtx, id);
         if (!post) {
-            return new Response(null, {
+            return new Response(JSON.stringify({ error: 'Post not found' }), {
                 status: 404,
             });
         }
@@ -520,9 +541,12 @@ export function createDerepostActionHandler(
             .get([announceId.href]);
 
         if (!announceToUndoJson) {
-            return new Response(null, {
-                status: 409,
-            });
+            return new Response(
+                JSON.stringify({ error: 'Repost activity not found' }),
+                {
+                    status: 409,
+                },
+            );
         }
 
         const announceToUndo = await Announce.fromJsonLd(announceToUndoJson);
@@ -532,9 +556,12 @@ export function createDerepostActionHandler(
         const idAsUrl = parseURL(id);
 
         if (!idAsUrl) {
-            return new Response(null, {
-                status: 400,
-            });
+            return new Response(
+                JSON.stringify({ error: 'ID should be a valid URL' }),
+                {
+                    status: 400,
+                },
+            );
         }
 
         const account = await accountRepository.getBySite(ctx.get('site'));

--- a/src/http/api/note.ts
+++ b/src/http/api/note.ts
@@ -21,7 +21,10 @@ export async function handleCreateNote(
     try {
         data = NoteSchema.parse((await ctx.req.json()) as unknown);
     } catch (err) {
-        return new Response(JSON.stringify({}), { status: 400 });
+        return new Response(
+            JSON.stringify({ error: 'Invalid request format' }),
+            { status: 400 },
+        );
     }
 
     const postResult = await postService.createNote(

--- a/src/http/api/reply.ts
+++ b/src/http/api/reply.ts
@@ -48,20 +48,6 @@ export async function handleCreateReply(
         logger,
     });
 
-    if (
-        process.env.NODE_ENV === 'testing' &&
-        ctx.get('account').username === 'blocked'
-    ) {
-        return new Response(
-            JSON.stringify({
-                error: 'Cannot interact with this account',
-            }),
-            {
-                status: 403,
-            },
-        );
-    }
-
     const inReplyToId = parseURL(decodeURIComponent(id));
 
     if (!inReplyToId) {

--- a/src/http/api/reply.ts
+++ b/src/http/api/reply.ts
@@ -36,7 +36,10 @@ export async function handleCreateReply(
     try {
         data = ReplyActionSchema.parse((await ctx.req.json()) as unknown);
     } catch (err) {
-        return new Response(JSON.stringify(err), { status: 400 });
+        return new Response(
+            JSON.stringify({ error: 'Invalid request format' }),
+            { status: 400 },
+        );
     }
 
     const apCtx = fedify.createContext(ctx.req.raw as Request, {
@@ -45,11 +48,25 @@ export async function handleCreateReply(
         logger,
     });
 
+    if (
+        process.env.NODE_ENV === 'testing' &&
+        ctx.get('account').username === 'blocked'
+    ) {
+        return new Response(
+            JSON.stringify({
+                error: 'Cannot interact with this account',
+            }),
+            {
+                status: 403,
+            },
+        );
+    }
+
     const inReplyToId = parseURL(decodeURIComponent(id));
 
     if (!inReplyToId) {
         return new Response(
-            JSON.stringify({ message: 'ID should be a valid URL' }),
+            JSON.stringify({ error: 'ID should be a valid URL' }),
             {
                 status: 400,
             },
@@ -58,9 +75,12 @@ export async function handleCreateReply(
 
     const objectToReplyTo = await lookupObject(apCtx, id);
     if (!objectToReplyTo) {
-        return new Response(null, {
-            status: 404,
-        });
+        return new Response(
+            JSON.stringify({ error: 'Object to reply to not found' }),
+            {
+                status: 404,
+            },
+        );
     }
 
     const actor = await apCtx.getActor(ACTOR_DEFAULT_HANDLE);
@@ -74,9 +94,12 @@ export async function handleCreateReply(
     }
 
     if (!attributionActor) {
-        return new Response(null, {
-            status: 400,
-        });
+        return new Response(
+            JSON.stringify({ error: 'Attribution actor not found' }),
+            {
+                status: 400,
+            },
+        );
     }
 
     const to = PUBLIC_COLLECTION;
@@ -108,7 +131,9 @@ export async function handleCreateReply(
                     },
                 );
                 return new Response(
-                    'Invalid Reply - upstream error fetching parent post',
+                    JSON.stringify({
+                        error: 'Invalid Reply - upstream error fetching parent post',
+                    }),
                     {
                         status: 502,
                     },
@@ -120,9 +145,14 @@ export async function handleCreateReply(
                         postId: inReplyToId.href,
                     },
                 );
-                return new Response('Invalid Reply - parent is not a post', {
-                    status: 404,
-                });
+                return new Response(
+                    JSON.stringify({
+                        error: 'Invalid Reply - parent is not a post',
+                    }),
+                    {
+                        status: 404,
+                    },
+                );
             case 'missing-author':
                 ctx.get('logger').info(
                     'Parent post for reply has missing author',
@@ -131,7 +161,9 @@ export async function handleCreateReply(
                     },
                 );
                 return new Response(
-                    'Invalid Reply - parent post has no author',
+                    JSON.stringify({
+                        error: 'Invalid Reply - parent post has no author',
+                    }),
                     {
                         status: 404,
                     },


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-669

As part of the block work we're handling specific errors from the API to show a message baout not being able to interact with the account. In order to handle errors easily in the frontend we want to standardise all of the errors returned