### PR TITLE
Ensured `next` is passed to the webfinger handler

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1238,9 +1238,9 @@ function requireRole(...roles: GhostRole[]) {
 
 app.get(
     '/.well-known/webfinger',
-    spanWrapper((ctx: AppContext) => {
+    spanWrapper((ctx: AppContext, next: Next) => {
         const handler = container.resolve('webFingerHandler');
-        return handler(ctx);
+        return handler(ctx, next);
     }),
 );
 app.post(


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1922

When we refactored to use awilix for dependency injection, the next parameter was mistakenly dropped from being passed to the webfinger handler.