### PR TITLE
Fixed flaky KnexAccountRepository test

### DIFF
--- a/src/account/account.repository.knex.integration.test.ts
+++ b/src/account/account.repository.knex.integration.test.ts
@@ -469,16 +469,19 @@ describe('KnexAccountRepository', () => {
             'following_id',
         );
 
-        expect(followsBeforeUnfollow).toStrictEqual([
-            {
-                follower_id: account.id,
-                following_id: accountToFollow.id,
-            },
-            {
-                follower_id: accountToFollow.id,
-                following_id: accountNotFollowed.id,
-            },
-        ]);
+        expect(followsBeforeUnfollow).toHaveLength(2);
+        expect(followsBeforeUnfollow).toEqual(
+            expect.arrayContaining([
+                {
+                    follower_id: account.id,
+                    following_id: accountToFollow.id,
+                },
+                {
+                    follower_id: accountToFollow.id,
+                    following_id: accountNotFollowed.id,
+                },
+            ]),
+        );
 
         await accountRepository.save(account.unfollow(accountToFollow));
 


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PROD-1782

- `handles removing rows from the follows table when an account has been unfollowed` test is flaky because database results order is not fixed
- Checking array content with arrayContaining to avoid checking order
- Added length check to ensure correct number of entries in db