### PR TITLE
Removed gated content that is visible to members only

### DIFF
--- a/src/http/api/webhook.ts
+++ b/src/http/api/webhook.ts
@@ -67,9 +67,13 @@ export function createPostPublishedWebhookHandler(
         if (isError(postResult)) {
             const error = getError(postResult);
             switch (error) {
+                case 'missing-content':
+                    return BadRequest(
+                        'Error creating post: the post has no content',
+                    );
                 case 'private-content':
                     return BadRequest(
-                        'Cannot create Post from private content',
+                        'Error creating post: the post content is private',
                     );
                 default:
                     return exhaustiveCheck(error);

--- a/src/post/content.unit.test.ts
+++ b/src/post/content.unit.test.ts
@@ -11,6 +11,7 @@ describe('ContentPreparer', () => {
 
     describe('prepare', () => {
         const allOptionsDisabled = {
+            removeGatedContent: false,
             removeMemberContent: false,
             escapeHtml: false,
             convertLineBreaks: false,
@@ -19,6 +20,43 @@ describe('ContentPreparer', () => {
             addPaidContentMessage: false as const,
             addMentions: false as const,
         };
+
+        describe('Removing gated content', () => {
+            it('removes content that is visible to members only', () => {
+                const content =
+                    'Hello, world!<!--kg-gated-block:begin nonMember:false memberSegment:"status:free" --> This is visible to free members only!<!--kg-gated-block:end-->';
+                const result = preparer.prepare(content, {
+                    ...allOptionsDisabled,
+                    removeGatedContent: true,
+                });
+
+                expect(result).toEqual('Hello, world!');
+            });
+
+            it('removes content that is visible to paid members only', () => {
+                const content =
+                    'Hello, world!<!--kg-gated-block:begin nonMember:false memberSegment:"status:-free" --> This is visible to paid members only!<!--kg-gated-block:end-->';
+                const result = preparer.prepare(content, {
+                    ...allOptionsDisabled,
+                    removeGatedContent: true,
+                });
+
+                expect(result).toEqual('Hello, world!');
+            });
+
+            it('keeps content that is visible publicly but removes markers', () => {
+                const content =
+                    'Hello, world!<!--kg-gated-block:begin nonMember:true memberSegment:"" --> This is visible publicly!<!--kg-gated-block:end-->';
+                const result = preparer.prepare(content, {
+                    ...allOptionsDisabled,
+                    removeGatedContent: true,
+                });
+
+                expect(result).toEqual(
+                    'Hello, world! This is visible publicly!',
+                );
+            });
+        });
 
         describe('Removing member content', () => {
             it('should remove member content', () => {

--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -4,7 +4,7 @@ import { sanitizeHtml } from 'helpers/html';
 import type { Account } from '../account/account.entity';
 import { BaseEntity } from '../core/base.entity';
 import { parseURL } from '../core/url';
-import { ContentPreparer } from './content';
+import { ContentPreparer, type PrepareContentOptions } from './content';
 
 export enum PostType {
     Note = 0,
@@ -90,7 +90,7 @@ export function isFollowersOnlyPost(post: Post): post is FollowersOnlyPost {
     return post.audience === Audience.FollowersOnly;
 }
 
-type CreatePostError = 'private-content';
+type CreatePostError = 'private-content' | 'missing-content';
 
 export class Post extends BaseEntity {
     public readonly uuid: string;
@@ -246,15 +246,31 @@ export class Post extends BaseEntity {
 
         let content = ghostPost.html;
         let excerpt = ghostPost.excerpt;
-        if (isPublic === false && ghostPost.html !== null) {
-            content = ContentPreparer.prepare(ghostPost.html, {
+
+        const allOptionsDisabled: PrepareContentOptions = {
+            removeGatedContent: false,
+            removeMemberContent: false,
+            escapeHtml: false,
+            convertLineBreaks: false,
+            wrapInParagraph: false,
+            extractLinks: false,
+            addPaidContentMessage: false,
+            addMentions: false,
+        };
+
+        if (content === null || content === '') {
+            return error('missing-content');
+        }
+
+        content = ContentPreparer.prepare(content, {
+            ...allOptionsDisabled,
+            removeGatedContent: true,
+        });
+
+        if (isPublic === false) {
+            content = ContentPreparer.prepare(content, {
+                ...allOptionsDisabled,
                 removeMemberContent: true,
-                escapeHtml: false,
-                convertLineBreaks: false,
-                wrapInParagraph: false,
-                extractLinks: false,
-                addPaidContentMessage: false,
-                addMentions: false,
             });
 
             if (content === '') {
@@ -270,15 +286,10 @@ export class Post extends BaseEntity {
 
             // We add the paid content message _after_ so it doesn't appear in excerpt
             content = ContentPreparer.prepare(content, {
-                removeMemberContent: false,
-                escapeHtml: false,
-                convertLineBreaks: false,
-                wrapInParagraph: false,
-                extractLinks: false,
+                ...allOptionsDisabled,
                 addPaidContentMessage: {
                     url: new URL(ghostPost.url),
                 },
-                addMentions: false,
             });
         }
 
@@ -363,6 +374,7 @@ export class Post extends BaseEntity {
         }
 
         const content = ContentPreparer.prepare(noteContent, {
+            removeGatedContent: false,
             removeMemberContent: false,
             escapeHtml: true,
             convertLineBreaks: true,
@@ -434,6 +446,7 @@ export class Post extends BaseEntity {
         const threadRootId = inReplyTo.threadRoot ?? inReplyTo.id;
 
         const content = ContentPreparer.prepare(replyContent, {
+            removeGatedContent: false,
             removeMemberContent: false,
             escapeHtml: true,
             convertLineBreaks: true,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1883

- in Ghost, a publisher can create a CTA card with different visibility options: visible to public visitors, free members or paid members
- in ActivityPub, we want to display only content that is visible publicly
- this commit removes gated content that is visible to members only, as well as gated content markers (`<!--kg-gated-block:begin>...<!--kg-gated-block:end-->`)