### PR TITLE
Added a `data-profile` attribute with the social web handle for mentions

### DIFF
--- a/src/helpers/html.ts
+++ b/src/helpers/html.ts
@@ -100,7 +100,15 @@ export function sanitizeHtml(content: string): string {
             '*': ['id', 'class', 'title', 'lang', 'dir', 'tabindex', 'style'],
 
             // Specific HTML elements
-            a: ['href', 'target', 'rel', 'download', 'hreflang', 'type'],
+            a: [
+                'href',
+                'target',
+                'rel',
+                'download',
+                'hreflang',
+                'type',
+                'data-profile',
+            ],
             img: [
                 'src',
                 'srcset',

--- a/src/helpers/html.unit.test.ts
+++ b/src/helpers/html.unit.test.ts
@@ -121,7 +121,15 @@ describe('sanitizeHtml', () => {
                 ],
 
                 // Specific HTML elements
-                a: ['href', 'target', 'rel', 'download', 'hreflang', 'type'],
+                a: [
+                    'href',
+                    'target',
+                    'rel',
+                    'download',
+                    'hreflang',
+                    'type',
+                    'data-profile',
+                ],
                 img: [
                     'src',
                     'srcset',

--- a/src/post/content.ts
+++ b/src/post/content.ts
@@ -150,7 +150,7 @@ export class ContentPreparer {
             );
             preparedContent = preparedContent.replace(
                 mentionRegex,
-                `<a href="${mention.href}" rel="nofollow noopener noreferrer">${mention.name}</a>`,
+                `<a href="${mention.href}" data-profile="${mention.name}" rel="nofollow noopener noreferrer">${mention.name}</a>`,
             );
         }
         return preparedContent;

--- a/src/post/content.unit.test.ts
+++ b/src/post/content.unit.test.ts
@@ -193,7 +193,7 @@ describe('ContentPreparer', () => {
                 });
 
                 expect(result).toEqual(
-                    'Hello <a href="https://example.xyz/@user" rel="nofollow noopener noreferrer">@user@example.xyz</a>, how are you?',
+                    'Hello <a href="https://example.xyz/@user" data-profile="@user@example.xyz" rel="nofollow noopener noreferrer">@user@example.xyz</a>, how are you?',
                 );
             });
 
@@ -217,7 +217,7 @@ describe('ContentPreparer', () => {
                 });
 
                 expect(result).toEqual(
-                    'Hello <a href="https://example.xyz/@user" rel="nofollow noopener noreferrer">@user@example.xyz</a> and <a href="https://example.co.uk/@newUser" rel="nofollow noopener noreferrer">@newUser@example.co.uk</a>!',
+                    'Hello <a href="https://example.xyz/@user" data-profile="@user@example.xyz" rel="nofollow noopener noreferrer">@user@example.xyz</a> and <a href="https://example.co.uk/@newUser" data-profile="@newUser@example.co.uk" rel="nofollow noopener noreferrer">@newUser@example.co.uk</a>!',
                 );
             });
 
@@ -236,7 +236,7 @@ describe('ContentPreparer', () => {
                 });
 
                 expect(result).toEqual(
-                    'Hello <a href="https://example.xyz/@user" rel="nofollow noopener noreferrer">@user@example.xyz</a>, <a href="https://example.xyz/@user" rel="nofollow noopener noreferrer">@user@example.xyz</a>, and <a href="https://example.xyz/@user" rel="nofollow noopener noreferrer">@user@example.xyz</a>!',
+                    'Hello <a href="https://example.xyz/@user" data-profile="@user@example.xyz" rel="nofollow noopener noreferrer">@user@example.xyz</a>, <a href="https://example.xyz/@user" data-profile="@user@example.xyz" rel="nofollow noopener noreferrer">@user@example.xyz</a>, and <a href="https://example.xyz/@user" data-profile="@user@example.xyz" rel="nofollow noopener noreferrer">@user@example.xyz</a>!',
                 );
             });
 
@@ -254,7 +254,7 @@ describe('ContentPreparer', () => {
                 });
 
                 expect(result).toEqual(
-                    'Hello <a href="https://example.xyz/@user" rel="nofollow noopener noreferrer">@user@example.xyz</a> and @user@exampleXxyz',
+                    'Hello <a href="https://example.xyz/@user" data-profile="@user@example.xyz" rel="nofollow noopener noreferrer">@user@example.xyz</a> and @user@exampleXxyz',
                 );
             });
 

