### PR TITLE
Increased key column size on key_value table

### DIFF
--- a/migrate/gh-ost.Dockerfile
+++ b/migrate/gh-ost.Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:24.04
+
+RUN apt update && \
+    apt install -y curl percona-toolkit
+RUN curl -fsSL https://github.com/github/gh-ost/releases/download/v1.1.7/gh-ost-binary-linux-arm64-20241219160321.tar.gz -o gh-ost.tar.gz && \
+    tar -xzf gh-ost.tar.gz && \
+    rm gh-ost.tar.gz && \
+    mv gh-ost /usr/local/bin/gh-ost
+
+CMD ["bin/bash"]

--- a/migrate/migrations/000051_alter-key-on-key-value-table.down.sql
+++ b/migrate/migrations/000051_alter-key-on-key-value-table.down.sql
@@ -1,0 +1,26 @@
+/*  This migration was executed manually.
+    The alter table query executed on a very large table can cause downtime
+    Instead, it was executed with gh-ost
+        $ docker run -it \
+            -e DB_USER=${DB_USER} \
+            -e DB_PASS=${DB_PASS} \
+            -e DB_HOST=${DB_HOST} \
+            -e DB_NAME=${DB_NAME} \
+            gh-ost bash
+        $ gh-ost \
+            --user="${DB_USER}" \
+            --password="${DB_PASS}" \
+            --host="${DB_HOST}" \
+            --database="${DB_NAME}" \
+            --table="key_value" \
+            --verbose \
+            --alter="MODIFY \`key\` VARCHAR(256)" \
+            --allow-on-master \
+            --exact-rowcount \
+            --concurrent-rowcount \
+            --default-retries=120 \
+            --ssl \
+            --ssl-allow-insecure \
+            --execute
+*/
+ALTER TABLE key_value MODIFY `key` VARCHAR(256);

--- a/migrate/migrations/000051_alter-key-on-key-value-table.up.sql
+++ b/migrate/migrations/000051_alter-key-on-key-value-table.up.sql
@@ -1,0 +1,26 @@
+/*  This migration was executed manually.
+    The alter table query executed on a very large table can cause downtime
+    Instead, it was executed with gh-ost
+        $ docker run -it \
+            -e DB_USER=${DB_USER} \
+            -e DB_PASS=${DB_PASS} \
+            -e DB_HOST=${DB_HOST} \
+            -e DB_NAME=${DB_NAME} \
+            gh-ost bash
+        $ gh-ost \
+            --user="${DB_USER}" \
+            --password="${DB_PASS}" \
+            --host="${DB_HOST}" \
+            --database="${DB_NAME}" \
+            --table="key_value" \
+            --verbose \
+            --alter="MODIFY \`key\` VARCHAR(768)" \
+            --allow-on-master \
+            --exact-rowcount \
+            --concurrent-rowcount \
+            --default-retries=120 \
+            --ssl \
+            --ssl-allow-insecure \
+            --execute
+*/
+ALTER TABLE key_value MODIFY `key` VARCHAR(768);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1587

- Key size was preventing some inserts on the key_value table and causing 500 errors.