### PR TITLE
Added Webfinger lookup for actor profile

### DIFF
--- a/src/lookup-helpers.ts
+++ b/src/lookup-helpers.ts
@@ -135,7 +135,13 @@ export async function lookupActorProfile(
         );
 
         if (profileLink?.href) {
-            return new URL(profileLink.href);
+            try {
+                return new URL(profileLink.href);
+            } catch (err) {
+                ctx.data.logger.info(
+                    `Invalid profile page URL for handle ${handle}, falling back to self link`,
+                );
+            }
         }
 
         // Fallback to ActivityPub self link if profile link not found

--- a/src/lookup-helpers.ts
+++ b/src/lookup-helpers.ts
@@ -144,7 +144,7 @@ export async function lookupActorProfile(
             }
         }
 
-        // Fallback to ActivityPub self link if profile link not found
+        // Fallback to ActivityPub self link if profile link not found or is not valid
         const selfLink = webfingerData.links.find(
             (link) =>
                 link.rel === 'self' &&

--- a/src/lookup-helpers.ts
+++ b/src/lookup-helpers.ts
@@ -106,3 +106,57 @@ export async function lookupAPIdByHandle(
         return null;
     }
 }
+
+export async function lookupActorProfile(
+    ctx: Context<ContextData>,
+    handle: string,
+): Promise<URL | null> {
+    try {
+        // Remove leading @ if present
+        const cleanHandle = handle.startsWith('@') ? handle.slice(1) : handle;
+
+        const resource = `acct:${cleanHandle}`;
+
+        const webfingerData = await lookupWebFinger(resource, {
+            allowPrivateAddress:
+                process.env.ALLOW_PRIVATE_ADDRESS === 'true' &&
+                ['development', 'testing'].includes(process.env.NODE_ENV || ''),
+        });
+
+        if (!webfingerData?.links) {
+            ctx.data.logger.info(
+                `No links found in WebFinger response for handle ${handle}`,
+            );
+            return null;
+        }
+
+        const profileLink = webfingerData.links.find(
+            (link) => link.rel === 'http://webfinger.net/rel/profile-page',
+        );
+
+        if (profileLink?.href) {
+            return new URL(profileLink.href);
+        }
+
+        // Fallback to ActivityPub self link if profile link not found
+        const selfLink = webfingerData.links.find(
+            (link) =>
+                link.rel === 'self' &&
+                link.type === 'application/activity+json',
+        );
+
+        if (!selfLink?.href) {
+            ctx.data.logger.info(
+                `No ActivityPub profile found in WebFinger response for handle ${handle}`,
+            );
+            return null;
+        }
+
+        return new URL(selfLink.href);
+    } catch (err) {
+        ctx.data.logger.error(
+            `Error looking up actor profile for handle ${handle} - ${err}`,
+        );
+        return null;
+    }
+}

