### PR TITLE
Re-enabled staging cicd tests

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -346,17 +346,17 @@ jobs:
           labels: |-
             commit-sha=${{ github.sha }}
 
-      # - name: "Deploy Tests to Cloud Run"
-      #   if: ${{ matrix.region == 'europe-west4' }}
-      #   uses: google-github-actions/deploy-cloudrun@v2
-      #   with:
-      #     image: europe-docker.pkg.dev/ghost-activitypub/activitypub/activitypub:${{ needs.build-test-push.outputs.migrations_docker_version }}
-      #     region: ${{ matrix.region }}
-      #     job: stg-${{ matrix.region_name }}-activitypub-tests
-      #     flags: --command="yarn" --args="_test:integration" --wait --execute-now
-      #     skip_default_labels: true
-      #     labels: |-
-      #       commit-sha=${{ github.sha }}
+      - name: "Deploy Tests to Cloud Run"
+        if: ${{ matrix.region == 'europe-west4' }}
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          image: europe-docker.pkg.dev/ghost-activitypub/activitypub/activitypub:${{ needs.build-test-push.outputs.migrations_docker_version }}
+          region: ${{ matrix.region }}
+          job: stg-${{ matrix.region_name }}-activitypub-tests
+          flags: --command="yarn" --args="_test:integration" --wait --execute-now
+          skip_default_labels: true
+          labels: |-
+            commit-sha=${{ github.sha }}
 
       - name: "Deploy ActivityPub Queue to Cloud Run"
         uses: google-github-actions/deploy-cloudrun@v2

--- a/src/test/db.ts
+++ b/src/test/db.ts
@@ -35,7 +35,7 @@ export async function createTestDb() {
         `SELECT table_name FROM information_schema.tables WHERE table_schema = '${process.env.MYSQL_DATABASE}'`,
     );
 
-    // Clone each table structure
+    // Clone each table structure - GCP SQL was having issues with the `CREATE TABLE LIKE` syntax
     for (const { TABLE_NAME } of tables[0]) {
         const [createTableResult] = await systemClient.raw(
             `SHOW CREATE TABLE \`${process.env.MYSQL_DATABASE}\`.\`${TABLE_NAME}\``,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1779

- Staging `key_value` table had a missing constraint and that was
triggering errors in the cloud run job.