### PR TITLE
Fixed actor & keypair mismatch when sending activities

### DIFF
--- a/src/activity-handlers/follow.handler.ts
+++ b/src/activity-handlers/follow.handler.ts
@@ -126,7 +126,7 @@ export class FollowHandler {
 
         await ctx.data.globaldb.set([accept.id!.href], acceptJson);
 
-        await ctx.sendActivity({ handle: 'index' }, sender, accept);
+        await ctx.sendActivity({ username: 'index' }, sender, accept);
     }
 
     private async sendReject(
@@ -145,6 +145,6 @@ export class FollowHandler {
 
         await ctx.data.globaldb.set([reject.id!.href], rejectJson);
 
-        await ctx.sendActivity({ handle: 'index' }, sender, reject);
+        await ctx.sendActivity({ username: 'index' }, sender, reject);
     }
 }

--- a/src/activity-handlers/follow.handler.ts
+++ b/src/activity-handlers/follow.handler.ts
@@ -126,7 +126,7 @@ export class FollowHandler {
 
         await ctx.data.globaldb.set([accept.id!.href], acceptJson);
 
-        await ctx.sendActivity({ handle }, sender, accept);
+        await ctx.sendActivity({ handle: 'index' }, sender, accept);
     }
 
     private async sendReject(
@@ -145,6 +145,6 @@ export class FollowHandler {
 
         await ctx.data.globaldb.set([reject.id!.href], rejectJson);
 
-        await ctx.sendActivity({ handle }, sender, reject);
+        await ctx.sendActivity({ handle: 'index' }, sender, reject);
     }
 }

