### PR TITLE
Support storing expiry in KnexKvStore

### DIFF
--- a/src/knex.kvstore.ts
+++ b/src/knex.kvstore.ts
@@ -39,7 +39,9 @@ export class KnexKvStore implements KvStore {
         };
         const values = {
             value: JSON.stringify(valueToStore),
-            expires: null,
+            expires: options?.ttl
+                ? new Date(Date.now() + options.ttl.total('milliseconds'))
+                : null,
         };
         await this.knex(this.table)
             .insert({


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-685

We want to start cleaning up old keys from the key_value table, for example the idempotency keys created by fedify. The first step toward that is storing the expiry, and then we can run a cron style job to delete expired rows