### PR TITLE
Added `isEqual()` to uri helper

### DIFF
--- a/src/helpers/uri.ts
+++ b/src/helpers/uri.ts
@@ -21,3 +21,13 @@ export function toURL(value: unknown): URL | undefined {
         return undefined;
     }
 }
+
+/**
+ * Compares two URLs or strings for equality, normalizing them by removing trailing slashes
+ */
+export function isEqual(a: URL | string, b: URL | string): boolean {
+    if (a instanceof URL) return isEqual(a.href, b);
+    if (b instanceof URL) return isEqual(a, b.href);
+
+    return a.replace(/\/+$/, '') === b.replace(/\/+$/, '');
+}

--- a/src/helpers/uri.unit.test.ts
+++ b/src/helpers/uri.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isUri, toURL } from './uri';
+import { isEqual, isUri, toURL } from './uri';
 
 describe('isUri', () => {
     it('should return a boolean indicating if the provided string is a valid URI', () => {
@@ -26,5 +26,52 @@ describe('toURL', () => {
 
     it('should return undefined if the provided value is not a valid URI', () => {
         expect(toURL('://example.com/user/foo')).toBeUndefined();
+    });
+});
+
+describe('isEqual', () => {
+    it('should compare string URLs correctly', () => {
+        expect(isEqual('https://example.com', 'https://example.com/')).toBe(
+            true,
+        );
+        expect(isEqual('https://example.com', 'https://example.com')).toBe(
+            true,
+        );
+        expect(isEqual('https://example.com/', 'https://example.com/')).toBe(
+            true,
+        );
+        expect(isEqual('https://example.com', 'https://example.org')).toBe(
+            false,
+        );
+    });
+
+    it('should compare URL objects correctly', () => {
+        const url1 = new URL('https://example.com');
+        const url2 = new URL('https://example.com/');
+        const url3 = new URL('https://example.org');
+
+        expect(isEqual(url1, url1)).toBe(true);
+        expect(isEqual(url1, url2)).toBe(true);
+        expect(isEqual(url2, url3)).toBe(false);
+        expect(isEqual(url1, url3)).toBe(false);
+    });
+
+    it('should compare mixed URL objects and strings correctly', () => {
+        const url = new URL('https://example.com');
+
+        expect(isEqual(url, 'https://example.com/')).toBe(true);
+        expect(isEqual(url, 'https://example.org')).toBe(false);
+    });
+
+    it('should handle URLs with paths', () => {
+        expect(
+            isEqual('https://example.com/path', 'https://example.com/path/'),
+        ).toBe(true);
+        expect(
+            isEqual(
+                'https://example.com/path',
+                'https://example.com/other-path',
+            ),
+        ).toBe(false);
     });
 });

--- a/src/post/content.ts
+++ b/src/post/content.ts
@@ -2,6 +2,7 @@ import { htmlToText } from 'html-to-text';
 import linkifyHtml from 'linkify-html';
 import { parse } from 'node-html-parser';
 import { HANDLE_REGEX } from '../constants';
+import { isEqual } from '../helpers/uri';
 import type { Mention } from './post.entity';
 
 /**
@@ -221,15 +222,14 @@ export class ContentPreparer {
             const links = html.querySelectorAll('a');
 
             for (const mention of mentions) {
-                const apId = mention.account.apId
-                    .toString()
-                    .replace(/\/+$/, '');
-                const url = mention.account.url.toString().replace(/\/+$/, '');
-
                 // Find all links that matches the mentioned account
                 for (const link of links) {
-                    const href = link.getAttribute('href')?.replace(/\/+$/, '');
-                    if (href === apId || href === url) {
+                    const href = link.getAttribute('href');
+                    if (
+                        href &&
+                        (isEqual(mention.account.apId, href) ||
+                            isEqual(mention.account.url, href))
+                    ) {
                         // Update the link attributes
                         link.setAttribute(
                             'data-profile',


### PR DESCRIPTION
No ref

- Added a method that compares two URLs or strings for equality, normalising them by removing trailing slashes