### PR TITLE
Change `Invalid URL` to 400

### DIFF
--- a/features/5xx-regressions.feature
+++ b/features/5xx-regressions.feature
@@ -8,3 +8,7 @@ Feature: We do not 5xx error for previously known regressions
   Scenario: We do not throw a 5xx when we receive nested invalid @context values
     Given we are sent invalid nested @context values to the inbox
     Then we respond with a 400
+
+  Scenario: We do not throw a 5xx when we receive an invalid url
+    Given we are sent invalid url to the inbox
+    Then we respond with a 400

--- a/features/step_definitions/5xx_steps.js
+++ b/features/step_definitions/5xx_steps.js
@@ -60,6 +60,31 @@ Given(
     },
 );
 
+Given('we are sent invalid url to the inbox', async function () {
+    this.response = await fetch(
+        'http://fake-ghost-activitypub.test/.ghost/activitypub/inbox/index',
+        {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/ld+json',
+            },
+            body: JSON.stringify({
+                '@context': [
+                    'https://www.w3.org/ns/activitystreams',
+                    {
+                        alsoKnownAs: {
+                            '@id': 'as:alsoKnownAs',
+                            '@type': '@id',
+                        },
+                    },
+                ],
+                type: 'Person',
+                alsoKnownAs: 'invalid URL',
+            }),
+        },
+    );
+});
+
 Then('we respond with a {int}', function (int) {
     assert.equal(this.response.status, int);
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -1185,6 +1185,11 @@ app.onError((err, c) => {
             return BadRequest('Invalid JSON-LD');
         }
     }
+    if (err.name === 'TypeError') {
+        if (err.message === 'Invalid URL') {
+            return BadRequest('Invalid URL');
+        }
+    }
     Sentry.captureException(err);
     c.get('logger').error('{error}', { error: err });
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-1847

- At the moment AP is throwing 500 instead of 400 when the error Invalid URL is thrown.