### PR TITLE
Exposed pubsub push message handler

### DIFF
--- a/nginx/server.conf
+++ b/nginx/server.conf
@@ -13,6 +13,10 @@ server {
         proxy_pass http://activitypub:8080;
     }
 
+    location /pubsub/ghost/push {
+        proxy_pass http://activitypub:8080;
+    }
+
     location / {
         proxy_pass http://host.docker.internal:2368;
     }

--- a/src/app.ts
+++ b/src/app.ts
@@ -847,6 +847,22 @@ app.get('/ping', (ctx) => {
     });
 });
 
+app.post('/pubsub/ghost/push', async (ctx) => {
+    let data: unknown;
+
+    try {
+        data = await ctx.req.json();
+    } catch (err) {
+        globalLogging.error('Failed to parse JSON: {err}', { err });
+
+        return new Response(null, { status: 400 });
+    }
+
+    globalLogging.info('PubSub push received\n{data}', { data });
+
+    return new Response(null, { status: 200 });
+});
+
 /** Middleware */
 
 app.use(async (ctx, next) => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1925

Added a new HTTP handler that will handle pubsub push messages (requests to the `/pubsub/push/ghost` endpoint) in preparation for using the new message queue for processing post count background refresh commands