### PR TITLE
Added support for the `next` param when reading replies

### DIFF
--- a/src/http/api/reply-chain.ts
+++ b/src/http/api/reply-chain.ts
@@ -12,6 +12,7 @@ export class ReplyChainController {
         const replyChainResult = await this.replyChainView.getReplyChain(
             account.id,
             new URL(ctx.req.param('post_ap_id')),
+            ctx.req.query('next'),
         );
 
         if (isError(replyChainResult)) {

--- a/src/http/api/views/reply.chain.view.ts
+++ b/src/http/api/views/reply.chain.view.ts
@@ -347,6 +347,7 @@ export class ReplyChainView {
     public async getReplyChain(
         accountId: number,
         postApId: URL,
+        cursor?: string,
     ): Promise<Result<ReplyChain, ReplyChainError>> {
         const selectPostRow = this.selectPostRow(accountId);
         const exists = await selectPostRow(
@@ -368,25 +369,40 @@ export class ReplyChainView {
         const childrenAndChains = await this.getChildren(
             accountId,
             currentPost.post_id,
+            cursor,
         );
 
-        const children: {
+        const allChildren: {
             post: PostDTO;
             chain: PostDTO[];
             next: string | null;
         }[] = [];
         for (const post of childrenAndChains) {
             if (post.post_in_reply_to === currentPost.post_id) {
-                children.push({
+                allChildren.push({
                     post: this.mapToPostDTO(post, accountId),
                     chain: [],
                     next: null,
                 });
             } else {
-                const current = children[children.length - 1];
+                const current = allChildren[allChildren.length - 1];
                 current.chain.push(this.mapToPostDTO(post, accountId));
             }
         }
+
+        const hasMoreChildren =
+            allChildren.length > ReplyChainView.MAX_CHILDREN_COUNT;
+
+        const children = allChildren
+            .slice(0, ReplyChainView.MAX_CHILDREN_COUNT)
+            .map((child) => ({
+                post: child.post,
+                chain: child.chain.slice(0, ReplyChainView.MAX_CHILDREN_DEPTH),
+                next:
+                    child.chain.length > ReplyChainView.MAX_CHILDREN_DEPTH
+                        ? 'TODO'
+                        : null,
+            }));
 
         return ok({
             ancestors: {
@@ -394,23 +410,10 @@ export class ReplyChainView {
                 next: ancestors[0]?.post_in_reply_to !== null ? 'TODO' : null,
             },
             post: this.mapToPostDTO(currentPost, accountId),
-            children: children
-                .slice(0, ReplyChainView.MAX_CHILDREN_COUNT)
-                .map((child) => ({
-                    post: child.post,
-                    chain: child.chain.slice(
-                        0,
-                        ReplyChainView.MAX_CHILDREN_DEPTH,
-                    ),
-                    next:
-                        child.chain.length > ReplyChainView.MAX_CHILDREN_DEPTH
-                            ? 'TODO'
-                            : null,
-                })),
-            next:
-                children.length > ReplyChainView.MAX_CHILDREN_COUNT
-                    ? 'TODO'
-                    : null,
+            children,
+            next: hasMoreChildren
+                ? children[children.length - 1].post.publishedAt.toISOString()
+                : null,
         });
     }
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1945

This just forwards on the `next` param to `getReplyChain` as well as exposes the `next` param based off of the published_at property.