### PR TITLE
Update account system to `follow` / `unfollow` via entity

### DIFF
--- a/src/account/account-followed.event.ts
+++ b/src/account/account-followed.event.ts
@@ -1,17 +1,19 @@
-import type { Account } from 'account/types';
-
 export class AccountFollowedEvent {
     constructor(
-        private readonly account: Account,
-        private readonly follower: Account,
+        private readonly accountId: number,
+        private readonly followerId: number,
     ) {}
 
-    getAccount(): Account {
-        return this.account;
+    getAccountId(): number {
+        return this.accountId;
     }
 
-    getFollower(): Account {
-        return this.follower;
+    getFollowerId(): number {
+        return this.followerId;
+    }
+
+    getName(): string {
+        return 'account.followed';
     }
 
     static getName(): string {

--- a/src/account/account.entity.ts
+++ b/src/account/account.entity.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import { type CreatePostType, PostType } from '../post/post.entity';
 import { AccountBlockedEvent } from './account-blocked.event';
+import { AccountFollowedEvent } from './account-followed.event';
 import { AccountUnblockedEvent } from './account-unblocked.event';
+import { AccountUnfollowedEvent } from './account-unfollowed.event';
 import { DomainBlockedEvent } from './domain-blocked.event';
 import { DomainUnblockedEvent } from './domain-unblocked.event';
 
@@ -22,6 +24,8 @@ export interface Account {
     block(account: Account): Account;
     blockDomain(domain: URL): Account;
     unblockDomain(domain: URL): Account;
+    follow(account: Account): Account;
+    unfollow(account: Account): Account;
     /**
      * Returns a new Account instance which needs to be saved.
      */
@@ -184,6 +188,26 @@ export class AccountEntity implements Account {
         return AccountEntity.create(
             this,
             this.events.concat(new DomainUnblockedEvent(domain, this.id)),
+        );
+    }
+
+    follow(account: Account): Account {
+        if (account.id === this.id) {
+            return this;
+        }
+        return AccountEntity.create(
+            this,
+            this.events.concat(new AccountFollowedEvent(account.id, this.id)),
+        );
+    }
+
+    unfollow(account: Account): Account {
+        if (account.id === this.id) {
+            return this;
+        }
+        return AccountEntity.create(
+            this,
+            this.events.concat(new AccountUnfollowedEvent(account.id, this.id)),
         );
     }
 }

--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -408,8 +408,8 @@ describe('AccountService', () => {
             });
 
             expect(accountFollowedEvent).toBeDefined();
-            expect(accountFollowedEvent?.getAccount()).toBe(account);
-            expect(accountFollowedEvent?.getFollower()).toBe(follower);
+            expect(accountFollowedEvent?.getAccountId()).toBe(account.id);
+            expect(accountFollowedEvent?.getFollowerId()).toBe(follower.id);
         });
 
         it('should not emit an account.followed event if the follow is not recorded due to being a duplicate', async () => {

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -277,6 +277,8 @@ export class AccountService {
      *
      * @param followee Account to follow
      * @param follower Following account
+     *
+     * @deprecated Use `followAccount` instead
      */
     async recordAccountFollow(
         followee: AccountType,
@@ -296,7 +298,7 @@ export class AccountService {
 
         await this.events.emitAsync(
             AccountFollowedEvent.getName(),
-            new AccountFollowedEvent(followee, follower),
+            new AccountFollowedEvent(followee.id, follower.id),
         );
     }
 
@@ -305,6 +307,8 @@ export class AccountService {
      *
      * @param following The account that is being unfollowed
      * @param follower The account that is a follower
+     *
+     * @deprecated Use `unfollowAccount` instead
      */
     async recordAccountUnfollow(
         following: AccountType,
@@ -673,5 +677,17 @@ export class AccountService {
         const updated = account.unblockDomain(domain);
         await this.accountRepository.save(updated);
         return ok(true);
+    }
+
+    async followAccount(account: Account, accountToFollow: Account) {
+        const updated = account.follow(accountToFollow);
+
+        await this.accountRepository.save(updated);
+    }
+
+    async unfollowAccount(account: Account, accountToUnfollow: Account) {
+        const updated = account.unfollow(accountToUnfollow);
+
+        await this.accountRepository.save(updated);
     }
 }

--- a/src/account/account.service.unit.test.ts
+++ b/src/account/account.service.unit.test.ts
@@ -133,4 +133,50 @@ describe('AccountService', () => {
             expect(result).toBe(account);
         });
     });
+
+    describe('followAccount', () => {
+        it('should follow an account', async () => {
+            const account = {
+                id: 1,
+                follow: vi.fn(),
+            } as unknown as AccountEntity;
+            const accountToFollow = { id: 2 } as unknown as AccountEntity;
+            const updatedAccount = {
+                id: 1,
+            } as unknown as AccountEntity;
+
+            vi.mocked(account.follow).mockImplementation(() => updatedAccount);
+
+            await accountService.followAccount(account, accountToFollow);
+
+            expect(account.follow).toHaveBeenCalledWith(accountToFollow);
+            expect(knexAccountRepository.save).toHaveBeenCalledWith(
+                updatedAccount,
+            );
+        });
+    });
+
+    describe('unfollowAccount', () => {
+        it('should unfollow an account', async () => {
+            const account = {
+                id: 1,
+                unfollow: vi.fn(),
+            } as unknown as AccountEntity;
+            const accountToUnfollow = { id: 2 } as unknown as AccountEntity;
+            const updatedAccount = {
+                id: 1,
+            } as unknown as AccountEntity;
+
+            vi.mocked(account.unfollow).mockImplementation(
+                () => updatedAccount,
+            );
+
+            await accountService.unfollowAccount(account, accountToUnfollow);
+
+            expect(account.unfollow).toHaveBeenCalledWith(accountToUnfollow);
+            expect(knexAccountRepository.save).toHaveBeenCalledWith(
+                updatedAccount,
+            );
+        });
+    });
 });

--- a/src/notification/notification-event.service.ts
+++ b/src/notification/notification-event.service.ts
@@ -53,8 +53,8 @@ export class NotificationEventService {
 
     private async handleAccountFollowedEvent(event: AccountFollowedEvent) {
         await this.notificationService.createFollowNotification(
-            event.getAccount(),
-            event.getFollower(),
+            event.getAccountId(),
+            event.getFollowerId(),
         );
     }
 

--- a/src/notification/notification-event.service.unit.test.ts
+++ b/src/notification/notification-event.service.unit.test.ts
@@ -7,7 +7,6 @@ import { AccountFollowedEvent } from 'account/account-followed.event';
 import { AccountMentionedEvent } from 'account/account-mentioned.event';
 import type { Account as AccountEntity } from 'account/account.entity';
 import { DomainBlockedEvent } from 'account/domain-blocked.event';
-import type { Account } from 'account/types';
 import { PostCreatedEvent } from 'post/post-created.event';
 import { PostDeletedEvent } from 'post/post-deleted.event';
 import { PostLikedEvent } from 'post/post-liked.event';
@@ -48,15 +47,12 @@ describe('NotificationEventService', () => {
 
             events.emit(
                 AccountFollowedEvent.getName(),
-                new AccountFollowedEvent(
-                    account as Account,
-                    followerAccount as Account,
-                ),
+                new AccountFollowedEvent(account.id, followerAccount.id),
             );
 
             expect(
                 notificationService.createFollowNotification,
-            ).toHaveBeenCalledWith(account, followerAccount);
+            ).toHaveBeenCalledWith(account.id, followerAccount.id);
         });
     });
 

--- a/src/notification/notification.service.integration.test.ts
+++ b/src/notification/notification.service.integration.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
-import type { Account } from 'account/types';
 import type { Knex } from 'knex';
+
 import { ModerationService } from 'moderation/moderation.service';
 import { Audience, PostType } from 'post/post.entity';
 import type { Post } from 'post/post.entity';
@@ -327,17 +327,9 @@ describe('NotificationService', () => {
                 domain: 'bob.com',
             });
 
-            const account = {
-                id: accountId,
-            } as Account;
-
-            const followerAccount = {
-                id: followerAccountId,
-            } as Account;
-
             await notificationService.createFollowNotification(
-                account,
-                followerAccount,
+                accountId,
+                followerAccountId,
             );
 
             const notifications = await client('notifications').select('*');
@@ -349,18 +341,7 @@ describe('NotificationService', () => {
         });
 
         it('should do nothing if user is not found for account', async () => {
-            const accountWithoutUser = {
-                id: 999,
-            } as Account;
-
-            const followerAccount = {
-                id: 1,
-            } as Account;
-
-            await notificationService.createFollowNotification(
-                accountWithoutUser,
-                followerAccount,
-            );
+            await notificationService.createFollowNotification(999, 1);
 
             const notifications = await client('notifications').select('*');
 
@@ -375,17 +356,9 @@ describe('NotificationService', () => {
 
             await fixtureManager.createBlock(aliceAccount, bobAccount);
 
-            const account = {
-                id: aliceAccount.id,
-            } as Account;
-
-            const followerAccount = {
-                id: bobAccount.id,
-            } as Account;
-
             await notificationService.createFollowNotification(
-                account,
-                followerAccount,
+                aliceAccount.id,
+                bobAccount.id,
             );
 
             const notifications = await client('notifications').select('*');

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -1,4 +1,3 @@
-import type { Account } from 'account/types';
 import { sanitizeHtml } from 'helpers/html';
 import type { Knex } from 'knex';
 import type { ModerationService } from 'moderation/moderation.service';
@@ -177,15 +176,12 @@ export class NotificationService {
         };
     }
 
-    /**
-     * Create a notification for an account being followed
-     *
-     * @param account The account that is being followed
-     * @param followerAccount The account that is following
-     */
-    async createFollowNotification(account: Account, followerAccount: Account) {
+    async createFollowNotification(
+        accountId: number,
+        followerAccountId: number,
+    ) {
         const user = await this.db('users')
-            .where('account_id', account.id)
+            .where('account_id', accountId)
             .select('id')
             .first();
 
@@ -198,8 +194,8 @@ export class NotificationService {
 
         const notificationAllowed =
             await this.moderationService.canInteractWithAccount(
-                followerAccount.id,
-                account.id,
+                followerAccountId,
+                accountId,
             );
 
         if (!notificationAllowed) {
@@ -208,7 +204,7 @@ export class NotificationService {
 
         await this.db('notifications').insert({
             user_id: user.id,
-            account_id: followerAccount.id,
+            account_id: followerAccountId,
             event_type: NotificationType.Follow,
         });
     }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-679

This includes a bunch of modifications to the account system in preparation for usage of the account unfollowed event to remove posts of unfollowed accounts from feeds:

- Emitted `account.unfollowed` event when an account is saved (if applicable)
- Added `follow` & `unfollow` methods to account entity
- Updated account repository to handle persisting of follows based on events
- Updated existing `account.followed` event to use IDs instead of full accounts for consistency with other events
- Added `followAccount` and `unfollowAccount` methods to the account service
- Deprecated usage of `recordAccountFollow` and updated call sites to use `followAccount` instead
  - Have marked as deprecated instead of removing completely as the method is still in-use in a whole bunch of tests - We can clean this up later
- Removed `recordAccountUnfollow` and updated call sites to use `unfollowAccount` instead