### PR TITLE
Prevented `like` action from blocked accounts

### DIFF
--- a/src/post/post.service.integration.test.ts
+++ b/src/post/post.service.integration.test.ts
@@ -260,4 +260,44 @@ describe('PostService', () => {
             expect(getError(result)).toBe('cannot-interact');
         });
     });
+
+    describe('likePost', () => {
+        it('should like a post successfully', async () => {
+            const [likeAccount] = await fixtureManager.createInternalAccount();
+
+            const post = await fixtureManager.createPost(account);
+
+            const result = await postService.likePost(likeAccount, post);
+
+            expect(isError(result)).toBe(false);
+
+            const postWasLiked = await postRepository.isLikedByAccount(
+                post.id!,
+                likeAccount.id,
+            );
+
+            expect(postWasLiked).toBe(true);
+        });
+
+        it('should return error when moderation check fails', async () => {
+            const [accountToBlock] =
+                await fixtureManager.createInternalAccount();
+
+            const post = await fixtureManager.createPost(account);
+
+            await fixtureManager.createBlock(account, accountToBlock);
+
+            const result = await postService.likePost(accountToBlock, post);
+
+            expect(isError(result)).toBe(true);
+            expect(getError(result as Err<string>)).toBe('cannot-interact');
+
+            const postWasLiked = await postRepository.isLikedByAccount(
+                post.id!,
+                accountToBlock.id,
+            );
+
+            expect(postWasLiked).toBe(false);
+        });
+    });
 });

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -228,4 +228,24 @@ export class PostService {
 
         return ok(post);
     }
+
+    async likePost(
+        account: Account,
+        post: Post,
+    ): Promise<Result<Post, InteractionError>> {
+        const canInteract = await this.moderationService.canInteractWithAccount(
+            account.id,
+            post.author.id,
+        );
+
+        if (!canInteract) {
+            return error('cannot-interact');
+        }
+
+        post.addLike(account);
+
+        await this.postRepository.save(post);
+
+        return ok(post);
+    }
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-1082

If an account has blocked another one, and that account attempts to like a post authored by the blocking account via the API, the request will be rejected with a `403`. This is to allow the UI to report this to the blocked user when they attempt to like the blocking account's post