### PR TITLE
Added `domain` and `domain_hash` to `accounts` table

### DIFF
--- a/migrate/migrations/000045_add-domain-to-accounts-table.down.sql
+++ b/migrate/migrations/000045_add-domain-to-accounts-table.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX idx_accounts_domain_hash ON accounts;
+
+ALTER TABLE accounts
+    DROP COLUMN domain_hash,
+    DROP COLUMN domain;

--- a/migrate/migrations/000045_add-domain-to-accounts-table.up.sql
+++ b/migrate/migrations/000045_add-domain-to-accounts-table.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE accounts
+    ADD COLUMN domain VARCHAR(255) NULL,  -- Nullable to allow for incremental migration
+    ADD COLUMN domain_hash BINARY(32)
+        GENERATED ALWAYS AS (UNHEX(SHA2(LOWER(domain), 256))) STORED;
+
+CREATE INDEX idx_accounts_domain_hash ON accounts(domain_hash);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1637

Added `domain` and `domain_hash` to `accounts` table to optimize the performance of queries that may need to filter accounts by domain (i.e filter ouut all accounts belonging to a specific domain that have been blocked by an account)