### PR TITLE
Incoming Mentions: Added `data-profile` and `rel` attributes to mention links

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "linkify-html": "4.3.1",
     "linkifyjs": "4.3.1",
     "mysql2": "3.14.1",
+    "node-html-parser": "7.0.1",
     "node-jose": "2.2.0",
     "sanitize-html": "2.17.0",
     "sharp": "0.34.1",

--- a/src/post/content.unit.test.ts
+++ b/src/post/content.unit.test.ts
@@ -417,4 +417,291 @@ describe('ContentPreparer', () => {
             expect(result).toEqual(new Set(['@user@example.com']));
         });
     });
+
+    describe('updateMentions', () => {
+        const account = AccountEntity.create({
+            id: 1,
+            uuid: 'test-uuid',
+            username: 'user',
+            name: 'Test User',
+            bio: null,
+            url: new URL('https://example.xyz/@user'),
+            avatarUrl: null,
+            bannerImageUrl: null,
+            apId: new URL('https://example.xyz/user/@user'),
+            apFollowers: null,
+            apInbox: null,
+            isInternal: false,
+        });
+
+        const account2 = AccountEntity.create({
+            id: 2,
+            uuid: 'test-uuid-2',
+            username: 'user2',
+            name: 'Test User 2',
+            bio: null,
+            url: new URL('https://example.xyz/@user2/'),
+            avatarUrl: null,
+            bannerImageUrl: null,
+            apId: new URL('https://example.xyz/user/@user2/'),
+            apFollowers: null,
+            apInbox: null,
+            isInternal: false,
+        });
+
+        it('should add data-profile and rel to links matching account.apId', () => {
+            const content =
+                '<p>Hey there! <span class="h-card"><a href="https://example.xyz/user/@user">@user@example.xyz</a></span> How are you?</p>';
+            const result = ContentPreparer.updateMentions(content, [
+                {
+                    name: '@user@example.xyz',
+                    href: new URL('https://example.xyz/user/@user'),
+                    account: account,
+                },
+            ]);
+
+            expect(result).toEqual(
+                '<p>Hey there! <span class="h-card"><a href="https://example.xyz/user/@user" data-profile="@user@example.xyz" rel="nofollow noopener noreferrer">@user@example.xyz</a></span> How are you?</p>',
+            );
+        });
+
+        it('should add data-profile and rel to links matching account.url', () => {
+            const content =
+                '<p>Check out <span class="mention"><a href="https://example.xyz/@user">@user@example.xyz</a></span> profile!</p>';
+            const result = ContentPreparer.updateMentions(content, [
+                {
+                    name: '@user@example.xyz',
+                    href: new URL('https://example.xyz/user/@user'),
+                    account: account,
+                },
+            ]);
+
+            expect(result).toEqual(
+                '<p>Check out <span class="mention"><a href="https://example.xyz/@user" data-profile="@user@example.xyz" rel="nofollow noopener noreferrer">@user@example.xyz</a></span> profile!</p>',
+            );
+        });
+
+        it('should add data-profile and rel to mentions that are not complete handles', () => {
+            const content =
+                '<p>Check out <span class="mention"><a href="https://example.xyz/@user">@user</a></span> profile!</p>';
+            const result = ContentPreparer.updateMentions(content, [
+                {
+                    name: '@user@example.xyz',
+                    href: new URL('https://example.xyz/user/@user'),
+                    account: account,
+                },
+            ]);
+
+            expect(result).toEqual(
+                '<p>Check out <span class="mention"><a href="https://example.xyz/@user" data-profile="@user@example.xyz" rel="nofollow noopener noreferrer">@user</a></span> profile!</p>',
+            );
+        });
+
+        it('should add data-profile and rel to links with no rel attribute', () => {
+            const content =
+                '<p>Welcome <span class="h-card"><a href="https://example.xyz/@user" class="mention">@user@example.xyz</a></span> to our platform!</p>';
+            const result = ContentPreparer.updateMentions(content, [
+                {
+                    name: '@user@example.xyz',
+                    href: new URL('https://example.xyz/user/@user'),
+                    account: account,
+                },
+            ]);
+
+            expect(result).toEqual(
+                '<p>Welcome <span class="h-card"><a href="https://example.xyz/@user" class="mention" data-profile="@user@example.xyz" rel="nofollow noopener noreferrer">@user@example.xyz</a></span> to our platform!</p>',
+            );
+        });
+
+        it('should replace any existing rel with rel="nofollow noopener noreferrer"', () => {
+            const content =
+                '<p>Hello <span class="h-card"><a href="https://example.xyz/@user" rel="nofollow">@user@example.xyz</a></span> nice to meet you!</p>';
+            const result = ContentPreparer.updateMentions(content, [
+                {
+                    name: '@user@example.xyz',
+                    href: new URL('https://example.xyz/user/@user'),
+                    account: account,
+                },
+            ]);
+
+            expect(result).toEqual(
+                '<p>Hello <span class="h-card"><a href="https://example.xyz/@user" rel="nofollow noopener noreferrer" data-profile="@user@example.xyz">@user@example.xyz</a></span> nice to meet you!</p>',
+            );
+        });
+
+        it('should handle multiple links in the same content', () => {
+            const content =
+                '<p>Check out <span class="h-card"><a href="https://example.xyz/@user">@user@example.xyz</a></span>, <span class="h-card"><a href="https://example.xyz/@user">@user@example.xyz</a></span> and <span class="h-card"><a href="https://example.xyz/@user2">@user2@example.xyz</a></span> profiles!</p>';
+            const result = ContentPreparer.updateMentions(content, [
+                {
+                    name: '@user@example.xyz',
+                    href: new URL('https://example.xyz/user/@user'),
+                    account: account,
+                },
+                {
+                    name: '@user2@example.xyz',
+                    href: new URL('https://example.xyz/user/@user2'),
+                    account: account2,
+                },
+            ]);
+
+            expect(result).toEqual(
+                '<p>Check out <span class="h-card"><a href="https://example.xyz/@user" data-profile="@user@example.xyz" rel="nofollow noopener noreferrer">@user@example.xyz</a></span>, <span class="h-card"><a href="https://example.xyz/@user" data-profile="@user@example.xyz" rel="nofollow noopener noreferrer">@user@example.xyz</a></span> and <span class="h-card"><a href="https://example.xyz/@user2" data-profile="@user2@example.xyz" rel="nofollow noopener noreferrer">@user2@example.xyz</a></span> profiles!</p>',
+            );
+        });
+
+        it('should handle links with different quote types', () => {
+            const content =
+                '<p>Welcome <span class="h-card"><a href=\'https://example.xyz/@user\'>@user@example.xyz</a></span> to our community!</p>';
+            const result = ContentPreparer.updateMentions(content, [
+                {
+                    name: '@user@example.xyz',
+                    href: new URL('https://example.xyz/user/@user'),
+                    account: account,
+                },
+            ]);
+
+            expect(result).toEqual(
+                '<p>Welcome <span class="h-card"><a href="https://example.xyz/@user" data-profile="@user@example.xyz" rel="nofollow noopener noreferrer">@user@example.xyz</a></span> to our community!</p>',
+            );
+        });
+
+        it('should handle empty link content', () => {
+            const content =
+                '<p>Hey <a href="https://example.xyz/@user"></a>, how are you?</p>';
+            const result = ContentPreparer.updateMentions(content, [
+                {
+                    name: '@user@example.xyz',
+                    href: new URL('https://example.xyz/user/@user'),
+                    account: account,
+                },
+            ]);
+
+            expect(result).toBe(
+                '<p>Hey <a href="https://example.xyz/@user" data-profile="@user@example.xyz" rel="nofollow noopener noreferrer"></a>, how are you?</p>',
+            );
+        });
+
+        it('should handle links with existing data-profile', () => {
+            const content =
+                '<p>Hello <span class="h-card"><a href="https://example.xyz/@user" data-profile="@user@example.xyz">@user@example.xyz</a></span> welcome back!</p>';
+            const result = ContentPreparer.updateMentions(content, [
+                {
+                    name: '@user@example.xyz',
+                    href: new URL('https://example.xyz/user/@user'),
+                    account: account,
+                },
+            ]);
+
+            expect(result).toEqual(
+                '<p>Hello <span class="h-card"><a href="https://example.xyz/@user" data-profile="@user@example.xyz" rel="nofollow noopener noreferrer">@user@example.xyz</a></span> welcome back!</p>',
+            );
+        });
+
+        it('should not modify non-matching links', () => {
+            const content =
+                '<p>Check out <span class="h-card"><a href="https://other-domain.com/@user">@user@other-domain.com</a></span> and <span class="h-card"><a href="https://example.xyz/@user">@user@example.xyz</a></span> profiles!</p>';
+            const result = ContentPreparer.updateMentions(content, [
+                {
+                    name: '@user@example.xyz',
+                    href: new URL('https://example.xyz/user/@user'),
+                    account: account,
+                },
+            ]);
+
+            expect(result).toEqual(
+                '<p>Check out <span class="h-card"><a href="https://other-domain.com/@user">@user@other-domain.com</a></span> and <span class="h-card"><a href="https://example.xyz/@user" data-profile="@user@example.xyz" rel="nofollow noopener noreferrer">@user@example.xyz</a></span> profiles!</p>',
+            );
+        });
+
+        it('should handle links with nested spans in their content', () => {
+            const content =
+                '<p>Hello check <span class="h-card" translate="no"><a href="https://example.xyz/@user" class="u-url mention">@<span>user</span></a></span> <span class="h-card" translate="no"><a href="https://other-domain.com/" class="u-url mention">@<span>other</span></a></span></p>';
+            const result = ContentPreparer.updateMentions(content, [
+                {
+                    name: '@user@example.xyz',
+                    href: new URL('https://example.xyz/@user'),
+                    account: account,
+                },
+            ]);
+
+            expect(result).toEqual(
+                '<p>Hello check <span class="h-card" translate="no"><a href="https://example.xyz/@user" class="u-url mention" data-profile="@user@example.xyz" rel="nofollow noopener noreferrer">@<span>user</span></a></span> <span class="h-card" translate="no"><a href="https://other-domain.com/" class="u-url mention">@<span>other</span></a></span></p>',
+            );
+        });
+
+        it('should handle links with complex nested HTML structure', () => {
+            const content =
+                '<p>Check out <span class="h-card"><a href="https://example.xyz/@user" class="mention">@<span class="username"><strong>user</strong><em>@example.xyz</em></span><img src="avatar.jpg" alt="avatar" ></a></span> profile!</p>';
+            const result = ContentPreparer.updateMentions(content, [
+                {
+                    name: '@user@example.xyz',
+                    href: new URL('https://example.xyz/@user'),
+                    account: account,
+                },
+            ]);
+
+            expect(result).toEqual(
+                '<p>Check out <span class="h-card"><a href="https://example.xyz/@user" class="mention" data-profile="@user@example.xyz" rel="nofollow noopener noreferrer">@<span class="username"><strong>user</strong><em>@example.xyz</em></span><img src="avatar.jpg" alt="avatar" ></a></span> profile!</p>',
+            );
+        });
+
+        it('should handle URLs with trailing slashes', () => {
+            const content =
+                '<p>Check out <span class="h-card"><a href="https://example.xyz/@user/">@user@example.xyz</a></span> profile!</p>';
+            const result = ContentPreparer.updateMentions(content, [
+                {
+                    name: '@user@example.xyz',
+                    href: new URL('https://example.xyz/@user'),
+                    account: account,
+                },
+            ]);
+
+            expect(result).toEqual(
+                '<p>Check out <span class="h-card"><a href="https://example.xyz/@user/" data-profile="@user@example.xyz" rel="nofollow noopener noreferrer">@user@example.xyz</a></span> profile!</p>',
+            );
+        });
+
+        it('should handle href attribute in any position within the tag', () => {
+            const content =
+                '<p>Check out <span class="h-card"><a class="mention" href="https://example.xyz/@user" data-other="value">@<span>user</span></a></span> profile!</p>';
+            const result = ContentPreparer.updateMentions(content, [
+                {
+                    name: '@user@example.xyz',
+                    href: new URL('https://example.xyz/@user'),
+                    account: account,
+                },
+            ]);
+
+            expect(result).toEqual(
+                '<p>Check out <span class="h-card"><a class="mention" href="https://example.xyz/@user" data-other="value" data-profile="@user@example.xyz" rel="nofollow noopener noreferrer">@<span>user</span></a></span> profile!</p>',
+            );
+        });
+
+        it('should not do anything if the content is not valid HTML', () => {
+            const content = 'This is plain text with @user@example.xyz mention';
+            const result = ContentPreparer.updateMentions(content, [
+                {
+                    name: '@user@example.xyz',
+                    href: new URL('https://example.xyz/@user'),
+                    account: account,
+                },
+            ]);
+
+            expect(result).toEqual(content);
+        });
+
+        it('should not do anything if the mention is not wrapped in hyperlink', () => {
+            const content = '<p>Check out @user@example.xyz profile!</p>';
+            const result = ContentPreparer.updateMentions(content, [
+                {
+                    name: '@user@example.xyz',
+                    href: new URL('https://example.xyz/@user'),
+                    account: account,
+                },
+            ]);
+
+            expect(result).toEqual(content);
+        });
+    });
 });

