### PR TITLE
Removed feed items from blocked domain on domain block

### DIFF
--- a/src/feed/feed-update.service.ts
+++ b/src/feed/feed-update.service.ts
@@ -1,6 +1,7 @@
 import type { EventEmitter } from 'node:events';
 
 import { AccountBlockedEvent } from 'account/account-blocked.event';
+import { DomainBlockedEvent } from 'account/domain-blocked.event';
 import type { FeedService } from 'feed/feed.service';
 import { PostCreatedEvent } from 'post/post-created.event';
 import { PostDeletedEvent } from 'post/post-deleted.event';
@@ -34,6 +35,10 @@ export class FeedUpdateService {
         this.events.on(
             AccountBlockedEvent.getName(),
             this.handleAccountBlockedEvent.bind(this),
+        );
+        this.events.on(
+            DomainBlockedEvent.getName(),
+            this.handleDomainBlockedEvent.bind(this),
         );
     }
 
@@ -74,6 +79,16 @@ export class FeedUpdateService {
         await this.feedService.removeBlockedAccountPostsFromFeed(
             blockerId,
             blockedId,
+        );
+    }
+
+    private async handleDomainBlockedEvent(event: DomainBlockedEvent) {
+        const blockerId = event.getBlockerId();
+        const domain = event.getDomain();
+
+        await this.feedService.removeBlockedDomainPostsFromFeed(
+            blockerId,
+            domain,
         );
     }
 }

--- a/src/feed/feed-update.service.unit.test.ts
+++ b/src/feed/feed-update.service.unit.test.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'node:events';
 
 import { AccountBlockedEvent } from 'account/account-blocked.event';
 import { AccountEntity } from 'account/account.entity';
+import { DomainBlockedEvent } from 'account/domain-blocked.event';
 import { FeedUpdateService } from 'feed/feed-update.service';
 import type { FeedService } from 'feed/feed.service';
 import { PostCreatedEvent } from 'post/post-created.event';
@@ -27,6 +28,7 @@ describe('FeedUpdateService', () => {
             addPostToFeeds: vi.fn(),
             removePostFromFeeds: vi.fn(),
             removeBlockedAccountPostsFromFeed: vi.fn(),
+            removeBlockedDomainPostsFromFeed: vi.fn(),
         } as unknown as FeedService;
 
         const draft = AccountEntity.draft({
@@ -207,6 +209,22 @@ describe('FeedUpdateService', () => {
             expect(
                 feedService.removeBlockedAccountPostsFromFeed,
             ).toHaveBeenCalledWith(account.id, blockedAccount.id);
+        });
+    });
+
+    describe('handling a blocked domain', () => {
+        it('should remove blocked domain posts from feeds', () => {
+            const blockedDomain = new URL('https://blocked.com');
+            const blockerAccount = { id: 456 } as AccountEntity;
+
+            events.emit(
+                DomainBlockedEvent.getName(),
+                new DomainBlockedEvent(blockedDomain, blockerAccount.id),
+            );
+
+            expect(
+                feedService.removeBlockedDomainPostsFromFeed,
+            ).toHaveBeenCalledWith(blockerAccount.id, blockedDomain);
         });
     });
 });

--- a/src/feed/feed.service.unit.test.ts
+++ b/src/feed/feed.service.unit.test.ts
@@ -28,4 +28,29 @@ describe('FeedService', () => {
             expect(mockKnex.delete).not.toHaveBeenCalled();
         });
     });
+
+    describe('removeBlockedDomainPostsFromFeed', () => {
+        it('should do nothing if the user associated with the feed account does not exist', async () => {
+            const mockKnex = {
+                where: vi.fn().mockReturnThis(),
+                andWhere: vi.fn().mockReturnThis(),
+                delete: vi.fn().mockReturnThis(),
+                select: vi.fn().mockReturnThis(),
+                first: vi.fn(),
+            };
+            const db = () => mockKnex;
+            const moderationService = {} as ModerationService;
+            const feedService = new FeedService(
+                db as unknown as Knex,
+                moderationService,
+            );
+
+            await feedService.removeBlockedDomainPostsFromFeed(
+                123,
+                new URL('https://blocked.com'),
+            );
+
+            expect(mockKnex.delete).not.toHaveBeenCalled();
+        });
+    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-669

When a domain is blocked by an account, any feed items (posted or reposted) that they have from accounts that are from the blocked domain are removed