### PR TITLE
Added mentions for notes and replies

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,3 +6,5 @@ export const ACTIVITY_TYPE_ANNOUNCE = 'Announce';
 export const ACTIVITY_TYPE_CREATE = 'Create';
 export const ACTIVITY_OBJECT_TYPE_ARTICLE = 'Article';
 export const ACTIVITY_OBJECT_TYPE_NOTE = 'Note';
+
+export const HANDLE_REGEX = /@([\w.-]+)@([\w-]+\.[\w.-]+[a-zA-Z])/;

--- a/src/helpers/activitypub/actor.ts
+++ b/src/helpers/activitypub/actor.ts
@@ -1,7 +1,7 @@
 import { type Actor, PropertyValue } from '@fedify/fedify';
 import type { AccountService } from '../../account/account.service';
+import { HANDLE_REGEX } from '../../constants';
 import type { Site } from '../../site/site.service';
-
 interface Attachment {
     name: string;
     value: string;
@@ -78,5 +78,5 @@ export async function isFollowedByDefaultSiteAccount(
 }
 
 export function isHandle(handle: string): boolean {
-    return /^@([\w.-]+)@([\w-]+\.[\w.-]+[^.])$/.test(handle);
+    return new RegExp(`^${HANDLE_REGEX.source}$`).test(handle);
 }

--- a/src/helpers/activitypub/actor.unit.test.ts
+++ b/src/helpers/activitypub/actor.unit.test.ts
@@ -284,6 +284,11 @@ describe('isHandle', () => {
         expect(isHandle('@@foo')).toBe(false);
         expect(isHandle('@foo@')).toBe(false);
         expect(isHandle('@foo@@example.com')).toBe(false);
+        expect(isHandle('@foo@example.com!')).toBe(false);
+        expect(isHandle('@foo@example.com.')).toBe(false);
+        expect(isHandle('@foo@example.com@')).toBe(false);
+        expect(isHandle('@foo@example.com ')).toBe(false);
+        expect(isHandle('@foo@example.com-')).toBe(false);
         expect(isHandle('@some.user.name@example.domain.com')).toBe(true);
         expect(isHandle('@some.user.name@example.com/bar')).toBe(false);
         expect(isHandle('@foo@example.com.')).toBe(false);

--- a/src/lookup-helpers.unit.test.ts
+++ b/src/lookup-helpers.unit.test.ts
@@ -1,6 +1,7 @@
 import { type Context, lookupWebFinger } from '@fedify/fedify';
 import type { ContextData } from 'app';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { error, ok } from './core/result';
 import { lookupAPIdByHandle, lookupActorProfile } from './lookup-helpers';
 
 vi.mock('@fedify/fedify', () => ({
@@ -143,72 +144,9 @@ describe('lookupActorProfile', () => {
         vi.clearAllMocks();
     });
 
-    it('should return both profile page URL and apId when available', async () => {
-        const mockWebFingerResponse = {
-            links: [
-                {
-                    rel: 'self',
-                    type: 'application/activity+json',
-                    href: 'https://example.com/actor',
-                },
-                {
-                    rel: 'http://webfinger.net/rel/profile-page',
-                    href: 'https://example.com/profile',
-                },
-            ],
-        };
-
-        (
-            lookupWebFinger as unknown as ReturnType<typeof vi.fn>
-        ).mockResolvedValue(mockWebFingerResponse);
-
-        const result = await lookupActorProfile(
-            mockCtx as unknown as Context<ContextData>,
-            'user@example.com',
-        );
-
-        expect(lookupWebFinger).toHaveBeenCalledWith('acct:user@example.com', {
-            allowPrivateAddress: true,
-        });
-        expect(result).toEqual({
-            profileUrl: new URL('https://example.com/profile'),
-            apId: new URL('https://example.com/actor'),
-        });
-    });
-
-    it('should return only apid when profile page is not available', async () => {
-        const mockWebFingerResponse = {
-            links: [
-                {
-                    rel: 'self',
-                    type: 'application/activity+json',
-                    href: 'https://example.com/actor',
-                },
-            ],
-        };
-
-        (
-            lookupWebFinger as unknown as ReturnType<typeof vi.fn>
-        ).mockResolvedValue(mockWebFingerResponse);
-
-        const result = await lookupActorProfile(
-            mockCtx as unknown as Context<ContextData>,
-            'user@example.com',
-        );
-
-        expect(result).toEqual({
-            profileUrl: null,
-            apId: new URL('https://example.com/actor'),
-        });
-    });
-
     it('should handle handles with leading @', async () => {
         const mockWebFingerResponse = {
             links: [
-                {
-                    rel: 'http://webfinger.net/rel/profile-page',
-                    href: 'https://example.com/profile',
-                },
                 {
                     rel: 'self',
                     type: 'application/activity+json',
@@ -229,14 +167,13 @@ describe('lookupActorProfile', () => {
         expect(lookupWebFinger).toHaveBeenCalledWith('acct:user@example.com', {
             allowPrivateAddress: true,
         });
-        expect(result).toEqual({
-            profileUrl: new URL('https://example.com/profile'),
-            apId: new URL('https://example.com/actor'),
-        });
+        expect(result).toEqual(ok(new URL('https://example.com/actor')));
     });
 
-    it('should return null for both links when WebFinger response has no links', async () => {
-        const mockWebFingerResponse = {};
+    it('should return no-links-found error when WebFinger response has no links', async () => {
+        const mockWebFingerResponse = {
+            links: null,
+        };
 
         (
             lookupWebFinger as unknown as ReturnType<typeof vi.fn>
@@ -247,18 +184,16 @@ describe('lookupActorProfile', () => {
             'user@example.com',
         );
 
-        expect(result).toEqual({ profileUrl: null, apId: null });
-        expect(mockCtx.data.logger.info).toHaveBeenCalledWith(
-            'No links found in WebFinger response for handle user@example.com',
-        );
+        expect(result).toEqual(error('no-links-found'));
     });
 
-    it('should return null for both links when no profile page or self link is found', async () => {
+    it('should return no-self-link error when WebFinger response has no self link', async () => {
         const mockWebFingerResponse = {
             links: [
                 {
                     rel: 'other',
-                    href: 'https://example.com/other',
+                    type: 'application/activity+json',
+                    href: 'https://example.com/actor',
                 },
             ],
         };
@@ -272,13 +207,10 @@ describe('lookupActorProfile', () => {
             'user@example.com',
         );
 
-        expect(result).toEqual({ profileUrl: null, apId: null });
-        expect(mockCtx.data.logger.info).toHaveBeenCalledWith(
-            'No valid ActivityPub links found in WebFinger response for handle user@example.com',
-        );
+        expect(result).toEqual(error('no-self-link'));
     });
 
-    it('should return null for both links when WebFinger lookup fails', async () => {
+    it('should return lookup-error when WebFinger lookup fails', async () => {
         (
             lookupWebFinger as unknown as ReturnType<typeof vi.fn>
         ).mockRejectedValue(new Error('WebFinger lookup failed'));
@@ -288,23 +220,21 @@ describe('lookupActorProfile', () => {
             'user@example.com',
         );
 
-        expect(result).toEqual({ profileUrl: null, apId: null });
-        expect(mockCtx.data.logger.error).toHaveBeenCalledWith(
-            'Error looking up actor profile for handle user@example.com - Error: WebFinger lookup failed',
-        );
+        expect(result).toEqual(error('lookup-error'));
     });
 
-    it('should handle invalid URLs in both profile and self links', async () => {
+    it('should handle WebFinger response with multiple links and return self link', async () => {
         const mockWebFingerResponse = {
             links: [
                 {
-                    rel: 'http://webfinger.net/rel/profile-page',
-                    href: 'not-a-valid-url',
+                    rel: 'other',
+                    type: 'application/activity+json',
+                    href: 'https://example.com/other',
                 },
                 {
                     rel: 'self',
                     type: 'application/activity+json',
-                    href: 'also-not-valid',
+                    href: 'https://example.com/actor',
                 },
             ],
         };
@@ -318,42 +248,6 @@ describe('lookupActorProfile', () => {
             'user@example.com',
         );
 
-        expect(result).toEqual({ profileUrl: null, apId: null });
-        expect(mockCtx.data.logger.info).toHaveBeenCalledWith(
-            'Invalid profile page URL for handle user@example.com',
-        );
-        expect(mockCtx.data.logger.info).toHaveBeenCalledWith(
-            'Invalid self link URL for handle user@example.com',
-        );
-    });
-
-    it('should handle valid profile link but invalid self link', async () => {
-        const mockWebFingerResponse = {
-            links: [
-                {
-                    rel: 'http://webfinger.net/rel/profile-page',
-                    href: 'https://example.com/profile',
-                },
-                {
-                    rel: 'self',
-                    type: 'application/activity+json',
-                    href: 'not-a-valid-url',
-                },
-            ],
-        };
-
-        (
-            lookupWebFinger as unknown as ReturnType<typeof vi.fn>
-        ).mockResolvedValue(mockWebFingerResponse);
-
-        const result = await lookupActorProfile(
-            mockCtx as unknown as Context<ContextData>,
-            'user@example.com',
-        );
-
-        expect(result).toEqual({
-            profileUrl: new URL('https://example.com/profile'),
-            apId: null,
-        });
+        expect(result).toEqual(ok(new URL('https://example.com/actor')));
     });
 });

--- a/src/post/content.ts
+++ b/src/post/content.ts
@@ -1,6 +1,6 @@
-import { isHandle } from 'helpers/activitypub/actor';
 import { htmlToText } from 'html-to-text';
 import linkifyHtml from 'linkify-html';
+import { HANDLE_REGEX } from '../constants';
 import type { Mention } from './post.entity';
 
 /**
@@ -144,7 +144,10 @@ export class ContentPreparer {
     private addMentions(content: string, mentions: Mention[]) {
         let preparedContent = content;
         for (const mention of mentions) {
-            const mentionRegex = new RegExp(mention.name, 'g');
+            const mentionRegex = new RegExp(
+                mention.name.replace(/\./g, '\\.'), // Escape the dot (.) character
+                'g',
+            );
             preparedContent = preparedContent.replace(
                 mentionRegex,
                 `<a href="${mention.href}" rel="nofollow noopener noreferrer">${mention.name}</a>`,
@@ -199,9 +202,9 @@ export class ContentPreparer {
     }
 
     private parseMentions(content: string): Set<string> {
-        const handleRegex = /@[\w.-]+@[\w-]+\.[\w.-]+/g;
-        const mentions = content.match(handleRegex) || [];
-        return new Set(mentions.filter(isHandle));
+        const mentions =
+            content.match(new RegExp(HANDLE_REGEX.source, 'g')) || [];
+        return new Set(mentions);
     }
 
     /**

--- a/src/post/content.ts
+++ b/src/post/content.ts
@@ -1,5 +1,7 @@
+import { isHandle } from 'helpers/activitypub/actor';
 import { htmlToText } from 'html-to-text';
 import linkifyHtml from 'linkify-html';
+import type { Mention } from './post.entity';
 
 /**
  * Marker to indicate that the proceeding content is member content
@@ -44,6 +46,10 @@ interface PrepareContentOptions {
         | {
               url: URL;
           };
+    /**
+     * Whether to add mentions to the content
+     */
+    addMentions: false | Mention[];
 }
 
 export class ContentPreparer {
@@ -58,6 +64,7 @@ export class ContentPreparer {
             wrapInParagraph: false,
             extractLinks: false,
             addPaidContentMessage: false,
+            addMentions: false,
         },
     ) {
         return ContentPreparer.instance.prepare(content, options);
@@ -65,6 +72,10 @@ export class ContentPreparer {
 
     static regenerateExcerpt(html: string, charLimit = 500) {
         return ContentPreparer.instance.regenerateExcerpt(html, charLimit);
+    }
+
+    static parseMentions(content: string) {
+        return ContentPreparer.instance.parseMentions(content);
     }
 
     /**
@@ -82,6 +93,7 @@ export class ContentPreparer {
             wrapInParagraph: false,
             extractLinks: false,
             addPaidContentMessage: false,
+            addMentions: false,
         },
     ) {
         let prepared = content;
@@ -113,6 +125,10 @@ export class ContentPreparer {
             );
         }
 
+        if (options.addMentions !== false && options.addMentions.length > 0) {
+            prepared = this.addMentions(prepared, options.addMentions);
+        }
+
         return prepared;
     }
 
@@ -123,6 +139,18 @@ export class ContentPreparer {
      */
     private addPaidContentMessage(content: string, url: URL) {
         return content + PAID_CONTENT_PREVIEW_HTML(url);
+    }
+
+    private addMentions(content: string, mentions: Mention[]) {
+        let preparedContent = content;
+        for (const mention of mentions) {
+            const mentionRegex = new RegExp(mention.name, 'g');
+            preparedContent = preparedContent.replace(
+                mentionRegex,
+                `<a href="${mention.href}" rel="nofollow noopener noreferrer">${mention.name}</a>`,
+            );
+        }
+        return preparedContent;
     }
 
     /**
@@ -168,6 +196,12 @@ export class ContentPreparer {
         }
 
         return `${text.substring(0, charLimit - 3)}...`;
+    }
+
+    private parseMentions(content: string): Set<string> {
+        const handleRegex = /@[\w.-]+@[\w-]+\.[\w.-]+/g;
+        const mentions = content.match(handleRegex) || [];
+        return new Set(mentions.filter(isHandle));
     }
 
     /**

--- a/src/post/content.unit.test.ts
+++ b/src/post/content.unit.test.ts
@@ -240,6 +240,24 @@ describe('ContentPreparer', () => {
                 );
             });
 
+            it('should reject partially matching mentions', () => {
+                const content = 'Hello @user@example.xyz and @user@exampleXxyz';
+                const result = preparer.prepare(content, {
+                    ...allOptionsDisabled,
+                    addMentions: [
+                        {
+                            name: '@user@example.xyz',
+                            href: new URL('https://example.xyz/@user'),
+                            account: account,
+                        },
+                    ],
+                });
+
+                expect(result).toEqual(
+                    'Hello <a href="https://example.xyz/@user" rel="nofollow noopener noreferrer">@user@example.xyz</a> and @user@exampleXxyz',
+                );
+            });
+
             it('should not modify content when no mentions are provided', () => {
                 const content = 'Hello @user@example.xyz, how are you?';
                 const result = preparer.prepare(content, {

--- a/src/post/content.unit.test.ts
+++ b/src/post/content.unit.test.ts
@@ -1,3 +1,4 @@
+import { AccountEntity } from 'account/account.entity';
 import { describe, expect, it } from 'vitest';
 import {
     ContentPreparer,
@@ -164,6 +165,20 @@ describe('ContentPreparer', () => {
         });
 
         describe('Adding mentions', () => {
+            const account = AccountEntity.create({
+                id: 1,
+                uuid: 'test-uuid',
+                username: 'user',
+                name: 'Test User',
+                bio: null,
+                url: new URL('https://example.xyz/@user'),
+                avatarUrl: null,
+                bannerImageUrl: null,
+                apId: new URL('https://example.xyz/@user'),
+                apFollowers: null,
+                apInbox: null,
+                isInternal: false,
+            });
             it('should convert mentions to hyperlinks', () => {
                 const content = 'Hello @user@example.xyz, how are you?';
                 const result = preparer.prepare(content, {
@@ -172,6 +187,7 @@ describe('ContentPreparer', () => {
                         {
                             name: '@user@example.xyz',
                             href: new URL('https://example.xyz/@user'),
+                            account: account,
                         },
                     ],
                 });
@@ -190,10 +206,12 @@ describe('ContentPreparer', () => {
                         {
                             name: '@user@example.xyz',
                             href: new URL('https://example.xyz/@user'),
+                            account: account,
                         },
                         {
                             name: '@newUser@example.co.uk',
                             href: new URL('https://example.co.uk/@newUser'),
+                            account: account,
                         },
                     ],
                 });
@@ -212,6 +230,7 @@ describe('ContentPreparer', () => {
                         {
                             name: '@user@example.xyz',
                             href: new URL('https://example.xyz/@user'),
+                            account: account,
                         },
                     ],
                 });

--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -49,6 +49,11 @@ export interface PostAttachment {
     url: URL;
 }
 
+export interface Mention {
+    name: string;
+    href: URL;
+}
+
 export interface PostData {
     type: CreatePostType;
     audience?: Audience;
@@ -251,6 +256,7 @@ export class Post extends BaseEntity {
                 wrapInParagraph: false,
                 extractLinks: false,
                 addPaidContentMessage: false,
+                addMentions: false,
             });
 
             if (content === '') {
@@ -274,6 +280,7 @@ export class Post extends BaseEntity {
                 addPaidContentMessage: {
                     url: new URL(ghostPost.url),
                 },
+                addMentions: false,
             });
         }
 
@@ -348,6 +355,7 @@ export class Post extends BaseEntity {
             wrapInParagraph: true,
             extractLinks: true,
             addPaidContentMessage: false,
+            addMentions: false,
         });
 
         const postAttachment = imageUrl
@@ -409,6 +417,7 @@ export class Post extends BaseEntity {
             wrapInParagraph: true,
             extractLinks: true,
             addPaidContentMessage: false,
+            addMentions: false,
         });
 
         const postAttachment = imageUrl

--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -52,6 +52,7 @@ export interface PostAttachment {
 export interface Mention {
     name: string;
     href: URL;
+    account: Account;
 }
 
 export interface PostData {
@@ -343,6 +344,7 @@ export class Post extends BaseEntity {
         account: Account,
         noteContent: string,
         imageUrl?: URL,
+        mentions: Mention[] = [],
     ): Post {
         if (!account.isInternal) {
             throw new Error('createNote is for use with internal accounts');
@@ -355,7 +357,7 @@ export class Post extends BaseEntity {
             wrapInParagraph: true,
             extractLinks: true,
             addPaidContentMessage: false,
-            addMentions: false,
+            addMentions: mentions,
         });
 
         const postAttachment = imageUrl
@@ -369,7 +371,7 @@ export class Post extends BaseEntity {
               ]
             : [];
 
-        return new Post(
+        const post = new Post(
             null,
             null,
             account,
@@ -391,6 +393,14 @@ export class Post extends BaseEntity {
             postAttachment,
             null,
         );
+
+        for (const mention of mentions) {
+            if (mention.account) {
+                post.addMention(mention.account);
+            }
+        }
+
+        return post;
     }
 
     static createReply(
@@ -398,6 +408,7 @@ export class Post extends BaseEntity {
         replyContent: string,
         inReplyTo: Post,
         imageUrl?: URL,
+        mentions: Mention[] = [],
     ): Post {
         if (!account.isInternal) {
             throw new Error('createReply is for use with internal accounts');
@@ -417,7 +428,7 @@ export class Post extends BaseEntity {
             wrapInParagraph: true,
             extractLinks: true,
             addPaidContentMessage: false,
-            addMentions: false,
+            addMentions: mentions,
         });
 
         const postAttachment = imageUrl
@@ -431,7 +442,7 @@ export class Post extends BaseEntity {
               ]
             : [];
 
-        return new Post(
+        const post = new Post(
             null,
             null,
             account,
@@ -453,5 +464,13 @@ export class Post extends BaseEntity {
             postAttachment,
             null,
         );
+
+        for (const mention of mentions) {
+            if (mention.account) {
+                post.addMention(mention.account);
+            }
+        }
+
+        return post;
     }
 }

--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -229,9 +229,6 @@ export class Post extends BaseEntity {
     }
 
     addMention(account: Account) {
-        if (!account.id) {
-            throw new Error('Cannot add mention for account with no id');
-        }
         this.mentionsToAdd.add(account.id);
     }
 

--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -86,6 +86,7 @@ export class Post extends BaseEntity {
     public readonly url: URL;
     private likesToRemove: Set<number> = new Set();
     private likesToAdd: Set<number> = new Set();
+    private mentionsToAdd: Set<number> = new Set();
     private repostsToAdd: Set<number> = new Set();
     private repostsToRemove: Set<number> = new Set();
     private deleted = false;
@@ -219,6 +220,19 @@ export class Post extends BaseEntity {
             repostsToRemove,
             repostsToAdd,
         };
+    }
+
+    addMention(account: Account) {
+        if (!account.id) {
+            throw new Error('Cannot add mention for account with no id');
+        }
+        this.mentionsToAdd.add(account.id);
+    }
+
+    getMentions() {
+        const mentionsToAdd = [...this.mentionsToAdd.values()];
+        this.mentionsToAdd.clear();
+        return mentionsToAdd;
     }
 
     static createArticleFromGhostPost(

--- a/src/post/post.entity.unit.test.ts
+++ b/src/post/post.entity.unit.test.ts
@@ -215,9 +215,7 @@ describe('Post', () => {
         it('creates a reply with mentions', () => {
             const account = internalAccount();
             const inReplyTo = Post.createNote(account, 'Parent');
-            // TODO: Clean up the any type
-            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
-            (inReplyTo as any).id = 'fake-id';
+            (inReplyTo as unknown as { id: string }).id = 'fake-id';
             const content = 'My reply to @test@example.com';
             const mentionedAccount = externalAccount(789);
             const mentions = [
@@ -246,9 +244,7 @@ describe('Post', () => {
         it('creates a reply with multiple mentions', () => {
             const account = internalAccount();
             const inReplyTo = Post.createNote(account, 'Parent');
-            // TODO: Clean up the any type
-            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
-            (inReplyTo as any).id = 'fake-id';
+            (inReplyTo as unknown as { id: string }).id = 'fake-id';
             const content =
                 'My reply to @test@example.com and @test2@example.com';
             const mentionedAccount1 = externalAccount(789);

--- a/src/post/post.entity.unit.test.ts
+++ b/src/post/post.entity.unit.test.ts
@@ -508,6 +508,31 @@ describe('Post', () => {
         });
     });
 
+    it('should handle adding mentions', () => {
+        const postAuthorAccount = internalAccount(456);
+        const mentionedAccount1 = externalAccount(789);
+        const mentionedAccount2 = externalAccount(987);
+        const mentionedAccount3 = externalAccount(654);
+
+        const post = Post.createFromData(postAuthorAccount, {
+            type: PostType.Note,
+            content: 'Hello, world!',
+        });
+
+        post.addMention(mentionedAccount1);
+        post.addMention(mentionedAccount2);
+        post.addMention(mentionedAccount3);
+
+        expect(post.getMentions()).toEqual([
+            mentionedAccount1.id,
+            mentionedAccount2.id,
+            mentionedAccount3.id,
+        ]);
+
+        // Verify mentions are cleared after getting them
+        expect(post.getMentions()).toEqual([]);
+    });
+
     it('should save ghost authors in posts metadata', () => {
         const account = internalAccount();
         const ghostPost = {

--- a/src/post/post.entity.unit.test.ts
+++ b/src/post/post.entity.unit.test.ts
@@ -212,6 +212,78 @@ describe('Post', () => {
             expect(note.content).toBe('<p>My first note</p>');
         });
 
+        it('creates a reply with mentions', () => {
+            const account = internalAccount();
+            const inReplyTo = Post.createNote(account, 'Parent');
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
+            (inReplyTo as any).id = 'fake-id';
+            const content = 'My reply to @test@example.com';
+            const mentionedAccount = externalAccount(789);
+            const mentions = [
+                {
+                    name: '@test@example.com',
+                    href: new URL('https://example.com/@test'),
+                    account: mentionedAccount,
+                },
+            ];
+
+            const note = Post.createReply(
+                account,
+                content,
+                inReplyTo,
+                undefined,
+                mentions,
+            );
+
+            expect(note.type).toBe(PostType.Note);
+            expect(note.content).toBe(
+                '<p>My reply to <a href="https://example.com/@test" rel="nofollow noopener noreferrer">@test@example.com</a></p>',
+            );
+            expect(note.getMentions()).toEqual([mentionedAccount.id]);
+        });
+
+        it('creates a reply with multiple mentions', () => {
+            const account = internalAccount();
+            const inReplyTo = Post.createNote(account, 'Parent');
+            // TODO: Clean up the any type
+            // biome-ignore lint/suspicious/noExplicitAny: Legacy code needs proper typing
+            (inReplyTo as any).id = 'fake-id';
+            const content =
+                'My reply to @test@example.com and @test2@example.com';
+            const mentionedAccount1 = externalAccount(789);
+            const mentionedAccount2 = externalAccount(790);
+            const mentions = [
+                {
+                    name: '@test@example.com',
+                    href: new URL('https://example.com/@test'),
+                    account: mentionedAccount1,
+                },
+                {
+                    name: '@test2@example.com',
+                    href: new URL('https://example.com/@test2'),
+                    account: mentionedAccount2,
+                },
+            ];
+
+            const note = Post.createReply(
+                account,
+                content,
+                inReplyTo,
+                undefined,
+                mentions,
+            );
+
+            expect(note.type).toBe(PostType.Note);
+            expect(note.content).toBe(
+                '<p>My reply to <a href="https://example.com/@test" rel="nofollow noopener noreferrer">@test@example.com</a> and <a href="https://example.com/@test2" rel="nofollow noopener noreferrer">@test2@example.com</a></p>',
+            );
+            expect(note.getMentions()).toEqual([
+                mentionedAccount1.id,
+                mentionedAccount2.id,
+            ]);
+        });
+
         it('creates a note with line breaks', () => {
             const account = internalAccount();
             const inReplyTo = Post.createNote(account, 'Parent');
@@ -317,6 +389,58 @@ describe('Post', () => {
             expect(note.type).toBe(PostType.Note);
 
             expect(note.content).toBe('<p>My first note</p>');
+        });
+
+        it('creates a note with mentions', () => {
+            const account = internalAccount();
+            const content = 'My note with @test@example.com';
+            const mentionedAccount = externalAccount(789);
+            const mentions = [
+                {
+                    name: '@test@example.com',
+                    href: new URL('https://example.com/@test'),
+                    account: mentionedAccount,
+                },
+            ];
+
+            const note = Post.createNote(account, content, undefined, mentions);
+
+            expect(note.type).toBe(PostType.Note);
+            expect(note.content).toBe(
+                '<p>My note with <a href="https://example.com/@test" rel="nofollow noopener noreferrer">@test@example.com</a></p>',
+            );
+            expect(note.getMentions()).toEqual([mentionedAccount.id]);
+        });
+
+        it('creates a note with multiple mentions', () => {
+            const account = internalAccount();
+            const content =
+                'My note with @test@example.com and @test2@example.com';
+            const mentionedAccount1 = externalAccount(789);
+            const mentionedAccount2 = externalAccount(790);
+            const mentions = [
+                {
+                    name: '@test@example.com',
+                    href: new URL('https://example.com/@test'),
+                    account: mentionedAccount1,
+                },
+                {
+                    name: '@test2@example.com',
+                    href: new URL('https://example.com/@test2'),
+                    account: mentionedAccount2,
+                },
+            ];
+
+            const note = Post.createNote(account, content, undefined, mentions);
+
+            expect(note.type).toBe(PostType.Note);
+            expect(note.content).toBe(
+                '<p>My note with <a href="https://example.com/@test" rel="nofollow noopener noreferrer">@test@example.com</a> and <a href="https://example.com/@test2" rel="nofollow noopener noreferrer">@test2@example.com</a></p>',
+            );
+            expect(note.getMentions()).toEqual([
+                mentionedAccount1.id,
+                mentionedAccount2.id,
+            ]);
         });
 
         it('creates a note with an image URL', () => {

--- a/src/post/post.service.integration.test.ts
+++ b/src/post/post.service.integration.test.ts
@@ -61,23 +61,17 @@ describe('PostService', () => {
 
         // Mock the lookup functions
         vi.mock('lookup-helpers', () => ({
-            lookupAPIdByHandle: vi
-                .fn()
-                .mockImplementation(async (ctx, handle) => {
-                    // Extract username and domain from handle
-                    const match = handle.match(/@?([^@]+)@(.+)/);
-                    if (!match) return null;
-                    const [, username, domain] = match;
-                    return `https://${domain}/${username}`;
-                }),
             lookupActorProfile: vi
                 .fn()
                 .mockImplementation(async (ctx, handle) => {
                     // Extract username and domain from handle
                     const match = handle.match(/@?([^@]+)@(.+)/);
-                    if (!match) return null;
+                    if (!match) return { profileUrl: null, apId: null };
                     const [, username, domain] = match;
-                    return new URL(`https://${domain}/${username}`);
+                    return {
+                        profileUrl: new URL(`https://${domain}/${username}`),
+                        apId: new URL(`https://${domain}/${username}`),
+                    };
                 }),
         }));
 

--- a/src/post/post.service.integration.test.ts
+++ b/src/post/post.service.integration.test.ts
@@ -6,6 +6,7 @@ import { AsyncEvents } from 'core/events';
 import {
     type Error as Err,
     error as createError,
+    error,
     getError,
     getValue,
     isError,
@@ -66,12 +67,9 @@ describe('PostService', () => {
                 .mockImplementation(async (ctx, handle) => {
                     // Extract username and domain from handle
                     const match = handle.match(/@?([^@]+)@(.+)/);
-                    if (!match) return { profileUrl: null, apId: null };
+                    if (!match) return error('lookup-error');
                     const [, username, domain] = match;
-                    return {
-                        profileUrl: new URL(`https://${domain}/${username}`),
-                        apId: new URL(`https://${domain}/${username}`),
-                    };
+                    return ok(new URL(`https://${domain}/${username}`));
                 }),
         }));
 

--- a/src/post/post.service.integration.test.ts
+++ b/src/post/post.service.integration.test.ts
@@ -1,7 +1,7 @@
 import type { Account } from 'account/account.entity';
 import { KnexAccountRepository } from 'account/account.repository.knex';
 import { AccountService } from 'account/account.service';
-import { FedifyContextFactory } from 'activitypub/fedify-context.factory';
+import type { FedifyContextFactory } from 'activitypub/fedify-context.factory';
 import { AsyncEvents } from 'core/events';
 import {
     type Error as Err,
@@ -16,7 +16,7 @@ import { ModerationService } from 'moderation/moderation.service';
 import type { GCPStorageService } from 'storage/gcloud-storage/gcp-storage.service';
 import { createTestDb } from 'test/db';
 import { type FixtureManager, createFixtureManager } from 'test/fixtures';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Post, PostType } from './post.entity';
 import { KnexPostRepository } from './post.repository.knex';
 import { PostService } from './post.service';
@@ -26,7 +26,7 @@ describe('PostService', () => {
     let postRepository: KnexPostRepository;
     let accountRepository: KnexAccountRepository;
     let fixtureManager: FixtureManager;
-    let fedifyContextFactory: FedifyContextFactory;
+    let mockFedifyContextFactory: FedifyContextFactory;
     let storageService: GCPStorageService;
     let moderationService: ModerationService;
     let postService: PostService;
@@ -40,7 +40,46 @@ describe('PostService', () => {
         postRepository = new KnexPostRepository(db, events);
         accountRepository = new KnexAccountRepository(db, events);
         fixtureManager = createFixtureManager(db, events);
-        fedifyContextFactory = new FedifyContextFactory();
+        mockFedifyContextFactory = {
+            getFedifyContext: () => ({
+                getDocumentLoader: async () => ({}),
+                data: {
+                    logger: {
+                        info: vi.fn(),
+                        error: vi.fn(),
+                        warn: vi.fn(),
+                    },
+                },
+                lookupObject: vi.fn(),
+            }),
+            asyncLocalStorage: {
+                getStore: vi.fn(),
+                run: vi.fn(),
+            },
+            registerContext: vi.fn(),
+        } as unknown as FedifyContextFactory;
+
+        // Mock the lookup functions
+        vi.mock('lookup-helpers', () => ({
+            lookupAPIdByHandle: vi
+                .fn()
+                .mockImplementation(async (ctx, handle) => {
+                    // Extract username and domain from handle
+                    const match = handle.match(/@?([^@]+)@(.+)/);
+                    if (!match) return null;
+                    const [, username, domain] = match;
+                    return `https://${domain}/${username}`;
+                }),
+            lookupActorProfile: vi
+                .fn()
+                .mockImplementation(async (ctx, handle) => {
+                    // Extract username and domain from handle
+                    const match = handle.match(/@?([^@]+)@(.+)/);
+                    if (!match) return null;
+                    const [, username, domain] = match;
+                    return new URL(`https://${domain}/${username}`);
+                }),
+        }));
 
         storageService = {
             verifyImageUrl: vi.fn().mockResolvedValue(ok(true)),
@@ -52,13 +91,13 @@ describe('PostService', () => {
             db,
             events,
             accountRepository,
-            fedifyContextFactory,
+            mockFedifyContextFactory,
         );
 
         postService = new PostService(
             postRepository,
             accountService,
-            fedifyContextFactory,
+            mockFedifyContextFactory,
             storageService,
             moderationService,
         );
@@ -68,6 +107,11 @@ describe('PostService', () => {
 
         // Create a test account
         [account] = await fixtureManager.createInternalAccount();
+    });
+
+    afterEach(async () => {
+        // Clean up database connections
+        await db.destroy();
     });
 
     describe('createNote', () => {
@@ -129,7 +173,7 @@ describe('PostService', () => {
             const serviceWithFailingStorage = new PostService(
                 postRepository,
                 accountService,
-                fedifyContextFactory,
+                mockFedifyContextFactory,
                 failingStorageService,
                 moderationService,
             );
@@ -145,6 +189,46 @@ describe('PostService', () => {
 
             expect(isError(result)).toBe(true);
             expect(getError(result as Err<string>)).toBe('invalid-url');
+        });
+
+        it('should store mentions in database and format them in content', async () => {
+            // Create an external account to mention
+            const mentionedAccount =
+                await fixtureManager.createExternalAccount();
+
+            const content = `This is a test note mentioning @${mentionedAccount.username}@${mentionedAccount.apId.hostname}`;
+
+            const result = await postService.createNote(account, content);
+
+            if (isError(result)) {
+                throw new Error('Result should not be an error');
+            }
+
+            const post = getValue(result);
+            expect(post).toBeInstanceOf(Post);
+            expect(post.author.id).toBe(account.id);
+            expect(post.type).toBe(PostType.Note);
+
+            // Verify mention is wrapped in hyperlink in content
+            expect(post.content).toBe(
+                `<p>This is a test note mentioning <a href="${mentionedAccount.apId}" rel="nofollow noopener noreferrer">@${mentionedAccount.username}@${mentionedAccount.apId.hostname}</a></p>`,
+            );
+
+            // Verify the post was saved to database
+            const savedPost = await postRepository.getById(post.id!);
+            expect(savedPost).not.toBeNull();
+            expect(savedPost!.id).toBe(post.id);
+
+            // Verify mention is stored in database
+            const mentionInDb = await db('mentions')
+                .where({
+                    post_id: post.id,
+                    account_id: mentionedAccount.id,
+                })
+                .first();
+            expect(mentionInDb).not.toBeNull();
+            expect(mentionInDb.post_id).toBe(post.id);
+            expect(mentionInDb.account_id).toBe(mentionedAccount.id);
         });
     });
 
@@ -210,27 +294,7 @@ describe('PostService', () => {
             );
             const replyContent = 'This reply will fail';
 
-            // Mock the fedify context to simulate upstream error
-            const mockFedifyContextFactory = {
-                getFedifyContext: () => ({
-                    getDocumentLoader: async () => ({}),
-                }),
-                asyncLocalStorage: {
-                    getStore: vi.fn(),
-                    run: vi.fn(),
-                },
-                registerContext: vi.fn(),
-            } as unknown as FedifyContextFactory;
-
-            const serviceWithMockContext = new PostService(
-                postRepository,
-                accountService,
-                mockFedifyContextFactory,
-                storageService,
-                moderationService,
-            );
-
-            const result = await serviceWithMockContext.createReply(
+            const result = await postService.createReply(
                 account,
                 replyContent,
                 nonExistentPostUrl,
@@ -265,6 +329,55 @@ describe('PostService', () => {
             }
 
             expect(getError(result)).toBe('cannot-interact');
+        });
+
+        it('should store mentions in database and format them in content', async () => {
+            // Create an original post to reply to
+            const originalPost = await fixtureManager.createPost(account);
+
+            // Create an external account to mention
+            const mentionedAccount =
+                await fixtureManager.createExternalAccount();
+
+            const replyContent = `This is a reply mentioning @${mentionedAccount.username}@${mentionedAccount.apId.hostname}`;
+
+            const result = await postService.createReply(
+                account,
+                replyContent,
+                originalPost.apId,
+            );
+
+            if (isError(result)) {
+                throw new Error('Result should not be an error');
+            }
+
+            const reply = getValue(result);
+            expect(reply).toBeInstanceOf(Post);
+            expect(reply.author.id).toBe(account.id);
+            expect(reply.type).toBe(PostType.Note);
+            expect(reply.inReplyTo).toBe(originalPost.id);
+
+            // Verify mention is wrapped in hyperlink in content
+            expect(reply.content).toBe(
+                `<p>This is a reply mentioning <a href="${mentionedAccount.apId}" rel="nofollow noopener noreferrer">@${mentionedAccount.username}@${mentionedAccount.apId.hostname}</a></p>`,
+            );
+
+            // Verify the reply was saved to database
+            const savedReply = await postRepository.getById(reply.id!);
+            expect(savedReply).not.toBeNull();
+            expect(savedReply!.id).toBe(reply.id);
+            expect(savedReply!.inReplyTo).toBe(originalPost.id);
+
+            // Verify mention is stored in database
+            const mentionInDb = await db('mentions')
+                .where({
+                    post_id: reply.id,
+                    account_id: mentionedAccount.id,
+                })
+                .first();
+            expect(mentionInDb).not.toBeNull();
+            expect(mentionInDb.post_id).toBe(reply.id);
+            expect(mentionInDb.account_id).toBe(mentionedAccount.id);
         });
     });
 
@@ -370,27 +483,7 @@ describe('PostService', () => {
                 'https://example.com/posts/nonexistent',
             );
 
-            // Mock the fedify context to simulate upstream error
-            const mockFedifyContextFactory = {
-                getFedifyContext: () => ({
-                    getDocumentLoader: async () => ({}),
-                }),
-                asyncLocalStorage: {
-                    getStore: vi.fn(),
-                    run: vi.fn(),
-                },
-                registerContext: vi.fn(),
-            } as unknown as FedifyContextFactory;
-
-            const serviceWithMockContext = new PostService(
-                postRepository,
-                accountService,
-                mockFedifyContextFactory,
-                storageService,
-                moderationService,
-            );
-
-            const result = await serviceWithMockContext.repostByApId(
+            const result = await postService.repostByApId(
                 account,
                 nonExistentPostUrl,
             );

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -192,12 +192,18 @@ export class PostService {
             let account: Account | null = null;
             const lookupResult = await lookupActorProfile(ctx, mention);
             if (!lookupResult.apId) {
+                ctx.data.logger.info(
+                    `Failed to lookup apId for mention: ${mention}`,
+                );
                 continue;
             }
             const accountResult = await this.accountService.ensureByApId(
                 lookupResult.apId,
             );
             if (isError(accountResult)) {
+                ctx.data.logger.info(
+                    `Failed to lookup account for mention: ${mention}, error: ${getError(accountResult)}`,
+                );
                 continue;
             }
             account = getValue(accountResult);

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -191,14 +191,15 @@ export class PostService {
         for (const mention of mentions) {
             let account: Account | null = null;
             const lookupResult = await lookupActorProfile(ctx, mention);
-            if (!lookupResult.apId) {
+            if (isError(lookupResult)) {
                 ctx.data.logger.info(
-                    `Failed to lookup apId for mention: ${mention}`,
+                    `Failed to lookup apId for mention: ${mention}, error: ${getError(lookupResult)}`,
                 );
                 continue;
             }
+
             const accountResult = await this.accountService.ensureByApId(
-                lookupResult.apId,
+                getValue(lookupResult),
             );
             if (isError(accountResult)) {
                 ctx.data.logger.info(
@@ -208,13 +209,9 @@ export class PostService {
             }
             account = getValue(accountResult);
 
-            const profileUrl = lookupResult.profileUrl
-                ? lookupResult.profileUrl
-                : lookupResult.apId;
-
             processedMentions.push({
                 name: mention,
-                href: profileUrl,
+                href: account.url,
                 account: account,
             });
         }


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PROD-1736

- Parse mentions from the Note/Reply content
- If mentions are present, wrap it into hyperlinks and add to the db
- Send a account mentioned event when post is saved with mentions