### PR TITLE
Change `Cannot create Post from private content` to 400

### DIFF
--- a/features/create-article-from-post.feature
+++ b/features/create-article-from-post.feature
@@ -1,13 +1,13 @@
 Feature: Deliver Create(Article) activities when a post.published webhook is received
 
-  Scenario: We recieve a webhook for the post.published event
+  Scenario: We receive a webhook for the post.published event
     Given we are followed by "Alice"
     And a "post.published" webhook
     When it is sent to the webhook endpoint
     Then the request is accepted
     Then A "Create(Article)" Activity is sent to all followers
 
-  Scenario: We recieve a webhook for the post.published event and the post has no content
+  Scenario: We receive a webhook for the post.published event and the post has no content
     Given we are followed by "Alice"
     And a "post.published" webhook:
       | property             | value |
@@ -17,12 +17,20 @@ Feature: Deliver Create(Article) activities when a post.published webhook is rec
     Then the request is accepted
     Then A "Create(Article)" Activity is sent to all followers
 
-  Scenario: We recieve a webhook for the post.published event with an old signature
+  Scenario: We receive a webhook for the post.published event with an old signature
     Given a "post.published" webhook
     When it is sent to the webhook endpoint with an old signature
     Then the request is rejected with a 401
 
-  Scenario: We recieve a webhook for the post.published event without a signature
+  Scenario: We receive a webhook for the post.published event without a signature
     Given a "post.published" webhook
     When it is sent to the webhook endpoint without a signature
     Then the request is rejected with a 401
+
+  Scenario: We receive a webhook for the post.published event with private visibility
+    Given a "post.published" webhook
+    And a "post.published" webhook:
+      | property                | value   |
+      | post.current.visibility | private |
+    When it is sent to the webhook endpoint with private visibility
+    Then the request is rejected with a 400

--- a/features/step_definitions/webhook_steps.js
+++ b/features/step_definitions/webhook_steps.js
@@ -90,3 +90,28 @@ When(
         });
     },
 );
+
+When(
+    'it is sent to the webhook endpoint with private visibility',
+    async function () {
+        const endpoint = endpoints[this.payloadType];
+        let payload = createWebhookPost();
+        if (this.payloadData) {
+            payload = merge(payload, this.payloadData);
+        }
+        const body = JSON.stringify(payload);
+        const timestamp = Date.now();
+        const hmac = createHmac('sha256', getWebhookSecret())
+            .update(body + timestamp)
+            .digest('hex');
+
+        this.response = await fetchActivityPub(endpoint, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Ghost-Signature': `sha256=${hmac}, t=${timestamp}`,
+            },
+            body: body,
+        });
+    },
+);

--- a/src/post/post.entity.unit.test.ts
+++ b/src/post/post.entity.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { type Ok, getValue, isError } from 'core/result';
 import { type Account, AccountEntity } from '../account/account.entity';
 import { Audience, Post, type PostData, PostType } from './post.entity';
 
