### PR TITLE
Clean outboxes table before e2e tests

### DIFF
--- a/features/support/db.js
+++ b/features/support/db.js
@@ -33,6 +33,7 @@ export async function reset() {
     await db('likes').truncate();
     await db('reposts').truncate();
     await db('posts').truncate();
+    await db('outboxes').truncate();
     await db('accounts').truncate();
     await db('users').truncate();
     await db('sites').truncate();


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PROD-1916/

- Adds `outboxes` table to the list of tables to clean up before each tests
- This was causing some flaky tests related to outbox