--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -69,7 +69,7 @@ export interface PostData {
     inReplyTo?: Post | null;
     apId?: URL | null;
     attachments?: PostAttachment[] | null;
-    mentions?: Account[] | null;
+    mentions?: Mention[] | null;
     metadata?: Metadata | null;
 }
 
@@ -310,6 +310,13 @@ export class Post extends BaseEntity {
             threadRoot = data.inReplyTo.threadRoot ?? data.inReplyTo.id;
         }
 
+        if (data.mentions && data.mentions.length > 0) {
+            data.content = ContentPreparer.updateMentions(
+                data.content ?? '',
+                data.mentions,
+            );
+        }
+
         const post = new Post(
             null,
             null,
@@ -334,7 +341,7 @@ export class Post extends BaseEntity {
         );
 
         for (const mention of data.mentions ?? []) {
-            post.addMention(mention);
+            post.addMention(mention.account);
         }
 
         return post;

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -86,8 +86,8 @@ export class PostService {
 
     private async getMentionedAccounts(
         object: Note | Article,
-    ): Promise<Account[]> {
-        const accounts: Account[] = [];
+    ): Promise<Mention[]> {
+        const mentions: Mention[] = [];
         for await (const tag of object.getTags()) {
             if (tag instanceof FedifyMention) {
                 if (!tag.href) {
@@ -106,11 +106,15 @@ export class PostService {
                 }
 
                 const account = getValue(accountResult);
-                accounts.push(account);
+                mentions.push({
+                    name: tag.name.toString(),
+                    href: tag.href,
+                    account,
+                });
             }
         }
 
-        return accounts;
+        return mentions;
     }
 
     async getByApId(id: URL): Promise<Result<Post, GetByApIdError>> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1870,6 +1870,11 @@ bignumber.js@^9.0.0:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
   integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
 
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+
 brace-expansion@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
@@ -2047,6 +2052,22 @@ cross-spawn@^7.0.0:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
+css-what@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
 
 data-uri-to-buffer@^4.0.0:
   version "4.0.1"
@@ -2497,6 +2518,11 @@ hasown@^2.0.2:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
+
+he@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 heap-js@^2.2.0:
   version "2.5.0"
@@ -3143,6 +3169,14 @@ node-forge@^1.2.1:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
 
+node-html-parser@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-7.0.1.tgz#e3056550bae48517ebf161a0b0638f4b0123dfe3"
+  integrity sha512-KGtmPY2kS0thCWGK0VuPyOS+pBKhhe8gXztzA2ilAOhbUbxa9homF1bOyKvhGzMLXUoRds9IOmr/v5lr/lqNmA==
+  dependencies:
+    css-select "^5.1.0"
+    he "1.2.0"
+
 node-jose@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/node-jose/-/node-jose-2.2.0.tgz#b64f3225ad6bec328509a420800de597ba2bf3ed"
@@ -3166,6 +3200,13 @@ normalize-package-data@^6.0.0:
     hosted-git-info "^7.0.0"
     semver "^7.3.5"
     validate-npm-package-license "^3.0.4"
+
+nth-check@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
+  dependencies:
+    boolbase "^1.0.0"
 
 object-assign@^4.0.1:
   version "4.1.1"
@@ -3804,16 +3845,7 @@ string-argv@0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3838,14 +3870,7 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4200,16 +4225,7 @@ wiremock-captain@3.5.0:
   dependencies:
     axios "1.7.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PROD-1810/

The updateMentions function handles incoming mentions by:
 1. Adding `data-profile` and `rel` attributes to existing mention links

For existing links:
- Preserves the original href and other attributes
- Adds `data-profile` attribute with the mention handle
- Adds `rel="nofollow noopener noreferrer"`

For unwrapped mentions:
- Do Nothing