@@ -39,7 +40,7 @@ const internalAccount = (id: number | null = 123) => mockAccount(id, true);
 
 describe('Post', () => {
     describe('delete', () => {
-        it('Should be possible to delete posts authored by the account', () => {
+        it('Should be possible to delete posts authored by the account', async () => {
             const author = internalAccount();
             const ghostPost = {
                 uuid: '550e8400-e29b-41d4-a716-446655440000',
@@ -54,14 +55,18 @@ describe('Post', () => {
                 authors: [],
             };
 
-            const post = Post.createArticleFromGhostPost(author, ghostPost);
+            const postResult = await Post.createArticleFromGhostPost(
+                author,
+                ghostPost,
+            );
+            const post = getValue(postResult as Ok<Post>) as Post;
 
             post.delete(author);
 
             expect(Post.isDeleted(post)).toBe(true);
         });
 
-        it('Should not be possible to delete posts from other authors', () => {
+        it('Should not be possible to delete posts from other authors', async () => {
             const author = internalAccount();
             const notAuthor = externalAccount();
             const ghostPost = {
@@ -77,7 +82,11 @@ describe('Post', () => {
                 authors: [],
             };
 
-            const post = Post.createArticleFromGhostPost(author, ghostPost);
+            const postResult = await Post.createArticleFromGhostPost(
+                author,
+                ghostPost,
+            );
+            const post = getValue(postResult as Ok<Post>) as Post;
 
             expect(() => {
                 post.delete(notAuthor);
@@ -86,7 +95,7 @@ describe('Post', () => {
             expect(Post.isDeleted(post)).toBe(false);
         });
 
-        it('Should set all content to null for deleted posts', () => {
+        it('Should set all content to null for deleted posts', async () => {
             const author = internalAccount();
             const ghostPost = {
                 uuid: '550e8400-e29b-41d4-a716-446655440000',
@@ -106,7 +115,11 @@ describe('Post', () => {
                 ],
             };
 
-            const post = Post.createArticleFromGhostPost(author, ghostPost);
+            const postResult = await Post.createArticleFromGhostPost(
+                author,
+                ghostPost,
+            );
+            const post = getValue(postResult as Ok<Post>) as Post;
 
             post.delete(author);
 
@@ -498,7 +511,7 @@ describe('Post', () => {
         });
     });
 
-    it('should correctly create an article from a Ghost Post', () => {
+    it('should correctly create an article from a Ghost Post', async () => {
         const account = internalAccount();
         const ghostPost = {
             uuid: '550e8400-e29b-41d4-a716-446655440000',
@@ -513,13 +526,17 @@ describe('Post', () => {
             authors: [],
         };
 
-        const post = Post.createArticleFromGhostPost(account, ghostPost);
+        const postResult = await Post.createArticleFromGhostPost(
+            account,
+            ghostPost,
+        );
+        const post = getValue(postResult as Ok<Post>) as Post;
 
         expect(post.uuid).toEqual(ghostPost.uuid);
         expect(post.content).toEqual(ghostPost.html);
     });
 
-    it('should refuse to create an article from a private Ghost Post with no public content', () => {
+    it('should refuse to create an article from a private Ghost Post with no public content', async () => {
         const account = internalAccount();
         const ghostPost = {
             uuid: '550e8400-e29b-41d4-a716-446655440000',
@@ -534,12 +551,14 @@ describe('Post', () => {
             authors: [],
         };
 
-        expect(() =>
-            Post.createArticleFromGhostPost(account, ghostPost),
-        ).toThrow();
+        const postResult = await Post.createArticleFromGhostPost(
+            account,
+            ghostPost,
+        );
+        expect(isError(postResult)).toBe(true);
     });
 
-    it('should create an article with restricted content from a private Ghost Post', () => {
+    it('should create an article with restricted content from a private Ghost Post', async () => {
         const account = internalAccount();
         const ghostPost = {
             uuid: '550e8400-e29b-41d4-a716-446655440000',
@@ -554,7 +573,11 @@ describe('Post', () => {
             authors: [],
         };
 
-        const post = Post.createArticleFromGhostPost(account, ghostPost);
+        const postResult = await Post.createArticleFromGhostPost(
+            account,
+            ghostPost,
+        );
+        const post = getValue(postResult as Ok<Post>) as Post;
 
         expect(post.uuid).toEqual(ghostPost.uuid);
         expect(post.content).toEqual(
@@ -650,7 +673,7 @@ describe('Post', () => {
         ]);
     });
 
-    it('should save ghost authors in posts metadata', () => {
+    it('should save ghost authors in posts metadata', async () => {
         const account = internalAccount();
         const ghostPost = {
             uuid: '550e8400-e29b-41d4-a716-446655440000',
@@ -674,7 +697,11 @@ describe('Post', () => {
             ],
         };
 
-        const post = Post.createArticleFromGhostPost(account, ghostPost);
+        const postResult = await Post.createArticleFromGhostPost(
+            account,
+            ghostPost,
+        );
+        const post = getValue(postResult as Ok<Post>) as Post;
 
         expect(post.metadata).toEqual({
             ghostAuthors: [
@@ -690,7 +717,7 @@ describe('Post', () => {
         });
     });
 
-    it('should handle an empty array of ghost authors', () => {
+    it('should handle an empty array of ghost authors', async () => {
         const account = internalAccount();
         const ghostPost = {
             uuid: '550e8400-e29b-41d4-a716-446655440000',
@@ -705,7 +732,11 @@ describe('Post', () => {
             authors: [],
         };
 
-        const post = Post.createArticleFromGhostPost(account, ghostPost);
+        const postResult = await Post.createArticleFromGhostPost(
+            account,
+            ghostPost,
+        );
+        const post = getValue(postResult as Ok<Post>) as Post;
 
         expect(post.metadata).toEqual({
             ghostAuthors: [],
@@ -714,7 +745,7 @@ describe('Post', () => {
 
     describe('post excerpt', () => {
         describe('when the post is public', () => {
-            it('should not re-generate excerpt', () => {
+            it('should not re-generate excerpt', async () => {
                 const account = internalAccount();
                 const ghostPost = {
                     uuid: '550e8400-e29b-41d4-a716-446655440000',
@@ -729,15 +760,16 @@ describe('Post', () => {
                     authors: [],
                 };
 
-                const post = Post.createArticleFromGhostPost(
+                const postResult = await Post.createArticleFromGhostPost(
                     account,
                     ghostPost,
                 );
+                const post = getValue(postResult as Ok<Post>) as Post;
 
                 expect(post.excerpt).toEqual(ghostPost.excerpt);
             });
 
-            it('should not re-generate excerpt even if there is a paywall', () => {
+            it('should not re-generate excerpt even if there is a paywall', async () => {
                 const account = internalAccount();
                 const ghostPost = {
                     uuid: '550e8400-e29b-41d4-a716-446655440000',
@@ -752,10 +784,11 @@ describe('Post', () => {
                     authors: [],
                 };
 
-                const post = Post.createArticleFromGhostPost(
+                const postResult = await Post.createArticleFromGhostPost(
                     account,
                     ghostPost,
                 );
+                const post = getValue(postResult as Ok<Post>) as Post;
 
                 expect(post.excerpt).toEqual(ghostPost.excerpt);
             });
@@ -763,7 +796,7 @@ describe('Post', () => {
 
         describe('when the post is members-only', () => {
             describe('and there is no custom excerpt', () => {
-                it('should re-generate excerpt without the gated content and without the paid signup message', () => {
+                it('should re-generate excerpt without the gated content and without the paid signup message', async () => {
                     const account = internalAccount();
                     const ghostPost = {
                         uuid: '550e8400-e29b-41d4-a716-446655440000',
@@ -778,17 +811,18 @@ describe('Post', () => {
                         authors: [],
                     };
 
-                    const post = Post.createArticleFromGhostPost(
+                    const postResult = await Post.createArticleFromGhostPost(
                         account,
                         ghostPost,
                     );
+                    const post = getValue(postResult as Ok<Post>) as Post;
 
                     expect(post.excerpt).toEqual('Hello world!');
                 });
             });
 
             describe('and there is a custom excerpt', () => {
-                it('should not re-generate the excerpt', () => {
+                it('should not re-generate the excerpt', async () => {
                     const account = internalAccount();
                     const ghostPost = {
                         uuid: '550e8400-e29b-41d4-a716-446655440000',
@@ -803,10 +837,11 @@ describe('Post', () => {
                         authors: [],
                     };
 
-                    const post = Post.createArticleFromGhostPost(
+                    const postResult = await Post.createArticleFromGhostPost(
                         account,
                         ghostPost,
                     );
+                    const post = getValue(postResult as Ok<Post>) as Post;
 
                     expect(post.excerpt).toEqual(ghostPost.excerpt);
                 });

--- a/src/post/post.repository.knex.integration.test.ts
+++ b/src/post/post.repository.knex.integration.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { randomUUID } from 'node:crypto';
 import { AsyncEvents } from 'core/events';
+import { type Ok, getValue } from 'core/result';
 import { FeedUpdateService } from 'feed/feed-update.service';
 import { FeedService } from 'feed/feed.service';
 import type { Knex } from 'knex';
@@ -82,7 +83,7 @@ describe('KnexPostRepository', () => {
         it('Waits for the post to be added to feeds before returning', async () => {
             const site = await siteService.initialiseSiteForHost('testing.com');
             const account = await accountRepository.getBySite(site);
-            const post = Post.createArticleFromGhostPost(account, {
+            const postResult = await Post.createArticleFromGhostPost(account, {
                 title: 'Title',
                 uuid: '3f1c5e84-9a2b-4d7f-8e62-1a6b9c9d4f10',
                 html: '<p>Hello, world!</p>',
@@ -94,6 +95,7 @@ describe('KnexPostRepository', () => {
                 visibility: 'public',
                 authors: [],
             });
+            const post = getValue(postResult as Ok<Post>) as Post;
 
             await postRepository.save(post);
 
@@ -110,7 +112,7 @@ describe('KnexPostRepository', () => {
         it('Waits for the deleted post to be removed from feeds before returning', async () => {
             const site = await siteService.initialiseSiteForHost('testing.com');
             const account = await accountRepository.getBySite(site);
-            const post = Post.createArticleFromGhostPost(account, {
+            const postResult = await Post.createArticleFromGhostPost(account, {
                 title: 'Title',
                 uuid: '3f1c5e84-9a2b-4d7f-8e62-1a6b9c9d4f10',
                 html: '<p>Hello, world!</p>',
@@ -122,6 +124,7 @@ describe('KnexPostRepository', () => {
                 visibility: 'public',
                 authors: [],
             });
+            const post = getValue(postResult as Ok<Post>) as Post;
 
             await postRepository.save(post);
 
@@ -160,7 +163,7 @@ describe('KnexPostRepository', () => {
             const site =
                 await siteService.initialiseSiteForHost('testing-delete.com');
             const account = await accountRepository.getBySite(site);
-            const post = Post.createArticleFromGhostPost(account, {
+            const postResult = await Post.createArticleFromGhostPost(account, {
                 title: 'Title',
                 uuid: '3f1c5e84-9a2b-4d7f-8e62-1a6b9c9d4f10',
                 html: '<p>Hello, world!</p>',
@@ -172,6 +175,7 @@ describe('KnexPostRepository', () => {
                 visibility: 'public',
                 authors: [],
             });
+            const post = getValue(postResult as Ok<Post>) as Post;
 
             await postRepository.save(post);
 
@@ -207,7 +211,7 @@ describe('KnexPostRepository', () => {
                 'testing-deleted-reply.com',
             );
             const account = await accountRepository.getBySite(site);
-            const post = Post.createArticleFromGhostPost(account, {
+            const postResult = await Post.createArticleFromGhostPost(account, {
                 title: 'Title',
                 uuid: '3f1c5e84-9a2b-4d7f-8e62-1a6b9c9d4f10',
                 html: '<p>Hello, world!</p>',
@@ -219,6 +223,7 @@ describe('KnexPostRepository', () => {
                 visibility: 'public',
                 authors: [],
             });
+            const post = getValue(postResult as Ok<Post>) as Post;
 
             await postRepository.save(post);
 
@@ -283,7 +288,7 @@ describe('KnexPostRepository', () => {
             );
 
             // Create a new post
-            const post = Post.createArticleFromGhostPost(account, {
+            const postResult = await Post.createArticleFromGhostPost(account, {
                 title: 'Title',
                 uuid: randomUUID(),
                 html: '<p>Hello, world!</p>',
@@ -295,6 +300,7 @@ describe('KnexPostRepository', () => {
                 visibility: 'public',
                 authors: [],
             });
+            const post = getValue(postResult as Ok<Post>) as Post;
 
             // Add a like from another account
             post.addLike(likerAccount);
@@ -324,7 +330,7 @@ describe('KnexPostRepository', () => {
                 'testing-new-deleted.com',
             );
             const account = await accountRepository.getBySite(site);
-            const post = Post.createArticleFromGhostPost(account, {
+            const postResult = await Post.createArticleFromGhostPost(account, {
                 title: 'Title',
                 uuid: randomUUID(),
                 html: '<p>Hello, world!</p>',
@@ -336,6 +342,7 @@ describe('KnexPostRepository', () => {
                 visibility: 'public',
                 authors: [],
             });
+            const post = getValue(postResult as Ok<Post>) as Post;
 
             post.delete(account);
 
@@ -356,7 +363,7 @@ describe('KnexPostRepository', () => {
         const site =
             await siteService.initialiseSiteForHost('testing-saving.com');
         const account = await accountRepository.getBySite(site);
-        const post = Post.createArticleFromGhostPost(account, {
+        const postResult = await Post.createArticleFromGhostPost(account, {
             title: 'Title',
             uuid: randomUUID(),
             html: '<p>Hello, world!</p>',
@@ -368,6 +375,7 @@ describe('KnexPostRepository', () => {
             visibility: 'public',
             authors: [],
         });
+        const post = getValue(postResult as Ok<Post>) as Post;
 
         await postRepository.save(post);
 
@@ -441,7 +449,7 @@ describe('KnexPostRepository', () => {
         );
         const account = await accountRepository.getBySite(site);
 
-        const post = Post.createArticleFromGhostPost(account, {
+        const postResult = await Post.createArticleFromGhostPost(account, {
             title: 'Title',
             uuid: randomUUID(),
             html: '<p>Hello, world!</p>',
@@ -453,6 +461,7 @@ describe('KnexPostRepository', () => {
             visibility: 'public',
             authors: [],
         });
+        const post = getValue(postResult as Ok<Post>) as Post;
 
         await postRepository.save(post);
 
@@ -469,7 +478,7 @@ describe('KnexPostRepository', () => {
         );
         const account = await accountRepository.getBySite(site);
 
-        const post = Post.createArticleFromGhostPost(account, {
+        const postResult = await Post.createArticleFromGhostPost(account, {
             title: 'Title',
             uuid: randomUUID(),
             html: '<p>Hello, world!</p>',
@@ -481,6 +490,7 @@ describe('KnexPostRepository', () => {
             visibility: 'public',
             authors: [],
         });
+        const post = getValue(postResult as Ok<Post>) as Post;
 
         await postRepository.save(post);
         await postRepository.save(post);
@@ -493,7 +503,7 @@ describe('KnexPostRepository', () => {
             'testing-by-apid.com',
         );
         const account = await accountRepository.getBySite(site);
-        const post = Post.createArticleFromGhostPost(account, {
+        const postResult = await Post.createArticleFromGhostPost(account, {
             title: 'Title',
             uuid: randomUUID(),
             html: '<p>Hello, world!</p>',
@@ -505,6 +515,7 @@ describe('KnexPostRepository', () => {
             visibility: 'public',
             authors: [],
         });
+        const post = getValue(postResult as Ok<Post>) as Post;
 
         await postRepository.save(post);
 
@@ -523,7 +534,7 @@ describe('KnexPostRepository', () => {
             'testing-by-apid.com',
         );
         const account = await accountRepository.getBySite(site);
-        const post = Post.createArticleFromGhostPost(account, {
+        const postResult = await Post.createArticleFromGhostPost(account, {
             title: 'Title',
             uuid: randomUUID(),
             html: '<p>Hello, world!</p>',
@@ -535,6 +546,7 @@ describe('KnexPostRepository', () => {
             visibility: 'public',
             authors: [],
         });
+        const post = getValue(postResult as Ok<Post>) as Post;
 
         await postRepository.save(post);
 
@@ -565,7 +577,7 @@ describe('KnexPostRepository', () => {
             .first();
         assert(accountInDb.uuid === null, 'Account should not have a uuid');
 
-        const post = Post.createArticleFromGhostPost(account, {
+        const postResult = await Post.createArticleFromGhostPost(account, {
             title: 'Title',
             uuid: randomUUID(),
             html: '<p>Hello, world!</p>',
@@ -577,6 +589,7 @@ describe('KnexPostRepository', () => {
             visibility: 'public',
             authors: [],
         });
+        const post = getValue(postResult as Ok<Post>) as Post;
 
         await postRepository.save(post);
 
@@ -596,7 +609,7 @@ describe('KnexPostRepository', () => {
             'testing-deleted-tombstone.com',
         );
         const account = await accountRepository.getBySite(site);
-        const post = Post.createArticleFromGhostPost(account, {
+        const postResult = await Post.createArticleFromGhostPost(account, {
             title: 'Title',
             uuid: randomUUID(),
             html: '<p>Hello, world!</p>',
@@ -608,6 +621,7 @@ describe('KnexPostRepository', () => {
             visibility: 'public',
             authors: [],
         });
+        const post = getValue(postResult as Ok<Post>) as Post;
 
         await postRepository.save(post);
 
@@ -646,7 +660,7 @@ describe('KnexPostRepository', () => {
             ].map(getAccount),
         );
 
-        const post = Post.createArticleFromGhostPost(accounts[0], {
+        const postResult = await Post.createArticleFromGhostPost(accounts[0], {
             title: 'Title',
             uuid: randomUUID(),
             html: '<p>Hello, world!</p>',
@@ -658,6 +672,7 @@ describe('KnexPostRepository', () => {
             visibility: 'public',
             authors: [],
         });
+        const post = getValue(postResult as Ok<Post>) as Post;
 
         post.addLike(accounts[0]);
         post.addLike(accounts[1]);
@@ -712,7 +727,7 @@ describe('KnexPostRepository', () => {
             ].map(getAccount),
         );
 
-        const post = Post.createArticleFromGhostPost(accounts[0], {
+        const postResult = await Post.createArticleFromGhostPost(accounts[0], {
             title: 'Title',
             uuid: randomUUID(),
             html: '<p>Hello, world!</p>',
@@ -724,6 +739,7 @@ describe('KnexPostRepository', () => {
             visibility: 'public',
             authors: [],
         });
+        const post = getValue(postResult as Ok<Post>) as Post;
 
         post.addLike(accounts[1]);
 
@@ -777,7 +793,7 @@ describe('KnexPostRepository', () => {
             ].map(getAccount),
         );
 
-        const post = Post.createArticleFromGhostPost(accounts[0], {
+        const postResult = await Post.createArticleFromGhostPost(accounts[0], {
             title: 'Title',
             uuid: randomUUID(),
             html: '<p>Hello, world!</p>',
@@ -789,6 +805,7 @@ describe('KnexPostRepository', () => {
             visibility: 'public',
             authors: [],
         });
+        const post = getValue(postResult as Ok<Post>) as Post;
 
         post.addRepost(accounts[1]);
         post.addRepost(accounts[2]);
@@ -840,7 +857,7 @@ describe('KnexPostRepository', () => {
             ].map(getAccount),
         );
 
-        const post = Post.createArticleFromGhostPost(accounts[0], {
+        const postResult = await Post.createArticleFromGhostPost(accounts[0], {
             title: 'Title',
             uuid: randomUUID(),
             html: '<p>Hello, world!</p>',
@@ -852,6 +869,7 @@ describe('KnexPostRepository', () => {
             visibility: 'public',
             authors: [],
         });
+        const post = getValue(postResult as Ok<Post>) as Post;
 
         post.addRepost(accounts[1]);
 
@@ -909,18 +927,23 @@ describe('KnexPostRepository', () => {
             ].map(getAccount),
         );
 
-        const originalPost = Post.createArticleFromGhostPost(accounts[0], {
-            title: 'Original Post',
-            uuid: randomUUID(),
-            html: '<p>Original content</p>',
-            excerpt: 'Original content',
-            custom_excerpt: null,
-            feature_image: null,
-            url: 'https://testing.com/original-post',
-            published_at: '2025-01-01',
-            visibility: 'public',
-            authors: [],
-        });
+        const originalPostResult = await Post.createArticleFromGhostPost(
+            accounts[0],
+            {
+                title: 'Original Post',
+                uuid: randomUUID(),
+                html: '<p>Original content</p>',
+                excerpt: 'Original content',
+                custom_excerpt: null,
+                feature_image: null,
+                url: 'https://testing.com/original-post',
+                published_at: '2025-01-01',
+                visibility: 'public',
+                authors: [],
+            },
+        );
+
+        const originalPost = getValue(originalPostResult as Ok<Post>) as Post;
 
         await postRepository.save(originalPost);
 
@@ -1022,8 +1045,9 @@ describe('KnexPostRepository', () => {
         const site = await siteService.initialiseSiteForHost(
             'testing-is-liked-by-account.com',
         );
+
         const account = await accountRepository.getBySite(site);
-        const post = Post.createArticleFromGhostPost(account, {
+        const postResult = await Post.createArticleFromGhostPost(account, {
             title: 'Title',
             uuid: randomUUID(),
             html: '<p>Hello, world!</p>',
@@ -1035,6 +1059,8 @@ describe('KnexPostRepository', () => {
             visibility: 'public',
             authors: [],
         });
+
+        const post = getValue(postResult as Ok<Post>) as Post;
 
         post.addLike(account);
 
@@ -1065,7 +1091,8 @@ describe('KnexPostRepository', () => {
         const reposterAccount = await accountRepository.getBySite(
             await siteService.initialiseSiteForHost('reposter-site.com'),
         );
-        const post = Post.createArticleFromGhostPost(account, {
+
+        const postResult = await Post.createArticleFromGhostPost(account, {
             title: 'Title',
             uuid: randomUUID(),
             html: '<p>Hello, world!</p>',
@@ -1077,6 +1104,8 @@ describe('KnexPostRepository', () => {
             visibility: 'public',
             authors: [],
         });
+
+        const post = getValue(postResult as Ok<Post>) as Post;
 
         post.addRepost(reposterAccount);
 
@@ -1239,7 +1268,7 @@ describe('KnexPostRepository', () => {
         );
         const account = await accountRepository.getBySite(site);
 
-        const post = Post.createArticleFromGhostPost(account, {
+        const postResult = await Post.createArticleFromGhostPost(account, {
             title: 'Title',
             uuid: randomUUID(),
             html: '<p>Hello, world!</p>',
@@ -1257,8 +1286,8 @@ describe('KnexPostRepository', () => {
             ],
         });
 
+        const post = getValue(postResult as Ok<Post>) as Post;
         await postRepository.save(post);
-
         const rowInDb = await client('posts')
             .where({
                 uuid: post.uuid,


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-1843

- At the moment AP is throwing 500 instead of 400 when the error Cannot create Post from private content is thrown.