--- a/src/lookup-helpers.unit.test.ts
+++ b/src/lookup-helpers.unit.test.ts
@@ -1,6 +1,7 @@
-import { lookupWebFinger } from '@fedify/fedify';
+import { type Context, lookupWebFinger } from '@fedify/fedify';
+import type { ContextData } from 'app';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { lookupAPIdByHandle } from './lookup-helpers';
+import { lookupAPIdByHandle, lookupActorProfile } from './lookup-helpers';
 
 vi.mock('@fedify/fedify', () => ({
     lookupWebFinger: vi.fn(),
@@ -36,9 +37,7 @@ describe('lookupAPIdByHandle', () => {
         ).mockResolvedValue(mockWebFingerResponse);
 
         const result = await lookupAPIdByHandle(
-            // TODO: Clean up the any type
-            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
-            mockCtx as any,
+            mockCtx as unknown as Context<ContextData>,
             '@user@example.com',
         );
 
@@ -58,9 +57,7 @@ describe('lookupAPIdByHandle', () => {
         ).mockResolvedValue(mockWebFingerResponse);
 
         const result = await lookupAPIdByHandle(
-            // TODO: Clean up the any type
-            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
-            mockCtx as any,
+            mockCtx as unknown as Context<ContextData>,
             'user@example.com',
         );
 
@@ -83,9 +80,7 @@ describe('lookupAPIdByHandle', () => {
         ).mockResolvedValue(mockWebFingerResponse);
 
         const result = await lookupAPIdByHandle(
-            // TODO: Clean up the any type
-            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
-            mockCtx as any,
+            mockCtx as unknown as Context<ContextData>,
             'user@example.com',
         );
 
@@ -98,9 +93,7 @@ describe('lookupAPIdByHandle', () => {
         ).mockRejectedValue(new Error('WebFinger lookup failed'));
 
         const result = await lookupAPIdByHandle(
-            // TODO: Clean up the any type
-            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
-            mockCtx as any,
+            mockCtx as unknown as Context<ContextData>,
             'user@example.com',
         );
 
@@ -128,12 +121,162 @@ describe('lookupAPIdByHandle', () => {
         ).mockResolvedValue(mockWebFingerResponse);
 
         const result = await lookupAPIdByHandle(
-            // TODO: Clean up the any type
-            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
-            mockCtx as any,
+            mockCtx as unknown as Context<ContextData>,
             'user@example.com',
         );
 
         expect(result).toBe('https://example.com/actor');
+    });
+});
+
+describe('lookupActorProfile', () => {
+    const mockCtx = {
+        data: {
+            logger: {
+                info: vi.fn(),
+                error: vi.fn(),
+            },
+        },
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should return profile page URL when available', async () => {
+        const mockWebFingerResponse = {
+            links: [
+                {
+                    rel: 'self',
+                    type: 'application/activity+json',
+                    href: 'https://example.com/actor',
+                },
+                {
+                    rel: 'http://webfinger.net/rel/profile-page',
+                    href: 'https://example.com/profile',
+                },
+            ],
+        };
+
+        (
+            lookupWebFinger as unknown as ReturnType<typeof vi.fn>
+        ).mockResolvedValue(mockWebFingerResponse);
+
+        const result = await lookupActorProfile(
+            mockCtx as unknown as Context<ContextData>,
+            'user@example.com',
+        );
+
+        expect(lookupWebFinger).toHaveBeenCalledWith('acct:user@example.com', {
+            allowPrivateAddress: true,
+        });
+        expect(result).toEqual(new URL('https://example.com/profile'));
+    });
+
+    it('should fallback to self link when profile page is not available', async () => {
+        const mockWebFingerResponse = {
+            links: [
+                {
+                    rel: 'self',
+                    type: 'application/activity+json',
+                    href: 'https://example.com/actor',
+                },
+            ],
+        };
+
+        (
+            lookupWebFinger as unknown as ReturnType<typeof vi.fn>
+        ).mockResolvedValue(mockWebFingerResponse);
+
+        const result = await lookupActorProfile(
+            mockCtx as unknown as Context<ContextData>,
+            'user@example.com',
+        );
+
+        expect(result).toEqual(new URL('https://example.com/actor'));
+    });
+
+    it('should handle handles with leading @', async () => {
+        const mockWebFingerResponse = {
+            links: [
+                {
+                    rel: 'http://webfinger.net/rel/profile-page',
+                    href: 'https://example.com/profile',
+                },
+            ],
+        };
+
+        (
+            lookupWebFinger as unknown as ReturnType<typeof vi.fn>
+        ).mockResolvedValue(mockWebFingerResponse);
+
+        const result = await lookupActorProfile(
+            mockCtx as unknown as Context<ContextData>,
+            '@user@example.com',
+        );
+
+        expect(lookupWebFinger).toHaveBeenCalledWith('acct:user@example.com', {
+            allowPrivateAddress: true,
+        });
+        expect(result).toEqual(new URL('https://example.com/profile'));
+    });
+
+    it('should return null when WebFinger response has no links', async () => {
+        const mockWebFingerResponse = {};
+
+        (
+            lookupWebFinger as unknown as ReturnType<typeof vi.fn>
+        ).mockResolvedValue(mockWebFingerResponse);
+
+        const result = await lookupActorProfile(
+            mockCtx as unknown as Context<ContextData>,
+            'user@example.com',
+        );
+
+        expect(result).toBeNull();
+        expect(mockCtx.data.logger.info).toHaveBeenCalledWith(
+            'No links found in WebFinger response for handle user@example.com',
+        );
+    });
+
+    it('should return null when no profile page or self link is found', async () => {
+        const mockWebFingerResponse = {
+            links: [
+                {
+                    rel: 'other',
+                    href: 'https://example.com/other',
+                },
+            ],
+        };
+
+        (
+            lookupWebFinger as unknown as ReturnType<typeof vi.fn>
+        ).mockResolvedValue(mockWebFingerResponse);
+
+        const result = await lookupActorProfile(
+            mockCtx as unknown as Context<ContextData>,
+            'user@example.com',
+        );
+
+        expect(result).toBeNull();
+        expect(mockCtx.data.logger.info).toHaveBeenCalledWith(
+            'No ActivityPub profile found in WebFinger response for handle user@example.com',
+        );
+    });
+
+    it('should return null when WebFinger lookup fails', async () => {
+        (
+            lookupWebFinger as unknown as ReturnType<typeof vi.fn>
+        ).mockRejectedValue(new Error('WebFinger lookup failed'));
+
+        const result = await lookupActorProfile(
+            mockCtx as unknown as Context<ContextData>,
+            'user@example.com',
+        );
+
+        expect(result).toBeNull();
+        expect(mockCtx.data.logger.error).toHaveBeenCalledWith(
+            'Error looking up actor profile for handle user@example.com - Error: WebFinger lookup failed',
+        );
     });
 });


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PROD-1736

- We want to do a Webfinger lookup to validate the handle, and retrieve the actor profile URL: 
- Webfinger lookup  - GET https://domain/.well-known/webfinger?resource=acct:user@domain
- Use the http://webfinger.net/rel/profile-page link if available 
- Otherwise, fallback to self