### PR TITLE
Added job for cleaning up key value rows

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -388,9 +388,9 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   build-cleanup-job:
-    name: Build & Push image for cleaning up key value records
+    name: Build & Push cleanup job
     runs-on: ubuntu-latest
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout
@@ -404,7 +404,7 @@ jobs:
             cleanup:
               - 'jobs/cleanup-expired-key-value-records/**'
 
-      - name: "Authenticate with GCP"
+      - name: Authenticate with GCP
         if: steps.changes.outputs.cleanup == 'true'
         id: gcp-auth
         uses: google-github-actions/auth@v2

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -386,3 +386,55 @@ jobs:
           status: ${{ job.status }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  build-cleanup-job:
+    name: Build & Push image for cleaning up key value records
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for changes in cleanup job
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            cleanup:
+              - 'jobs/cleanup-expired-key-value-records/**'
+
+      - name: "Authenticate with GCP"
+        if: steps.changes.outputs.cleanup == 'true'
+        id: gcp-auth
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: access_token
+          workload_identity_provider: projects/687476608778/locations/global/workloadIdentityPools/github-oidc-activitypub/providers/github-provider-activitypub
+          service_account: stg-activitypub-cicd@ghost-activitypub.iam.gserviceaccount.com
+
+      - name: Login to GCP Artifact Registry
+        if: steps.changes.outputs.cleanup == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: europe-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
+      - name: Docker metadata
+        if: steps.changes.outputs.cleanup == 'true'
+        id: cleanup-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: europe-docker.pkg.dev/ghost-activitypub/activitypub/cleanup-expired-key-value-records
+          tags: |
+            type=sha
+            type=edge,branch=main
+
+      - name: Build & Push cleanup job image
+        if: steps.changes.outputs.cleanup == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: jobs/cleanup-expired-key-value-records
+          push: true
+          tags: ${{ steps.cleanup-meta.outputs.tags }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -390,7 +390,7 @@ jobs:
   build-cleanup-job:
     name: Build & Push image for cleaning up key value records
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
         condition: service_healthy
 
   cleanup-expired-key-value-records:
-    build: jobs/cleanup-expired-key_value-records
+    build: jobs/cleanup-expired-key-value-records
     environment:
       - MYSQL_USER=ghost
       - MYSQL_PASSWORD=password
@@ -167,7 +167,7 @@ services:
         condition: service_healthy
 
   cleanup-expired-key-value-records-testing:
-    build: jobs/cleanup-expired-key_value-records
+    build: jobs/cleanup-expired-key-value-records
     environment:
       - MYSQL_USER=ghost
       - MYSQL_PASSWORD=password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,15 @@ services:
       mysql:
         condition: service_healthy
 
+  cleanup-expired-key-value-records:
+    build: jobs/cleanup-expired-key_value-records
+    environment:
+      - MYSQL_USER=ghost
+      - MYSQL_PASSWORD=password
+      - MYSQL_HOST=mysql
+      - MYSQL_PORT=3306
+      - MYSQL_DATABASE=activitypub
+
   scripts:
     build: scripts
     depends_on:
@@ -156,6 +165,15 @@ services:
     depends_on:
       mysql-testing:
         condition: service_healthy
+
+  cleanup-expired-key-value-records-testing:
+    build: jobs/cleanup-expired-key_value-records
+    environment:
+      - MYSQL_USER=ghost
+      - MYSQL_PASSWORD=password
+      - MYSQL_HOST=mysql-testing
+      - MYSQL_PORT=3306
+      - MYSQL_DATABASE=activitypub
 
   cucumber-tests:
     networks:

--- a/jobs/cleanup-expired-key-value-records/Dockerfile
+++ b/jobs/cleanup-expired-key-value-records/Dockerfile
@@ -1,0 +1,5 @@
+FROM mysql:8.3
+
+COPY cleanup-expired-key-value-records /bin
+
+ENTRYPOINT ["cleanup-expired-key-value-records"]

--- a/jobs/cleanup-expired-key-value-records/cleanup-expired-key-value-records
+++ b/jobs/cleanup-expired-key-value-records/cleanup-expired-key-value-records
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+mysql \
+  --host="$MYSQL_HOST" \
+  --port="$MYSQL_PORT" \
+  --user="$MYSQL_USER" \
+  --password="$MYSQL_PASSWORD" \
+  --database="$MYSQL_DATABASE" \
+  -e "DELETE FROM key_value WHERE expires IS NOT NULL AND expires < UTC_TIMESTAMP();"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "fix": "docker compose down --rmi all activitypub activitypub-testing cucumber-tests nginx",
     "logs": "docker compose logs activitypub -f",
     "wipe-db": "docker compose down -v mysql && docker compose up -d activitypub nginx && echo 'ActivityPub DB wiped. You must restart Ghost'",
+    "cleanup-db": "docker compose run --rm cleanup-expired-key-value-records cleanup-expired-key-value-records-testing",
     "migration": "docker compose run migrate create",
     "migrate": "docker compose up migrate",
     "test:cucumber": "./docker/cucumber-tests",


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-685

We can now use `yarn run cleanup-db` to cleanup expired rows from the key_value table locally. This image will also be used as a shceduled CloudRun Job.