### PR TITLE
Reply chain pagination

### DIFF
--- a/src/http/api/views/reply.chain.view.integration.test.ts
+++ b/src/http/api/views/reply.chain.view.integration.test.ts
@@ -1,10 +1,11 @@
+import assert from 'node:assert';
 import { unsafeUnwrap } from 'core/result';
 import type { Knex } from 'knex';
 import type { Post } from 'post/post.entity';
 import { createTestDb } from 'test/db';
 import { type FixtureManager, createFixtureManager } from 'test/fixtures';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import { ReplyChainView } from './reply.chain.view';
+import { type PostRow, ReplyChainView } from './reply.chain.view';
 
 /**
  * This will setup the database with a bunch of posts centered around a single post.
@@ -186,6 +187,51 @@ describe('ReplyChainView', () => {
                 );
 
             expect(resultIds).toEqual(expectedIds);
+        });
+    });
+
+    describe('getReplyChainContinuation', () => {
+        it('should return the reply chain continuation for a post', async () => {
+            const { post, chains } = await setupPosts(fixtureManager);
+
+            const replyChainView = new ReplyChainView(db);
+
+            // @ts-expect-error Property 'getChildren' is private and only accessible within class 'ReplyChainView'
+            const children = await replyChainView.getChildren(
+                post.author.id,
+                post.id!,
+            );
+
+            const retrievedChains: PostRow[][] = [];
+            for (const child of children) {
+                if (child.post_in_reply_to === post.id) {
+                    retrievedChains.push([]);
+                } else {
+                    const lastChain =
+                        retrievedChains[retrievedChains.length - 1];
+                    lastChain.push(child);
+                }
+            }
+
+            // Minus 2 because we want the last chain with stuff in
+            const chainToTestIndex = retrievedChains.length - 2;
+
+            const chainToTest = retrievedChains[chainToTestIndex];
+
+            // We expect that we haven't got the full chain
+            assert(chainToTest.length < chains[chainToTestIndex].length);
+
+            // @ts-expect-error Property 'getReplyChainContinuation' is private and only accessible within class 'ReplyChainView'
+            const continuation = await replyChainView.getReplyChainContinuation(
+                post.author.id,
+                chainToTest[chainToTest.length - 1].post_id,
+            );
+
+            const fullRetrievedChain = chainToTest.concat(continuation);
+            const actualIds = fullRetrievedChain.map((p) => p.post_id);
+            const expectedIds = chains[chainToTestIndex].map((p) => p.id);
+
+            expect(actualIds).toEqual(expectedIds);
         });
     });
 

--- a/src/http/api/views/reply.chain.view.ts
+++ b/src/http/api/views/reply.chain.view.ts
@@ -56,7 +56,7 @@ const PostRowSchema = z.object({
     author_avatar_url: z.string().nullable(),
 });
 
-type PostRow = z.infer<typeof PostRowSchema>;
+export type PostRow = z.infer<typeof PostRowSchema>;
 
 export class ReplyChainView {
     static readonly MAX_ANCESTOR_DEPTH = 10;
@@ -293,6 +293,55 @@ export class ReplyChainView {
         );
 
         return childrenRows.map(PostRowSchema.parse);
+    }
+
+    private async getReplyChainContinuation(
+        contextAccountId: number,
+        chainRootId: number,
+    ): Promise<PostRow[]> {
+        const db = this.db;
+        const selectPostRow = this.selectPostRow(contextAccountId);
+
+        const chainRows = await selectPostRow(
+            db
+                .withRecursive('chain_ids', (qb) => {
+                    qb.select(
+                        'id',
+                        'reply_count',
+                        'in_reply_to',
+                        db.raw('0 AS depth'),
+                    )
+                        .from('posts')
+                        .where('id', chainRootId)
+                        .andWhere('reply_count', '=', 1)
+                        .unionAll(function () {
+                            this.select(
+                                'p.id',
+                                'p.reply_count',
+                                'p.in_reply_to',
+                                db.raw('ci.depth + 1'),
+                            )
+                                .from('posts as p')
+                                .join(
+                                    'chain_ids as ci',
+                                    'p.in_reply_to',
+                                    'ci.id',
+                                )
+                                .where('ci.reply_count', '=', 1)
+                                .andWhere(
+                                    'ci.depth',
+                                    '<',
+                                    ReplyChainView.MAX_CHILDREN_DEPTH + 2,
+                                );
+                        });
+                })
+                .from('chain_ids')
+                .where('depth', '>', 0)
+                .orderBy('depth', 'asc')
+                .join('posts', 'posts.id', 'chain_ids.id'),
+        );
+
+        return chainRows.map(PostRowSchema.parse);
     }
 
     public async getReplyChain(


### PR DESCRIPTION
This provides the underlying methods to fetch the paginated data we'll need, but doesn't wire them up to the API yet.

We have the need for paginating on 3 lists:
1. Getting more ancestors, which can be done with the existing `getAncestors` method
2. Getting more children, which we've implemented here with a cursor in the existing query
3. Getting more replies in a chain, which we've implemented here as a new query