### PR TITLE
Added CI step to publish ActivityPub image publicly

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -132,9 +132,8 @@ jobs:
           load: true
           tags: ${{ steps.migrations-docker-metadata.outputs.tags }}
 
-      # TODO: Uncomment this when PR is ready!
-      # - name: "Run Tests"
-      #   run: yarn test
+      - name: "Run Tests"
+        run: yarn test
 
       - name: "Authenticate with GCP"
         if: github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened' || github.event.action == 'labeled' || github.event.action == 'unlabeled'))


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1662

- to facilitate self-hosting, we're publishing a Docker image for ActivityPub to a public registry (Github Container Registry)
- the public image will then be used in a Docker Compose file to run Ghost and ActivityPub services