### PR TITLE
Updated Actor dispatcher to use identifier

### DIFF
--- a/src/activity-handlers/follow.handler.ts
+++ b/src/activity-handlers/follow.handler.ts
@@ -89,7 +89,7 @@ export class FollowHandler {
             accountToFollow,
         );
 
-        await this.sendAccept(ctx, follow, parsed.handle, sender);
+        await this.sendAccept(ctx, follow, parsed.identifier, sender);
     }
 
     private async persistActivity(
@@ -113,7 +113,7 @@ export class FollowHandler {
     private async sendAccept(
         ctx: Context<ContextData>,
         follow: Follow,
-        handle: string,
+        identifier: string,
         sender: Actor,
     ): Promise<void> {
         const acceptId = ctx.getObjectUri(Accept, { id: uuidv4() });
@@ -126,13 +126,13 @@ export class FollowHandler {
 
         await ctx.data.globaldb.set([accept.id!.href], acceptJson);
 
-        await ctx.sendActivity({ username: 'index' }, sender, accept);
+        await ctx.sendActivity({ identifier }, sender, accept);
     }
 
     private async sendReject(
         ctx: Context<ContextData>,
         follow: Follow,
-        handle: string,
+        identifier: string,
         sender: Actor,
     ): Promise<void> {
         const rejectId = ctx.getObjectUri(Reject, { id: uuidv4() });
@@ -145,6 +145,6 @@ export class FollowHandler {
 
         await ctx.data.globaldb.set([reject.id!.href], rejectJson);
 
-        await ctx.sendActivity({ username: 'index' }, sender, reject);
+        await ctx.sendActivity({ identifier }, sender, reject);
     }
 }

--- a/src/activitypub/activity.ts
+++ b/src/activitypub/activity.ts
@@ -28,8 +28,11 @@ export class FedifyActivitySender implements ActivitySender<Activity, Actor> {
     constructor(private readonly fedifyCtx: FedifyRequestContext) {}
 
     async sendActivityToActorFollowers(activity: Activity, actor: Actor) {
+        if (!actor.preferredUsername) {
+            throw new Error(`Actor ${actor.id} has no preferred username`);
+        }
         await this.fedifyCtx.sendActivity(
-            { handle: String(actor.preferredUsername) },
+            { username: actor.preferredUsername.toString() },
             'followers',
             activity,
             {

--- a/src/activitypub/activity.unit.test.ts
+++ b/src/activitypub/activity.unit.test.ts
@@ -24,7 +24,7 @@ describe('FedifyActivitySender', () => {
             await sender.sendActivityToActorFollowers(mockActivity, mockActor);
 
             expect(mockFedifyCtx.sendActivity).toHaveBeenCalledWith(
-                { handle },
+                { username: 'foo' },
                 'followers',
                 mockActivity,
                 {

--- a/src/activitypub/fediverse-bridge.ts
+++ b/src/activitypub/fediverse-bridge.ts
@@ -139,7 +139,7 @@ export class FediverseBridge {
 
         await ctx.sendActivity(
             {
-                username: 'index',
+                username: post.author.username,
             },
             'followers',
             createActivity,
@@ -170,7 +170,7 @@ export class FediverseBridge {
 
         await ctx.sendActivity(
             {
-                username: 'index',
+                username: post.author.username,
             },
             'followers',
             deleteActivity,
@@ -200,7 +200,7 @@ export class FediverseBridge {
 
         await ctx.sendActivity(
             {
-                username: 'index',
+                username: account.username,
             },
             'followers',
             update,
@@ -241,7 +241,7 @@ export class FediverseBridge {
         await ctx.data.globaldb.set([reject.id!.href], await reject.toJsonLd());
 
         await ctx.sendActivity(
-            { username: 'index' },
+            { username: blockerAccount.username },
             {
                 id: blockedAccount.apId,
                 inboxId: blockedAccount.apInbox,

--- a/src/activitypub/fediverse-bridge.unit.test.ts
+++ b/src/activitypub/fediverse-bridge.unit.test.ts
@@ -201,9 +201,8 @@ describe('FediverseBridge', () => {
         expect(sendActivityMockCall).toBeDefined();
         expect(sendActivityMockCall!.length).toBe(3);
 
-        // Assert that the activity was sent with the hardcoded index username
         expect(sendActivityMockCall![0]).toMatchObject({
-            username: 'index',
+            username: 'blocker',
         });
 
         // Assert that the activity was sent to the correct account

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -36,7 +36,7 @@ export const actorDispatcher = (
 ) =>
     async function actorDispatcher(
         ctx: RequestContext<ContextData>,
-        handle: string,
+        identifier: string,
     ) {
         const site = await siteService.getSiteByHost(ctx.host);
         if (site === null) return null;
@@ -59,7 +59,7 @@ export const actorDispatcher = (
             followers: new URL(account.ap_followers_url),
             liked: new URL(account.ap_liked_url),
             url: new URL(account.url || account.ap_id),
-            publicKeys: (await ctx.getActorKeyPairs(handle)).map(
+            publicKeys: (await ctx.getActorKeyPairs(identifier)).map(
                 (key) => key.cryptographicKey,
             ),
         });
@@ -73,7 +73,7 @@ export const keypairDispatcher = (
 ) =>
     async function keypairDispatcher(
         ctx: Context<ContextData>,
-        handle: string,
+        identifier: string,
     ) {
         const site = await siteService.getSiteByHost(ctx.host);
         if (site === null) return [];
@@ -102,7 +102,7 @@ export const keypairDispatcher = (
                 },
             ];
         } catch (err) {
-            ctx.data.logger.warn(`Could not parse keypair for ${handle}`);
+            ctx.data.logger.warn(`Could not parse keypair for ${identifier}`);
             return [];
         }
     };

--- a/src/http/api/follow.ts
+++ b/src/http/api/follow.ts
@@ -104,7 +104,11 @@ export class FollowController {
 
         ctx.get('globaldb').set([follow.id!.href], followJson);
 
-        await apCtx.sendActivity({ username: 'index' }, actorToFollow, follow);
+        await apCtx.sendActivity(
+            { username: followerAccount.username },
+            actorToFollow,
+            follow,
+        );
 
         return new Response(JSON.stringify(await actorToFollow.toJsonLd()), {
             headers: {
@@ -184,7 +188,7 @@ export class FollowController {
         await ctx.get('globaldb').set([unfollow.id!.href], unfollowJson);
 
         await apCtx.sendActivity(
-            { username: 'index' },
+            { username: account.username },
             actorToUnfollow,
             unfollow,
         );

--- a/src/http/api/repost.ts
+++ b/src/http/api/repost.ts
@@ -63,7 +63,7 @@ export function createRepostActionHandler(postService: PostService) {
         await ctx.get('globaldb').set([announce.id!.href], announceJson);
 
         await apCtx.sendActivity(
-            { username: 'index' },
+            { username: account.username },
             {
                 id: post.author.apId,
                 inboxId: post.author.apInbox,
@@ -74,9 +74,14 @@ export function createRepostActionHandler(postService: PostService) {
             },
         );
 
-        await apCtx.sendActivity({ username: 'index' }, 'followers', announce, {
-            preferSharedInbox: true,
-        });
+        await apCtx.sendActivity(
+            { username: account.username },
+            'followers',
+            announce,
+            {
+                preferSharedInbox: true,
+            },
+        );
 
         return new Response(JSON.stringify(announceJson), {
             headers: {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1775

Our actor dispatcher now correctly uses identifier, so that 'index' is the identifier. We then have a username/handle mapper which is currently hardcoded to 'index'. This allows us to remove a lot of the hardcoding elsewhere in the application, so that we can correctly pass `username`.

Now we're in a good position to move toward multiple accounts, as we will just need to update the `mapHandle` and `actorDispatcher` to correctly fetch from the DB and the `sendActivity` calls will all work as expected.