### PR TITLE
Storing notes/reply images in post attachments

### DIFF
--- a/features/step_definitions/note_steps.js
+++ b/features/step_definitions/note_steps.js
@@ -89,7 +89,7 @@ Then(
     'note {string} has the image URL {string}',
     function (noteName, expectedImageUrl) {
         const object = this.objects[noteName];
-        assert.equal(object.attachment.url, expectedImageUrl);
-        assert.equal(object.attachment.type, 'Image');
+        assert.equal(object.attachment[0].url, expectedImageUrl);
+        assert.equal(object.attachment[0].type, 'Image');
     },
 );

--- a/features/step_definitions/note_steps.js
+++ b/features/step_definitions/note_steps.js
@@ -89,7 +89,9 @@ Then(
     'note {string} has the image URL {string}',
     function (noteName, expectedImageUrl) {
         const object = this.objects[noteName];
-        assert.equal(object.attachment[0].url, expectedImageUrl);
-        assert.equal(object.attachment[0].type, 'Image');
+        assert.ok(object.attachment, 'Note does not have attachments');
+
+        assert.equal(object.attachment.url, expectedImageUrl);
+        assert.equal(object.attachment.type, 'Image');
     },
 );

--- a/features/support/utils.js
+++ b/features/support/utils.js
@@ -6,11 +6,11 @@ export async function mapPostToActivityPubObject(post) {
     return {
         id: post.id,
         content: post.content,
-        attachment: post.featureImageUrl
-            ? {
-                  url: post.featureImageUrl,
-                  type: 'Image',
-              }
+        attachment: post.attachments
+            ? post.attachments.map((attachment) => ({
+                  url: attachment.url,
+                  type: attachment.type,
+              }))
             : null,
     };
 }

--- a/features/support/utils.js
+++ b/features/support/utils.js
@@ -6,11 +6,12 @@ export async function mapPostToActivityPubObject(post) {
     return {
         id: post.id,
         content: post.content,
-        attachment: post.attachments
-            ? post.attachments.map((attachment) => ({
-                  url: attachment.url,
-                  type: attachment.type,
-              }))
-            : null,
+        attachment:
+            post.attachments && post.attachments.length > 0
+                ? {
+                      url: post.attachments[0].url,
+                      type: post.attachments[0].type,
+                  }
+                : null,
     };
 }

--- a/src/activitypub/fediverse-bridge.ts
+++ b/src/activitypub/fediverse-bridge.ts
@@ -65,12 +65,15 @@ export class FediverseBridge {
                 content: post.content,
                 summary: null,
                 published: Temporal.Now.instant(),
-                attachments: post.imageUrl
-                    ? [
-                          new Image({
-                              url: post.imageUrl,
-                          }),
-                      ]
+                attachments: post.attachments
+                    ? post.attachments
+                          .filter((attachment) => attachment.type === 'Image')
+                          .map(
+                              (attachment) =>
+                                  new Image({
+                                      url: attachment.url,
+                                  }),
+                          )
                     : undefined,
                 to: PUBLIC_COLLECTION,
                 cc: post.author.apFollowers,

--- a/src/http/api/note.ts
+++ b/src/http/api/note.ts
@@ -60,8 +60,6 @@ export async function handleCreateNote(
 
     const post = getValue(postResult);
 
-    const account = ctx.get('account');
-
     const postDTO = postToDTO(post, {
         authoredByMe: true,
         likedByMe: false,

--- a/src/http/api/reply.ts
+++ b/src/http/api/reply.ts
@@ -206,12 +206,15 @@ export async function handleCreateReply(
         attribution: actor,
         replyTarget: objectToReplyTo,
         content: newReply.content,
-        attachments: newReply.imageUrl
-            ? [
-                  new Image({
-                      url: newReply.imageUrl,
-                  }),
-              ]
+        attachments: newReply.attachments
+            ? newReply.attachments
+                  .filter((attachment) => attachment.type === 'Image')
+                  .map(
+                      (attachment) =>
+                          new Image({
+                              url: attachment.url,
+                          }),
+                  )
             : undefined,
         summary: null,
         published: Temporal.Now.instant(),

--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -336,6 +336,17 @@ export class Post extends BaseEntity {
             addPaidContentMessage: false,
         });
 
+        const postAttachment = imageUrl
+            ? [
+                  {
+                      type: 'Image',
+                      mediaType: null,
+                      name: null,
+                      url: imageUrl,
+                  },
+              ]
+            : [];
+
         return new Post(
             null,
             null,
@@ -346,7 +357,7 @@ export class Post extends BaseEntity {
             null,
             content,
             null,
-            imageUrl ?? null,
+            null,
             new Date(),
             null,
             0,
@@ -355,7 +366,7 @@ export class Post extends BaseEntity {
             null,
             null,
             null,
-            [],
+            postAttachment,
             null,
         );
     }
@@ -386,6 +397,17 @@ export class Post extends BaseEntity {
             addPaidContentMessage: false,
         });
 
+        const postAttachment = imageUrl
+            ? [
+                  {
+                      type: 'Image',
+                      mediaType: null,
+                      name: null,
+                      url: imageUrl,
+                  },
+              ]
+            : [];
+
         return new Post(
             null,
             null,
@@ -396,7 +418,7 @@ export class Post extends BaseEntity {
             null,
             content,
             null,
-            imageUrl ?? null,
+            null,
             new Date(),
             null,
             0,
@@ -405,7 +427,7 @@ export class Post extends BaseEntity {
             inReplyToId,
             threadRootId,
             null,
-            [],
+            postAttachment,
             null,
         );
     }

--- a/src/post/post.entity.unit.test.ts
+++ b/src/post/post.entity.unit.test.ts
@@ -328,7 +328,14 @@ describe('Post', () => {
 
             expect(note.type).toBe(PostType.Note);
             expect(note.content).toBe('<p>My first note</p>');
-            expect(note.imageUrl?.toString()).toBe(imageUrl);
+            expect(note.attachments).toEqual([
+                {
+                    type: 'Image',
+                    mediaType: null,
+                    name: null,
+                    url: new URL(imageUrl),
+                },
+            ]);
         });
 
         it('creates a note with line breaks', () => {

--- a/src/post/post.service.integration.test.ts
+++ b/src/post/post.service.integration.test.ts
@@ -109,7 +109,14 @@ describe('PostService', () => {
             }
 
             const post = getValue(result);
-            expect(post.imageUrl).toEqual(imageUrl);
+            expect(post.attachments).toEqual([
+                {
+                    type: 'Image',
+                    mediaType: null,
+                    name: null,
+                    url: new URL(imageUrl),
+                },
+            ]);
         });
 
         it('should return error when image verification fails', async () => {


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PROD-1569

- For local actors we had image store in `featuredImage` whereas for remote actors it is stored in `attachments` 
- This PR includes changes to store the image in `attachments` when a note/reply is created. 
- `featuredImage` is kept as null - Not required