### PR TITLE
Added command to remove accumulating .metadata files in fake-gcs server

### DIFF
--- a/fake-gcs/start.sh
+++ b/fake-gcs/start.sh
@@ -7,6 +7,9 @@
 mkdir -p /storage
 chmod 777 /storage
 
+# Clean up any existing metadata files
+find /storage -name "*.metadata*" -type f -delete
+
 # Start the fake-gcs server in the background
 fake-gcs-server -scheme http -port 4443 -external-url http://fake-gcs:4443 -data /storage &
 


### PR DESCRIPTION
No ref

- fake-gcs keeps adding .metadata files in storage directory on each server restart
- Added cleanup command to prevent file accumulation in local storage
- Ensures storage remains clean
- This change only affects the local fake-gcs, no changes in the production set-up