### PR TITLE
Supported running cleanup job on GCP

### DIFF
--- a/jobs/cleanup-expired-key-value-records/Dockerfile
+++ b/jobs/cleanup-expired-key-value-records/Dockerfile
@@ -1,8 +1,5 @@
 FROM mysql:8.3
 
-RUN curl -Lo /bin/cloud-sql-proxy https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.10.1/cloud-sql-proxy.linux.amd64
-RUN chmod +x /bin/cloud-sql-proxy
-
 COPY cleanup-expired-key-value-records /bin
 
 ENTRYPOINT ["cleanup-expired-key-value-records"]


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-685

Connecting to CloudSQL isn't done in the usual way, we need to use the cloud-sql-proxy, or a socket, or some other way of connecting. Using this proxy seemed like the easiest way to have a shared image for both local and cloud use