### PR TITLE
Removed posts from feed from unfollowed account

### DIFF
--- a/src/feed/feed-update.service.ts
+++ b/src/feed/feed-update.service.ts
@@ -1,6 +1,7 @@
 import type { EventEmitter } from 'node:events';
 
 import { AccountBlockedEvent } from 'account/account-blocked.event';
+import { AccountUnfollowedEvent } from 'account/account-unfollowed.event';
 import { DomainBlockedEvent } from 'account/domain-blocked.event';
 import type { FeedService } from 'feed/feed.service';
 import { PostCreatedEvent } from 'post/post-created.event';
@@ -39,6 +40,10 @@ export class FeedUpdateService {
         this.events.on(
             DomainBlockedEvent.getName(),
             this.handleDomainBlockedEvent.bind(this),
+        );
+        this.events.on(
+            AccountUnfollowedEvent.getName(),
+            this.handleAccountUnfollowedEvent.bind(this),
         );
     }
 
@@ -89,6 +94,16 @@ export class FeedUpdateService {
         await this.feedService.removeBlockedDomainPostsFromFeed(
             blockerId,
             domain,
+        );
+    }
+
+    private async handleAccountUnfollowedEvent(event: AccountUnfollowedEvent) {
+        const unfollowerId = event.getUnfollowerId();
+        const accountId = event.getAccountId();
+
+        await this.feedService.removeUnfollowedAccountPostsFromFeed(
+            unfollowerId,
+            accountId,
         );
     }
 }

--- a/src/feed/feed-update.service.unit.test.ts
+++ b/src/feed/feed-update.service.unit.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
 
 import { AccountBlockedEvent } from 'account/account-blocked.event';
+import { AccountUnfollowedEvent } from 'account/account-unfollowed.event';
 import { AccountEntity } from 'account/account.entity';
 import { DomainBlockedEvent } from 'account/domain-blocked.event';
 import { FeedUpdateService } from 'feed/feed-update.service';
@@ -29,6 +30,7 @@ describe('FeedUpdateService', () => {
             removePostFromFeeds: vi.fn(),
             removeBlockedAccountPostsFromFeed: vi.fn(),
             removeBlockedDomainPostsFromFeed: vi.fn(),
+            removeUnfollowedAccountPostsFromFeed: vi.fn(),
         } as unknown as FeedService;
 
         const draft = AccountEntity.draft({
@@ -225,6 +227,22 @@ describe('FeedUpdateService', () => {
             expect(
                 feedService.removeBlockedDomainPostsFromFeed,
             ).toHaveBeenCalledWith(blockerAccount.id, blockedDomain);
+        });
+    });
+
+    describe('handling an unfollowed account', () => {
+        it("should remove an unfollowed account's posts from the feed of the unfollower", () => {
+            const unfollower = { id: 456 } as AccountEntity;
+            const account = { id: 789 } as AccountEntity;
+
+            events.emit(
+                AccountUnfollowedEvent.getName(),
+                new AccountUnfollowedEvent(account.id, unfollower.id),
+            );
+
+            expect(
+                feedService.removeUnfollowedAccountPostsFromFeed,
+            ).toHaveBeenCalledWith(unfollower.id, account.id);
         });
     });
 });

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -398,4 +398,28 @@ export class FeedService {
             ])
             .delete();
     }
+
+    async removeUnfollowedAccountPostsFromFeed(
+        feedAccountId: number,
+        unfollowedAccountId: number,
+    ) {
+        const user = await this.db('users')
+            .where('account_id', feedAccountId)
+            .select('id')
+            .first();
+
+        if (!user) {
+            return;
+        }
+
+        await this.db('feeds')
+            .where((qb) => {
+                qb.where('author_id', unfollowedAccountId).orWhere(
+                    'reposted_by_id',
+                    unfollowedAccountId,
+                );
+            })
+            .andWhere('user_id', user.id)
+            .delete();
+    }
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-679

When an account unfollows another account, any posts or reposts from the unfollowed account that appear in the feed of the unfollowing account will be removed. This is so the unfollower does not see content from the unfollowed account in there feed after the unfollow has occurred