### PR TITLE
Added `getPostsFromOutbox` function to read profile posts from outbox

### DIFF
--- a/src/http/api/account.ts
+++ b/src/http/api/account.ts
@@ -249,12 +249,24 @@ export function createGetAccountPostsHandler(
 
         // We are using the keyword 'me', if we want to get the posts of the current user
         if (handle === 'me') {
-            accountPosts = await accountPostsView.getPostsByAccount(
-                currentContextAccount.id,
-                currentContextAccount.id,
-                params.limit,
-                params.cursor,
-            );
+            const accountPostsResult =
+                await accountPostsView.getPostsFromOutbox(
+                    currentContextAccount,
+                    currentContextAccount.id,
+                    params.limit,
+                    params.cursor,
+                );
+            if (isError(accountPostsResult)) {
+                logger.error(`Error getting outbox for ${handle}`);
+                return new Response(
+                    JSON.stringify({
+                        posts: [],
+                        next: null,
+                    }),
+                    { status: 200 },
+                );
+            }
+            accountPosts = getValue(accountPostsResult);
         } else {
             const ctx = fedifyContextFactory.getFedifyContext();
             const apId = await lookupAPIdByHandle(ctx, handle);

--- a/src/http/api/views/account.posts.view.ts
+++ b/src/http/api/views/account.posts.view.ts
@@ -11,7 +11,7 @@ import { type Result, error, getValue, isError, ok } from 'core/result';
 import { sanitizeHtml } from 'helpers/html';
 import type { Knex } from 'knex';
 import { ContentPreparer } from 'post/content';
-import { type Mention, PostType } from 'post/post.entity';
+import { type Mention, OutboxType, PostType } from 'post/post.entity';
 import type { PostDTO } from '../types';
 
 export type GetPostsError =
@@ -93,13 +93,11 @@ export class AccountPostsView {
     ): Promise<Result<AccountPosts, GetPostsError>> {
         //If we found the account in our db and it's an internal account, do an internal lookup
         if (account?.isInternal) {
-            return ok(
-                await this.getPostsByAccount(
-                    account.id,
-                    currentContextAccount.id,
-                    limit,
-                    cursor,
-                ),
+            return await this.getPostsFromOutbox(
+                account,
+                currentContextAccount.id,
+                limit,
+                cursor,
             );
         }
 
@@ -112,6 +110,11 @@ export class AccountPostsView {
         );
     }
 
+    /**
+     * Get posts by account
+     *
+     * @deprecated Use getPostsFromOutbox instead
+     */
     async getPostsByAccount(
         accountId: number,
         contextAccountId: number,
@@ -284,6 +287,118 @@ export class AccountPostsView {
             ),
             nextCursor: hasMore ? lastResult.published_date : null,
         };
+    }
+
+    async getPostsFromOutbox(
+        account: Account,
+        contextAccountId: number,
+        limit: number,
+        cursor: string | null,
+    ): Promise<Result<AccountPosts, GetPostsError>> {
+        if (!account.isInternal) {
+            return error('error-getting-outbox');
+        }
+
+        const query = this.db('outboxes')
+            .select(
+                // Post fields
+                'posts.id as post_id',
+                'posts.type as post_type',
+                'posts.title as post_title',
+                'posts.excerpt as post_excerpt',
+                'posts.summary as post_summary',
+                'posts.content as post_content',
+                'posts.url as post_url',
+                'posts.image_url as post_image_url',
+                'posts.published_at as post_published_at',
+                'posts.like_count as post_like_count',
+                this.db.raw(`
+                    CASE
+                        WHEN likes.account_id IS NOT NULL THEN 1
+                        ELSE 0
+                    END AS post_liked_by_current_user
+                `),
+                'posts.reply_count as post_reply_count',
+                'posts.reading_time_minutes as post_reading_time_minutes',
+                'posts.attachments as post_attachments',
+                'posts.repost_count as post_repost_count',
+                this.db.raw(`
+                    CASE
+                        WHEN reposts.account_id IS NOT NULL THEN 1
+                        ELSE 0
+                    END AS post_reposted_by_current_user
+                `),
+                'posts.ap_id as post_ap_id',
+                // Author fields
+                'author_account.id as author_id',
+                'author_account.name as author_name',
+                'author_account.username as author_username',
+                'author_account.url as author_url',
+                'author_account.avatar_url as author_avatar_url',
+                // Reposter fields
+                'reposter_account.id as reposter_id',
+                'reposter_account.name as reposter_name',
+                'reposter_account.username as reposter_username',
+                'reposter_account.url as reposter_url',
+                'reposter_account.avatar_url as reposter_avatar_url',
+                // Outbox fields
+                'outboxes.published_at as outbox_published_at',
+                'outboxes.outbox_type as outbox_type',
+            )
+            .innerJoin('posts', 'posts.id', 'outboxes.post_id')
+            .innerJoin(
+                'accounts as author_account',
+                'author_account.id',
+                'posts.author_id',
+            )
+            .leftJoin('accounts as reposter_account', function () {
+                this.on(
+                    'reposter_account.id',
+                    '=',
+                    'outboxes.account_id',
+                ).andOnVal(
+                    'outboxes.outbox_type',
+                    '=',
+                    OutboxType.Repost.toString(),
+                );
+            })
+            .leftJoin('likes', function () {
+                this.on('likes.post_id', 'posts.id').andOnVal(
+                    'likes.account_id',
+                    '=',
+                    contextAccountId.toString(),
+                );
+            })
+            .leftJoin('reposts', function () {
+                this.on('reposts.post_id', 'posts.id').andOnVal(
+                    'reposts.account_id',
+                    '=',
+                    contextAccountId.toString(),
+                );
+            })
+            .where('outboxes.account_id', account.id)
+            .whereNot('outboxes.outbox_type', OutboxType.Reply)
+            .modify((query) => {
+                if (cursor) {
+                    query.where('outboxes.published_at', '<', cursor);
+                }
+            })
+            .orderBy('outboxes.published_at', 'desc')
+            .limit(limit + 1);
+
+        const results = await query;
+
+        const hasMore = results.length > limit;
+        const paginatedResults = results.slice(0, limit);
+        const lastResult = paginatedResults[paginatedResults.length - 1];
+
+        return ok({
+            results: paginatedResults.map((result: GetProfileDataResultRow) =>
+                this.mapToPostDTO(result, contextAccountId),
+            ),
+            nextCursor:
+                hasMore && lastResult ? lastResult.outbox_published_at : null,
+        });
     }
 
     async getPostsByRemoteLookUp(


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PROD-1879/

- Returns posts in descending order (newest first)
- Filter out replies
- Includes repost author information for reposted posts
- Adds likedByMe and repostedByMe status for the context account
- Supports pagination for posts
- The endpoint already have e2e tests [here](https://github.com/TryGhost/ActivityPub/blob/main/features/profile-posts.feature) and all of these tests pass with the new query