### PR TITLE
Prevented users from reposting content of accounts which have blocked them

### DIFF
--- a/src/http/api/repost.ts
+++ b/src/http/api/repost.ts
@@ -6,7 +6,7 @@ import { exhaustiveCheck, getError, getValue, isError } from 'core/result';
 import { parseURL } from 'core/url';
 import { addToList } from 'kv-helpers';
 import type { PostService } from 'post/post.service';
-import { BadRequest, Conflict, NotFound } from './helpers/response';
+import { BadRequest, Conflict, Forbidden, NotFound } from './helpers/response';
 
 export function createRepostActionHandler(postService: PostService) {
     return async function repostAction(ctx: AppContext): Promise<Response> {
@@ -37,6 +37,8 @@ export function createRepostActionHandler(postService: PostService) {
                     return BadRequest('Not a post');
                 case 'missing-author':
                     return NotFound('Post does not have an author');
+                case 'cannot-interact':
+                    return Forbidden('Cannot interact with this account');
                 default:
                     exhaustiveCheck(error);
             }

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -29,7 +29,10 @@ export type GetPostsError =
     | 'no-page-found'
     | 'not-an-actor';
 
-export type RepostError = GetByApIdError | 'already-reposted';
+export type RepostError =
+    | GetByApIdError
+    | 'already-reposted'
+    | InteractionError;
 
 export class PostService {
     constructor(
@@ -262,6 +265,15 @@ export class PostService {
         }
 
         const post = getValue(postToRepostResult);
+
+        const canInteract = await this.moderationService.canInteractWithAccount(
+            account.id,
+            post.author.id,
+        );
+
+        if (!canInteract) {
+            return error('cannot-interact');
+        }
 
         // We know this is not `null` because it just came from the DB
         const reposted = await this.isRepostedByAccount(post.id!, account.id);


### PR DESCRIPTION

ref https://linear.app/ghost/issue/PROD-669

As part of the block functionality we want to disable interaction entirely for blocked users on our own server. The frontend will display an error when we respond with a 403 indicated that the account has restricted who can interact with them.