### PR TITLE
Fixed error on like object network lookup

### DIFF
--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -698,7 +698,16 @@ export function createLikeHandler(
                 'Like object not found in globalDb, performing network lookup',
             );
 
-            object = await like.getObject();
+            try {
+                object = await like.getObject();
+            } catch (err) {
+                ctx.data.logger.info(
+                    'Error performing like object network lookup',
+                    {
+                        error: err,
+                    },
+                );
+            }
         }
 
         // Validate object


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1587

- Added a try/catch to like object network lookup. Previously, it was throwing an error if the remote server was not be reachable.