### PR TITLE
[WIP]

### DIFF
--- a/src/events/event.codec.ts
+++ b/src/events/event.codec.ts
@@ -1,0 +1,39 @@
+import { PostCreatedEvent } from 'post/post-created.event';
+import type { KnexPostRepository } from 'post/post.repository.knex';
+
+export class EventCodec {
+    constructor(private readonly postRepository: KnexPostRepository) {}
+
+    async encode(eventName: string, event: object): Promise<Buffer> {
+        if (eventName === PostCreatedEvent.getName()) {
+            if (!(event instanceof PostCreatedEvent)) {
+                throw new Error('Expected a PostCreatedEvent');
+            }
+            const data = {
+                id: event.getPost().id,
+            };
+
+            return Buffer.from(JSON.stringify(data));
+        }
+        throw new Error(`Unknown event ${eventName}`);
+    }
+
+    async decode(eventName: string, buffer: Buffer): Promise<object> {
+        let data = null;
+        try {
+            data = JSON.parse(buffer.toString('utf-8'));
+        } catch (err) {
+            throw new Error(`Could not decode event ${eventName}`);
+        }
+        if (eventName === PostCreatedEvent.getName()) {
+            const post = await this.postRepository.getByApId(data.id);
+            if (!post) {
+                throw new Error(`Could not decode event ${eventName} ${data}`);
+            }
+            const event = new PostCreatedEvent(post);
+            return event;
+        }
+
+        throw new Error(`Unknown event ${eventName}`);
+    }
+}

--- a/src/events/pubsub.events.ts
+++ b/src/events/pubsub.events.ts
@@ -1,0 +1,71 @@
+import type { PubSub } from '@google-cloud/pubsub';
+import { AsyncEvents } from 'core/events';
+import type { EventCodec } from 'events/event.codec';
+
+export class PubSubEvents extends AsyncEvents {
+    constructor(
+        private readonly pubSubClient: PubSub,
+        private readonly topicName: string,
+        private readonly eventCodec: EventCodec,
+    ) {
+        super();
+    }
+
+    private async publishMessage(
+        eventName: string,
+        event: object,
+    ): Promise<true> {
+        const data = await this.eventCodec.encode(eventName, event);
+        return new Promise((resolve, reject) => {
+            this.pubSubClient.topic(this.topicName).publishMessage(
+                {
+                    data,
+                    attributes: {
+                        event: eventName,
+                    },
+                },
+                (err) => {
+                    if (err) {
+                        reject(err);
+                    }
+                    resolve(true);
+                },
+            );
+        });
+    }
+
+    emit(eventName: string, data: object, ...args: unknown[]) {
+        // TODO: Handle promise? Disable this method?
+        this.publishMessage(eventName, data);
+        return true;
+    }
+
+    async emitAsync(eventName: string, data: object, ...args: unknown[]) {
+        return await this.publishMessage(eventName, data);
+    }
+
+    async handleIncomingMessage(message: {
+        attributes: { event: string };
+        data: string;
+    }) {
+        const handlers = this.listeners(message.attributes.event);
+        if (handlers.length === 0) {
+            return false;
+        }
+        if (handlers.length !== 1) {
+            // Maybe a warning
+        }
+        const event = await this.eventCodec.decode(
+            message.attributes.event,
+            Buffer.from(message.data, 'base64'),
+        );
+        const promises = handlers.map(async (handler) => {
+            return handler(
+                JSON.parse(
+                    Buffer.from(message.data, 'base64').toString('utf-8'),
+                ),
+            );
+        });
+        await Promise.all(promises);
+    }
+}


### PR DESCRIPTION
This was my WIP that I did get working locally at one point...

The idea is to instantiate the `PubSubEvents` and wire up the `handleIncomingMessage` to a message queue endpoint - similar to the FedifyMessage queue.

Under the hood it uses `EventCodec` to convert an event instance to serializable data, and back again. The idea here being to decouple the serialisation from the event bus.

The current implementation did all the serialisation in the `EventCodec` class - but that could be offloaded to the event itself potentially with a `toJSON` method on the event.

If we don't use entities in the event, and just id's this becomes even easier, because we don't need access to the repositories to hydrate the event from JSON.

