### PR TITLE
Added API endpoints for getting blocked accounts and domains

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -115,6 +115,7 @@ import {
 import { AccountFollowsView } from './http/api/views/account.follows.view';
 import { AccountPostsView } from './http/api/views/account.posts.view';
 import { AccountView } from './http/api/views/account.view';
+import { BlocksView } from './http/api/views/blocks.view';
 import { createWebFingerHandler } from './http/handler/webfinger';
 import { setupInstrumentation, spanWrapper } from './instrumentation';
 import { KnexKvStore } from './knex.kvstore';
@@ -297,6 +298,7 @@ const accountFollowsView = new AccountFollowsView(
     moderationService,
 );
 const accountPostsView = new AccountPostsView(client, fedifyContextFactory);
+const blocksView = new BlocksView(client);
 const siteService = new SiteService(client, accountService, {
     getSiteSettings: getSiteSettings,
 });
@@ -318,7 +320,7 @@ const notificationEventService = new NotificationEventService(
 );
 notificationEventService.init();
 
-const blockController = new BlockController(accountService);
+const blockController = new BlockController(accountService, blocksView);
 const followController = new FollowController(
     accountService,
     moderationService,
@@ -1126,6 +1128,22 @@ app.post(
     '/.ghost/activitypub/actions/unblock/domain/:domain',
     requireRole(GhostRole.Owner, GhostRole.Administrator),
     spanWrapper((ctx: AppContext) => blockController.handleUnblockDomain(ctx)),
+);
+
+app.get(
+    '/.ghost/activitypub/blocks/accounts',
+    requireRole(GhostRole.Owner, GhostRole.Administrator),
+    spanWrapper((ctx: AppContext) =>
+        blockController.handleGetBlockedAccounts(ctx),
+    ),
+);
+
+app.get(
+    '/.ghost/activitypub/blocks/domains',
+    requireRole(GhostRole.Owner, GhostRole.Administrator),
+    spanWrapper((ctx: AppContext) =>
+        blockController.handleGetBlockedDomains(ctx),
+    ),
 );
 /** Federation wire up */
 

--- a/src/http/api/block.ts
+++ b/src/http/api/block.ts
@@ -3,9 +3,13 @@ import type { AppContext } from 'app';
 import { exhaustiveCheck, getError, isError } from 'core/result';
 import { parseURL } from 'core/url';
 import { BadRequest, NotFound } from './helpers/response';
+import type { BlocksView } from './views/blocks.view';
 
 export class BlockController {
-    constructor(private readonly accountService: AccountService) {}
+    constructor(
+        private readonly accountService: AccountService,
+        private readonly blocksView: BlocksView,
+    ) {}
 
     async handleBlock(ctx: AppContext) {
         const accountToBlock = parseURL(
@@ -113,5 +117,39 @@ export class BlockController {
             },
             status: 200,
         });
+    }
+
+    async handleGetBlockedAccounts(ctx: AppContext) {
+        const account = ctx.get('account');
+        const blockedAccounts = await this.blocksView.getBlockedAccounts(
+            account.id,
+        );
+
+        return new Response(
+            JSON.stringify({ blocked_accounts: blockedAccounts }),
+            {
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                status: 200,
+            },
+        );
+    }
+
+    async handleGetBlockedDomains(ctx: AppContext) {
+        const account = ctx.get('account');
+        const blockedDomains = await this.blocksView.getBlockedDomains(
+            account.id,
+        );
+
+        return new Response(
+            JSON.stringify({ blocked_domains: blockedDomains }),
+            {
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                status: 200,
+            },
+        );
     }
 }

--- a/src/http/api/types.ts
+++ b/src/http/api/types.ts
@@ -1,16 +1,15 @@
 import type { Metadata, PostType } from '../../post/post.entity';
 
 /**
- * Account returned by the API - Anywhere an account is returned via the API,
- * it should be this shape, or a partial version of it
+ * Base account DTO that can be used across different views
  */
-export interface AccountDTO {
+export interface MinimalAccountDTO {
     /**
      * Internal ID of the account
      */
     id: string;
     /**
-     * ActivityPub ID of the account
+     * Internal ID of the account
      */
     apId: string;
     /**
@@ -22,17 +21,40 @@ export interface AccountDTO {
      */
     handle: string;
     /**
+     * URL of the avatar of the account
+     */
+    avatarUrl: string | null;
+    /**
+     * Whether the account of the current user is followed by this account
+     */
+    followedByMe: boolean;
+    /**
+     * Whether the account of the current user is blocking this account
+     */
+    blockedByMe: boolean;
+    /**
+     * Whether the account of the current user is blocking this accounts domain
+     */
+    domainBlockedByMe: boolean;
+    /**
+     * Whether the current user is following this account
+     */
+    isFollowing: boolean;
+}
+
+/**
+ * Account returned by the API - Anywhere an account is returned via the API,
+ * it should be this shape, or a partial version of it
+ */
+export interface AccountDTO extends Omit<MinimalAccountDTO, 'isFollowing'> {
+    /**
      * Bio of the account
      */
-    bio: string;
+    bio: string | null;
     /**
      * Public URL of the account
      */
-    url: string;
-    /**
-     * URL of the avatar of the account
-     */
-    avatarUrl: string;
+    url: string | null;
     /**
      * URL of the banner image of the account
      */
@@ -61,18 +83,6 @@ export interface AccountDTO {
      * Whether the account of the current user is followed by this account
      */
     followsMe: boolean;
-    /**
-     * Whether the account of the current user is following this account
-     */
-    followedByMe: boolean;
-    /**
-     * Whether the account of the current user is blocking this account
-     */
-    blockedByMe: boolean;
-    /**
-     * Whether the account of the current user is blocking this accounts domain
-     */
-    domainBlockedByMe: boolean;
 }
 
 export type AuthorDTO = Pick<
@@ -227,4 +237,14 @@ export interface NotificationDTO {
               type: 'article' | 'note';
           })
         | null;
+}
+
+/**
+ * DTO for a blocked domain
+ */
+export interface BlockedDomainDTO {
+    /**
+     * The fully qualified URL of the blocked domain
+     */
+    url: string;
 }

--- a/src/http/api/views/account.follows.view.integration.test.ts
+++ b/src/http/api/views/account.follows.view.integration.test.ts
@@ -427,6 +427,7 @@ describe('AccountFollowsView', () => {
                         accounts: [
                             {
                                 id: followerOne.apId.href,
+                                apId: followerOne.apId.href,
                                 name: followerOne.name,
                                 handle: `@${followerOne.username}@${followerOne.apId.host}`,
                                 avatarUrl: followerOne.avatarUrl?.href,
@@ -437,6 +438,7 @@ describe('AccountFollowsView', () => {
                             },
                             {
                                 id: followerTwo.apId.href,
+                                apId: followerTwo.apId.href,
                                 name: followerTwo.name,
                                 handle: `@${followerTwo.username}@${followerTwo.apId.host}`,
                                 avatarUrl: followerTwo.avatarUrl?.href,
@@ -447,6 +449,7 @@ describe('AccountFollowsView', () => {
                             },
                             {
                                 id: followerThree.apId.href,
+                                apId: followerThree.apId.href,
                                 name: followerThree.name,
                                 handle: `@${followerThree.username}@${followerThree.apId.host}`,
                                 avatarUrl: followerThree.avatarUrl?.href,
@@ -457,6 +460,7 @@ describe('AccountFollowsView', () => {
                             },
                             {
                                 id: 'https://404media.co/.ghost/activitypub/users/index',
+                                apId: 'https://404media.co/.ghost/activitypub/users/index',
                                 name: '404 Media',
                                 handle: '@feed@404media.co',
                                 avatarUrl: 'https://404media.co/avatar.jpg',
@@ -467,6 +471,7 @@ describe('AccountFollowsView', () => {
                             },
                             {
                                 id: 'https://john.onolan.org/.ghost/activitypub/users/index',
+                                apId: 'https://john.onolan.org/.ghost/activitypub/users/index',
                                 name: "John O'Nolan",
                                 handle: '@john@john.onolan.org',
                                 avatarUrl: 'https://john.onolan.org/avatar.jpg',
@@ -595,6 +600,7 @@ describe('AccountFollowsView', () => {
                         accounts: [
                             {
                                 id: followerOne.apId.href,
+                                apId: followerOne.apId.href,
                                 name: followerOne.name,
                                 handle: `@${followerOne.username}@${followerOne.apId.host}`,
                                 avatarUrl: followerOne.avatarUrl?.href,
@@ -605,6 +611,7 @@ describe('AccountFollowsView', () => {
                             },
                             {
                                 id: followerTwo.apId.href,
+                                apId: followerTwo.apId.href,
                                 name: followerTwo.name,
                                 handle: `@${followerTwo.username}@${followerTwo.apId.host}`,
                                 avatarUrl: followerTwo.avatarUrl?.href,
@@ -615,6 +622,7 @@ describe('AccountFollowsView', () => {
                             },
                             {
                                 id: followerThree.apId.href,
+                                apId: followerThree.apId.href,
                                 name: followerThree.name,
                                 handle: `@${followerThree.username}@${followerThree.apId.host}`,
                                 avatarUrl: followerThree.avatarUrl?.href,
@@ -625,6 +633,7 @@ describe('AccountFollowsView', () => {
                             },
                             {
                                 id: 'https://404media.co/.ghost/activitypub/users/index',
+                                apId: 'https://404media.co/.ghost/activitypub/users/index',
                                 name: '404 Media',
                                 handle: '@feed@404media.co',
                                 avatarUrl: 'https://404media.co/avatar.jpg',
@@ -635,6 +644,7 @@ describe('AccountFollowsView', () => {
                             },
                             {
                                 id: 'https://john.onolan.org/.ghost/activitypub/users/index',
+                                apId: 'https://john.onolan.org/.ghost/activitypub/users/index',
                                 name: "John O'Nolan",
                                 handle: '@john@john.onolan.org',
                                 avatarUrl: 'https://john.onolan.org/avatar.jpg',

--- a/src/http/api/views/account.follows.view.ts
+++ b/src/http/api/views/account.follows.view.ts
@@ -11,7 +11,7 @@ import type { FedifyContextFactory } from 'activitypub/fedify-context.factory';
 import { type Result, error, getValue, isError, ok } from 'core/result';
 import type { Knex } from 'knex';
 import type { ModerationService } from 'moderation/moderation.service';
-import type { AccountDTO } from '../types';
+import type { MinimalAccountDTO } from '../types';
 
 /**
  * Maximum number of follow accounts to return
@@ -23,19 +23,8 @@ export type GetFollowsError =
     | 'error-getting-follows'
     | 'not-an-actor';
 
-type AccountInfo = Pick<
-    AccountDTO,
-    | 'id'
-    | 'name'
-    | 'handle'
-    | 'avatarUrl'
-    | 'followedByMe'
-    | 'blockedByMe'
-    | 'domainBlockedByMe'
-> & { isFollowing: boolean };
-
 export interface AccountFollows {
-    accounts: AccountInfo[];
+    accounts: MinimalAccountDTO[];
     next: string | null;
 }
 
@@ -126,7 +115,7 @@ export class AccountFollowsView {
                 ? (next + FOLLOWS_LIMIT).toString()
                 : null;
 
-        const accounts: AccountInfo[] = [];
+        const accounts: MinimalAccountDTO[] = [];
 
         for (const result of results) {
             const domainBlockedByMe =
@@ -137,6 +126,7 @@ export class AccountFollowsView {
 
             accounts.push({
                 id: result.ap_id,
+                apId: result.ap_id,
                 name: result.name || '',
                 handle: getAccountHandle(
                     new URL(result.ap_id).host,
@@ -314,12 +304,12 @@ export class AccountFollowsView {
     private async processFollowsList(
         followsList: URL[],
         siteDefaultAccount: Account,
-    ): Promise<AccountInfo[]> {
+    ): Promise<MinimalAccountDTO[]> {
         const ctx = this.fedifyContextFactory.getFedifyContext();
         const documentLoader = await ctx.getDocumentLoader({
             handle: 'index',
         });
-        const accounts: AccountInfo[] = [];
+        const accounts: MinimalAccountDTO[] = [];
 
         for await (const item of followsList) {
             try {
@@ -375,6 +365,7 @@ export class AccountFollowsView {
 
                     accounts.push({
                         id: followeeAccount.ap_id,
+                        apId: followeeAccount.ap_id,
                         name: followeeAccount.name || '',
                         handle: getAccountHandle(
                             new URL(followeeAccount.ap_id).host,
@@ -411,6 +402,7 @@ export class AccountFollowsView {
 
                     accounts.push({
                         id: followsActor.id,
+                        apId: followsActor.id,
                         name: followsActor.name,
                         handle: getAccountHandle(
                             new URL(followsActor.id).host,

--- a/src/http/api/views/blocks.view.integration.test.ts
+++ b/src/http/api/views/blocks.view.integration.test.ts
@@ -1,0 +1,108 @@
+import type { Knex } from 'knex';
+import { createTestDb } from 'test/db';
+import { type FixtureManager, createFixtureManager } from 'test/fixtures';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { BlocksView } from './blocks.view';
+
+describe('BlocksView', () => {
+    let db: Knex;
+    let fixtureManager: FixtureManager;
+    let blocksView: BlocksView;
+
+    beforeAll(async () => {
+        db = await createTestDb();
+        fixtureManager = await createFixtureManager(db);
+    });
+
+    beforeEach(async () => {
+        blocksView = new BlocksView(db);
+    });
+
+    afterAll(async () => {
+        await db.destroy();
+    });
+
+    describe('getBlockedAccounts', () => {
+        it('should return empty array when no accounts are blocked', async () => {
+            const [account] = await fixtureManager.createInternalAccount();
+
+            const blockedAccounts = await blocksView.getBlockedAccounts(
+                account.id,
+            );
+
+            expect(blockedAccounts).toEqual([]);
+        });
+
+        it('should return blocked accounts', async () => {
+            const [blocker] = await fixtureManager.createInternalAccount();
+            const [blockedOne] = await fixtureManager.createInternalAccount();
+            const [blockedTwo] = await fixtureManager.createInternalAccount();
+
+            await fixtureManager.createBlock(blocker, blockedOne);
+            await fixtureManager.createBlock(blocker, blockedTwo);
+            await fixtureManager.createDomainBlock(blocker, blockedTwo.apId);
+
+            const blockedAccounts = await blocksView.getBlockedAccounts(
+                blocker.id,
+            );
+
+            expect(blockedAccounts).toHaveLength(2);
+            expect(blockedAccounts[0]).toEqual({
+                id: blockedOne.apId.toString(),
+                apId: blockedOne.apId.toString(),
+                name: blockedOne.name,
+                handle: `${blockedOne.username}@${blockedOne.apId.host}`,
+                avatarUrl: blockedOne.avatarUrl
+                    ? blockedOne.avatarUrl.toString()
+                    : null,
+                followedByMe: false,
+                blockedByMe: true,
+                domainBlockedByMe: false,
+                isFollowing: false,
+            });
+            expect(blockedAccounts[1]).toEqual({
+                id: blockedTwo.apId.toString(),
+                apId: blockedTwo.apId.toString(),
+                name: blockedTwo.name,
+                handle: `${blockedTwo.username}@${blockedTwo.apId.host}`,
+                avatarUrl: blockedTwo.avatarUrl
+                    ? blockedTwo.avatarUrl.toString()
+                    : null,
+                followedByMe: false,
+                blockedByMe: true,
+                domainBlockedByMe: true,
+                isFollowing: false,
+            });
+        });
+    });
+
+    describe('getBlockedDomains', () => {
+        it('should return empty array when no domains are blocked', async () => {
+            const [account] = await fixtureManager.createInternalAccount();
+
+            const blockedDomains = await blocksView.getBlockedDomains(
+                account.id,
+            );
+
+            expect(blockedDomains).toEqual([]);
+        });
+
+        it('should return blocked domains', async () => {
+            const [account] = await fixtureManager.createInternalAccount();
+
+            await fixtureManager.createDomainBlock(
+                account,
+                new URL('https://example.com'),
+            );
+
+            const blockedDomains = await blocksView.getBlockedDomains(
+                account.id,
+            );
+
+            expect(blockedDomains).toHaveLength(1);
+            expect(blockedDomains[0]).toEqual({
+                url: 'https://example.com',
+            });
+        });
+    });
+});

--- a/src/http/api/views/blocks.view.ts
+++ b/src/http/api/views/blocks.view.ts
@@ -1,0 +1,47 @@
+import type { Knex } from 'knex';
+import type { BlockedDomainDTO, MinimalAccountDTO } from '../types';
+
+export class BlocksView {
+    constructor(private readonly db: Knex) {}
+
+    async getBlockedAccounts(accountId: number): Promise<MinimalAccountDTO[]> {
+        const results = await this.db('blocks')
+            .select([
+                'accounts.ap_id',
+                'accounts.name',
+                'accounts.username',
+                'accounts.avatar_url',
+                'accounts.domain',
+                'domain_blocks.domain as blocked_domain',
+            ])
+            .innerJoin('accounts', 'accounts.id', 'blocks.blocked_id')
+            .leftJoin(
+                'domain_blocks',
+                'domain_blocks.domain',
+                'accounts.domain',
+            )
+            .where('blocks.blocker_id', accountId);
+
+        return results.map((result) => ({
+            id: result.ap_id,
+            apId: result.ap_id,
+            name: result.name || '',
+            handle: `${result.username}@${result.domain}`,
+            avatarUrl: result.avatar_url || null,
+            followedByMe: false,
+            blockedByMe: true,
+            domainBlockedByMe: !!result.blocked_domain,
+            isFollowing: false,
+        }));
+    }
+
+    async getBlockedDomains(accountId: number): Promise<BlockedDomainDTO[]> {
+        const results = await this.db('domain_blocks')
+            .select('domain')
+            .where('blocker_id', accountId);
+
+        return results.map((result) => ({
+            url: `https://${result.domain}`,
+        }));
+    }
+}


### PR DESCRIPTION
ref PROD-1636

- Implemented new endpoints to retrieve lists of blocked users and domains
- `/.ghost/activitypub/blocks/accounts` for accounts
- `/.ghost/activitypub/blocks/domains` for domains