--- a/src/activitypub/fediverse-bridge.ts
+++ b/src/activitypub/fediverse-bridge.ts
@@ -139,7 +139,7 @@ export class FediverseBridge {
 
         await ctx.sendActivity(
             {
-                handle: post.author.username,
+                handle: 'index',
             },
             'followers',
             createActivity,
@@ -170,7 +170,7 @@ export class FediverseBridge {
 
         await ctx.sendActivity(
             {
-                handle: post.author.username,
+                handle: 'index',
             },
             'followers',
             deleteActivity,
@@ -200,7 +200,7 @@ export class FediverseBridge {
 
         await ctx.sendActivity(
             {
-                handle: account.username,
+                handle: 'index',
             },
             'followers',
             update,
@@ -241,7 +241,7 @@ export class FediverseBridge {
         await ctx.data.globaldb.set([reject.id!.href], await reject.toJsonLd());
 
         await ctx.sendActivity(
-            { username: blockerAccount.username },
+            { username: 'index' },
             {
                 id: blockedAccount.apId,
                 inboxId: blockedAccount.apInbox,

--- a/src/activitypub/fediverse-bridge.ts
+++ b/src/activitypub/fediverse-bridge.ts
@@ -139,7 +139,7 @@ export class FediverseBridge {
 
         await ctx.sendActivity(
             {
-                handle: 'index',
+                username: 'index',
             },
             'followers',
             createActivity,
@@ -170,7 +170,7 @@ export class FediverseBridge {
 
         await ctx.sendActivity(
             {
-                handle: 'index',
+                username: 'index',
             },
             'followers',
             deleteActivity,
@@ -200,7 +200,7 @@ export class FediverseBridge {
 
         await ctx.sendActivity(
             {
-                handle: 'index',
+                username: 'index',
             },
             'followers',
             update,

--- a/src/activitypub/fediverse-bridge.unit.test.ts
+++ b/src/activitypub/fediverse-bridge.unit.test.ts
@@ -201,9 +201,9 @@ describe('FediverseBridge', () => {
         expect(sendActivityMockCall).toBeDefined();
         expect(sendActivityMockCall!.length).toBe(3);
 
-        // Assert that the activity was sent from the correct account
+        // Assert that the activity was sent with the hardcoded index username
         expect(sendActivityMockCall![0]).toMatchObject({
-            username: blockerAccount.username,
+            username: 'index',
         });
 
         // Assert that the activity was sent to the correct account

--- a/src/http/api/derepost.ts
+++ b/src/http/api/derepost.ts
@@ -125,24 +125,14 @@ export function createDerepostActionHandler(
             );
         }
         if (attributionActor) {
-            apCtx.sendActivity(
-                { handle: ACTOR_DEFAULT_HANDLE },
-                attributionActor,
-                undo,
-                {
-                    preferSharedInbox: true,
-                },
-            );
+            apCtx.sendActivity({ handle: 'index' }, attributionActor, undo, {
+                preferSharedInbox: true,
+            });
         }
 
-        apCtx.sendActivity(
-            { handle: ACTOR_DEFAULT_HANDLE },
-            'followers',
-            undo,
-            {
-                preferSharedInbox: true,
-            },
-        );
+        apCtx.sendActivity({ handle: 'index' }, 'followers', undo, {
+            preferSharedInbox: true,
+        });
 
         return new Response(JSON.stringify(undoJson), {
             headers: {

--- a/src/http/api/derepost.ts
+++ b/src/http/api/derepost.ts
@@ -125,12 +125,12 @@ export function createDerepostActionHandler(
             );
         }
         if (attributionActor) {
-            apCtx.sendActivity({ handle: 'index' }, attributionActor, undo, {
+            apCtx.sendActivity({ username: 'index' }, attributionActor, undo, {
                 preferSharedInbox: true,
             });
         }
 
-        apCtx.sendActivity({ handle: 'index' }, 'followers', undo, {
+        apCtx.sendActivity({ username: 'index' }, 'followers', undo, {
             preferSharedInbox: true,
         });
 

--- a/src/http/api/follow.ts
+++ b/src/http/api/follow.ts
@@ -7,7 +7,6 @@ import { type AppContext, fedify } from 'app';
 import { exhaustiveCheck, getError, getValue, isError } from 'core/result';
 import { lookupAPIdByHandle, lookupActor, lookupObject } from 'lookup-helpers';
 import type { ModerationService } from 'moderation/moderation.service';
-import { ACTOR_DEFAULT_HANDLE } from '../../constants';
 import { BadRequest, Conflict, Forbidden, NotFound } from './helpers/response';
 
 export class FollowController {
@@ -105,11 +104,7 @@ export class FollowController {
 
         ctx.get('globaldb').set([follow.id!.href], followJson);
 
-        await apCtx.sendActivity(
-            { username: followerAccount.username },
-            actorToFollow,
-            follow,
-        );
+        await apCtx.sendActivity({ username: 'index' }, actorToFollow, follow);
 
         return new Response(JSON.stringify(await actorToFollow.toJsonLd()), {
             headers: {
@@ -189,7 +184,7 @@ export class FollowController {
         await ctx.get('globaldb').set([unfollow.id!.href], unfollowJson);
 
         await apCtx.sendActivity(
-            { handle: ACTOR_DEFAULT_HANDLE },
+            { handle: 'index' },
             actorToUnfollow,
             unfollow,
         );

--- a/src/http/api/follow.ts
+++ b/src/http/api/follow.ts
@@ -184,7 +184,7 @@ export class FollowController {
         await ctx.get('globaldb').set([unfollow.id!.href], unfollowJson);
 
         await apCtx.sendActivity(
-            { handle: 'index' },
+            { username: 'index' },
             actorToUnfollow,
             unfollow,
         );

--- a/src/http/api/like.ts
+++ b/src/http/api/like.ts
@@ -136,24 +136,14 @@ export class LikeController {
             );
         }
         if (attributionActor) {
-            apCtx.sendActivity(
-                { handle: ACTOR_DEFAULT_HANDLE },
-                attributionActor,
-                like,
-                {
-                    preferSharedInbox: true,
-                },
-            );
+            apCtx.sendActivity({ handle: 'index' }, attributionActor, like, {
+                preferSharedInbox: true,
+            });
         }
 
-        apCtx.sendActivity(
-            { handle: ACTOR_DEFAULT_HANDLE },
-            'followers',
-            like,
-            {
-                preferSharedInbox: true,
-            },
-        );
+        apCtx.sendActivity({ handle: 'index' }, 'followers', like, {
+            preferSharedInbox: true,
+        });
         return new Response(JSON.stringify(likeJson), {
             headers: {
                 'Content-Type': 'application/activity+json',
@@ -271,24 +261,14 @@ export class LikeController {
             );
         }
         if (attributionActor) {
-            apCtx.sendActivity(
-                { handle: ACTOR_DEFAULT_HANDLE },
-                attributionActor,
-                undo,
-                {
-                    preferSharedInbox: true,
-                },
-            );
+            apCtx.sendActivity({ handle: 'index' }, attributionActor, undo, {
+                preferSharedInbox: true,
+            });
         }
 
-        apCtx.sendActivity(
-            { handle: ACTOR_DEFAULT_HANDLE },
-            'followers',
-            undo,
-            {
-                preferSharedInbox: true,
-            },
-        );
+        apCtx.sendActivity({ handle: 'index' }, 'followers', undo, {
+            preferSharedInbox: true,
+        });
         return new Response(JSON.stringify(undoJson), {
             headers: {
                 'Content-Type': 'application/activity+json',

--- a/src/http/api/like.ts
+++ b/src/http/api/like.ts
@@ -136,12 +136,12 @@ export class LikeController {
             );
         }
         if (attributionActor) {
-            apCtx.sendActivity({ handle: 'index' }, attributionActor, like, {
+            apCtx.sendActivity({ username: 'index' }, attributionActor, like, {
                 preferSharedInbox: true,
             });
         }
 
-        apCtx.sendActivity({ handle: 'index' }, 'followers', like, {
+        apCtx.sendActivity({ username: 'index' }, 'followers', like, {
             preferSharedInbox: true,
         });
         return new Response(JSON.stringify(likeJson), {
@@ -261,12 +261,12 @@ export class LikeController {
             );
         }
         if (attributionActor) {
-            apCtx.sendActivity({ handle: 'index' }, attributionActor, undo, {
+            apCtx.sendActivity({ username: 'index' }, attributionActor, undo, {
                 preferSharedInbox: true,
             });
         }
 
-        apCtx.sendActivity({ handle: 'index' }, 'followers', undo, {
+        apCtx.sendActivity({ username: 'index' }, 'followers', undo, {
             preferSharedInbox: true,
         });
         return new Response(JSON.stringify(undoJson), {

--- a/src/http/api/reply.ts
+++ b/src/http/api/reply.ts
@@ -255,24 +255,14 @@ export async function handleCreateReply(
     await ctx.get('globaldb').set([create.id!.href], activityJson);
     await ctx.get('globaldb').set([reply.id!.href], await reply.toJsonLd());
 
-    apCtx.sendActivity(
-        { handle: ACTOR_DEFAULT_HANDLE },
-        attributionActor,
-        create,
-        {
-            preferSharedInbox: true,
-        },
-    );
+    apCtx.sendActivity({ handle: 'index' }, attributionActor, create, {
+        preferSharedInbox: true,
+    });
 
     try {
-        await apCtx.sendActivity(
-            { handle: ACTOR_DEFAULT_HANDLE },
-            'followers',
-            create,
-            {
-                preferSharedInbox: true,
-            },
-        );
+        await apCtx.sendActivity({ handle: 'index' }, 'followers', create, {
+            preferSharedInbox: true,
+        });
     } catch (err) {
         logger.error('Error sending reply activity - {error}', {
             error: err,

--- a/src/http/api/reply.ts
+++ b/src/http/api/reply.ts
@@ -255,12 +255,12 @@ export async function handleCreateReply(
     await ctx.get('globaldb').set([create.id!.href], activityJson);
     await ctx.get('globaldb').set([reply.id!.href], await reply.toJsonLd());
 
-    apCtx.sendActivity({ handle: 'index' }, attributionActor, create, {
+    apCtx.sendActivity({ username: 'index' }, attributionActor, create, {
         preferSharedInbox: true,
     });
 
     try {
-        await apCtx.sendActivity({ handle: 'index' }, 'followers', create, {
+        await apCtx.sendActivity({ username: 'index' }, 'followers', create, {
             preferSharedInbox: true,
         });
     } catch (err) {

--- a/src/http/api/repost.ts
+++ b/src/http/api/repost.ts
@@ -63,7 +63,7 @@ export function createRepostActionHandler(postService: PostService) {
         await ctx.get('globaldb').set([announce.id!.href], announceJson);
 
         await apCtx.sendActivity(
-            { username: account.username },
+            { username: 'index' },
             {
                 id: post.author.apId,
                 inboxId: post.author.apInbox,
@@ -74,14 +74,9 @@ export function createRepostActionHandler(postService: PostService) {
             },
         );
 
-        await apCtx.sendActivity(
-            { username: account.username },
-            'followers',
-            announce,
-            {
-                preferSharedInbox: true,
-            },
-        );
+        await apCtx.sendActivity({ username: 'index' }, 'followers', announce, {
+            preferSharedInbox: true,
+        });
 
         return new Response(JSON.stringify(announceJson), {
             headers: {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1775

When calling `sendActivity` fedify uses the passed username to construct the id of the keypair, which is incorrect, because for existing account the id is always based on the "index" URL. We still only support one account per site, so we can safely hardcode the username which we pass to sendActivity.