--- a/src/post/post.entity.unit.test.ts
+++ b/src/post/post.entity.unit.test.ts
@@ -236,7 +236,7 @@ describe('Post', () => {
 
             expect(note.type).toBe(PostType.Note);
             expect(note.content).toBe(
-                '<p>My reply to <a href="https://example.com/@test" rel="nofollow noopener noreferrer">@test@example.com</a></p>',
+                '<p>My reply to <a href="https://example.com/@test" data-profile="@test@example.com" rel="nofollow noopener noreferrer">@test@example.com</a></p>',
             );
             expect(note.mentions).toEqual([mentionedAccount]);
         });
@@ -272,7 +272,7 @@ describe('Post', () => {
 
             expect(note.type).toBe(PostType.Note);
             expect(note.content).toBe(
-                '<p>My reply to <a href="https://example.com/@test" rel="nofollow noopener noreferrer">@test@example.com</a> and <a href="https://example.com/@test2" rel="nofollow noopener noreferrer">@test2@example.com</a></p>',
+                '<p>My reply to <a href="https://example.com/@test" data-profile="@test@example.com" rel="nofollow noopener noreferrer">@test@example.com</a> and <a href="https://example.com/@test2" data-profile="@test2@example.com" rel="nofollow noopener noreferrer">@test2@example.com</a></p>',
             );
             expect(note.mentions).toEqual([
                 mentionedAccount1,
@@ -403,7 +403,7 @@ describe('Post', () => {
 
             expect(note.type).toBe(PostType.Note);
             expect(note.content).toBe(
-                '<p>My note with <a href="https://example.com/@test" rel="nofollow noopener noreferrer">@test@example.com</a></p>',
+                '<p>My note with <a href="https://example.com/@test" data-profile="@test@example.com" rel="nofollow noopener noreferrer">@test@example.com</a></p>',
             );
             expect(note.mentions).toEqual([mentionedAccount]);
         });
@@ -431,7 +431,7 @@ describe('Post', () => {
 
             expect(note.type).toBe(PostType.Note);
             expect(note.content).toBe(
-                '<p>My note with <a href="https://example.com/@test" rel="nofollow noopener noreferrer">@test@example.com</a> and <a href="https://example.com/@test2" rel="nofollow noopener noreferrer">@test2@example.com</a></p>',
+                '<p>My note with <a href="https://example.com/@test" data-profile="@test@example.com" rel="nofollow noopener noreferrer">@test@example.com</a> and <a href="https://example.com/@test2" data-profile="@test2@example.com" rel="nofollow noopener noreferrer">@test2@example.com</a></p>',
             );
             expect(note.mentions).toEqual([
                 mentionedAccount1,

--- a/src/post/post.service.integration.test.ts
+++ b/src/post/post.service.integration.test.ts
@@ -203,7 +203,7 @@ describe('PostService', () => {
 
             // Verify mention is wrapped in hyperlink in content
             expect(post.content).toBe(
-                `<p>This is a test note mentioning <a href="${mentionedAccount.apId}" rel="nofollow noopener noreferrer">@${mentionedAccount.username}@${mentionedAccount.apId.hostname}</a></p>`,
+                `<p>This is a test note mentioning <a href="${mentionedAccount.apId}" data-profile="@${mentionedAccount.username}@${mentionedAccount.apId.hostname}" rel="nofollow noopener noreferrer">@${mentionedAccount.username}@${mentionedAccount.apId.hostname}</a></p>`,
             );
 
             // Verify the post was saved to database
@@ -351,7 +351,7 @@ describe('PostService', () => {
 
             // Verify mention is wrapped in hyperlink in content
             expect(reply.content).toBe(
-                `<p>This is a reply mentioning <a href="${mentionedAccount.apId}" rel="nofollow noopener noreferrer">@${mentionedAccount.username}@${mentionedAccount.apId.hostname}</a></p>`,
+                `<p>This is a reply mentioning <a href="${mentionedAccount.apId}" data-profile="@${mentionedAccount.username}@${mentionedAccount.apId.hostname}" rel="nofollow noopener noreferrer">@${mentionedAccount.username}@${mentionedAccount.apId.hostname}</a></p>`,
             );
 
             // Verify the reply was saved to database


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PROD-1785/

- In Feed and Profile views, we want to override mention hyperlinks so that the link opens in the Ghost app. 
- Added a `data-profile` attribute to the hyperlink when generating an outgoing Mention
- Frontend can override the default on-click behaviour using this `data-profile` attribute