### PR TITLE
Added logic to trigger interaction count update, when an update is due

### DIFF
--- a/src/post/post-interaction-counts.service.ts
+++ b/src/post/post-interaction-counts.service.ts
@@ -53,9 +53,9 @@ export class PostInteractionCountsService {
     }
 
     /**
-     * Computes whether the post is due an update of like/repost counts.
+     * Computes whether the post is due an update of like/repost counts,
+     * based on the following rules:
      *
-     * @table
      * | Post published       | Refresh interaction counts       |
      * |----------------------|----------------------------------|
      * | < 6 hours ago        | At most once every 10 minutes    |
@@ -73,26 +73,31 @@ export class PostInteractionCountsService {
             lastUpdate = publishedAt;
         }
 
-        const timeSinceLastUpdate = new Date().getTime() - lastUpdate.getTime();
-        const timeSincePublished = new Date().getTime() - publishedAt.getTime();
+        const now = new Date().getTime();
+        const timeSinceLastUpdate = now - lastUpdate.getTime();
+        const timeSincePublished = now - publishedAt.getTime();
 
-        const sixHours = 6 * 60 * 60 * 1000;
-        const tenMinutes = 10 * 60 * 1000;
-        if (timeSincePublished < sixHours) {
-            return timeSinceLastUpdate > tenMinutes;
+        const MINUTE = 60 * 1000;
+        const HOUR = 60 * MINUTE;
+        const DAY = 24 * HOUR;
+        const WEEK = 7 * DAY;
+
+        const TEN_MINUTES = 10 * MINUTE;
+        const TWO_HOURS = 2 * HOUR;
+        const SIX_HOURS = 6 * HOUR;
+
+        if (timeSincePublished < SIX_HOURS) {
+            return timeSinceLastUpdate > TEN_MINUTES;
         }
 
-        const oneDay = 24 * 60 * 60 * 1000;
-        const twoHours = 2 * 60 * 60 * 1000;
-        if (timeSincePublished < oneDay) {
-            return timeSinceLastUpdate > twoHours;
+        if (timeSincePublished < DAY) {
+            return timeSinceLastUpdate > TWO_HOURS;
         }
 
-        const oneWeek = 7 * 24 * 60 * 60 * 1000;
-        if (timeSincePublished < oneWeek) {
-            return timeSinceLastUpdate > sixHours;
+        if (timeSincePublished < WEEK) {
+            return timeSinceLastUpdate > SIX_HOURS;
         }
 
-        return timeSinceLastUpdate > oneDay;
+        return timeSinceLastUpdate > DAY;
     }
 }

--- a/src/post/post-interaction-counts.service.ts
+++ b/src/post/post-interaction-counts.service.ts
@@ -1,0 +1,98 @@
+import type { Logger } from '@logtape/logtape';
+import { getError, isError } from 'core/result';
+import type { KnexPostRepository } from './post.repository.knex';
+import type { PostService } from './post.service';
+
+export class PostInteractionCountsService {
+    constructor(
+        private readonly postService: PostService,
+        private readonly postRepository: KnexPostRepository,
+        private logger: Logger,
+    ) {}
+
+    /**
+     * Updates the interaction counts for the given post IDs, if the update is due.
+     *
+     * @param {number[]} postIds - The IDs of the posts to update
+     */
+    async updateInteractionCounts(postIds: number[]) {
+        for (const postId of postIds) {
+            const post = await this.postRepository.getById(postId);
+
+            if (!post) {
+                this.logger.error(
+                    'Post with ID {postId} not found when updating interaction counts - Skipping',
+                    { postId },
+                );
+                continue;
+            }
+
+            if (!this.isUpdateDue(post.publishedAt, post.updatedAt)) {
+                this.logger.info(
+                    'Post with ID {postId} is not due for an update of interaction counts - Skipping',
+                    { postId },
+                );
+                continue;
+            }
+
+            const result = await this.postService.updateInteractionCounts(post);
+
+            if (isError(result)) {
+                this.logger.error(
+                    'Error updating interaction counts for post with ID {postId}: {error}',
+                    { postId, error: getError(result) },
+                );
+                continue;
+            }
+
+            this.logger.info(
+                'Successfully updated interaction counts for post with ID {postId}',
+                { postId },
+            );
+        }
+    }
+
+    /**
+     * Computes whether the post is due an update of like/repost counts.
+     *
+     * @table
+     * | Post published       | Refresh interaction counts       |
+     * |----------------------|----------------------------------|
+     * | < 6 hours ago        | At most once every 10 minutes    |
+     * | 6–24 hours ago       | At most once every 2 hours       |
+     * | 1-7 days ago         | At most once every 6 hours       |
+     * | > 7 days ago         | At most once per day             |
+     *
+     * @param {Date} publishedAt - The date and time the post was published
+     * @param {Date|null} updatedAt - The date and time the post was last updated
+     * @returns {boolean}
+     */
+    private isUpdateDue(publishedAt: Date, updatedAt: Date | null): boolean {
+        let lastUpdate = updatedAt;
+        if (lastUpdate === null) {
+            lastUpdate = publishedAt;
+        }
+
+        const timeSinceLastUpdate = new Date().getTime() - lastUpdate.getTime();
+        const timeSincePublished = new Date().getTime() - publishedAt.getTime();
+
+        const sixHours = 6 * 60 * 60 * 1000;
+        const tenMinutes = 10 * 60 * 1000;
+        if (timeSincePublished < sixHours) {
+            return timeSinceLastUpdate > tenMinutes;
+        }
+
+        const oneDay = 24 * 60 * 60 * 1000;
+        const twoHours = 2 * 60 * 60 * 1000;
+        if (timeSincePublished < oneDay) {
+            return timeSinceLastUpdate > twoHours;
+        }
+
+        const oneWeek = 7 * 24 * 60 * 60 * 1000;
+        if (timeSincePublished < oneWeek) {
+            return timeSinceLastUpdate > sixHours;
+        }
+
+        return timeSinceLastUpdate > oneDay;
+    }
+}

--- a/src/post/post-interaction-counts.service.unit.test.ts
+++ b/src/post/post-interaction-counts.service.unit.test.ts
@@ -105,11 +105,11 @@ describe('PostInteractionCountsService', () => {
             vi.clearAllMocks();
 
             // Second call with updatedAt 5 minutes ago - should skip
-            const fiveMinutesAgo = new Date(now - 5 * MINUTE);
+            const updatedAt = new Date(now - 5 * MINUTE);
             post = {
                 id: postId,
                 publishedAt,
-                updatedAt: fiveMinutesAgo,
+                updatedAt,
             } as Post;
 
             vi.mocked(mockPostRepository.getById).mockResolvedValue(post);

--- a/src/post/post-interaction-counts.service.unit.test.ts
+++ b/src/post/post-interaction-counts.service.unit.test.ts
@@ -31,6 +31,10 @@ describe('PostInteractionCountsService', () => {
     });
 
     describe('updateInteractionCounts', () => {
+        const MINUTE = 60 * 1000;
+        const HOUR = 60 * MINUTE;
+        const DAY = 24 * HOUR;
+
         it('skips updating interaction counts if post is not found and logs an error', async () => {
             const postId = 999;
             vi.mocked(mockPostRepository.getById).mockResolvedValue(null);
@@ -48,8 +52,9 @@ describe('PostInteractionCountsService', () => {
 
         it('logs an error if updating interaction counts fails', async () => {
             const postId = 1;
-            const publishedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
-            const updatedAt = new Date(Date.now() - 15 * 60 * 1000);
+            const now = Date.now();
+            const publishedAt = new Date(now - 2 * HOUR);
+            const updatedAt = new Date(now - 15 * MINUTE);
             const post = {
                 id: postId,
                 publishedAt,
@@ -71,8 +76,8 @@ describe('PostInteractionCountsService', () => {
 
         it('does not update a post published less than 6 hours ago more than once every 10 minutes', async () => {
             const postId = 1;
-            const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
-            const publishedAt = twoHoursAgo;
+            const now = Date.now();
+            const publishedAt = new Date(now - 2 * HOUR);
 
             // First call with updatedAt null - should update
             let post = {
@@ -100,7 +105,7 @@ describe('PostInteractionCountsService', () => {
             vi.clearAllMocks();
 
             // Second call with updatedAt 5 minutes ago - should skip
-            const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
+            const fiveMinutesAgo = new Date(now - 5 * MINUTE);
             post = {
                 id: postId,
                 publishedAt,
@@ -122,14 +127,15 @@ describe('PostInteractionCountsService', () => {
 
         it('does not update a post published between 6-24 hours ago more than once every 2 hours', async () => {
             const postId = 1;
-            const publishedAt = new Date(Date.now() - 12 * 60 * 60 * 1000); // 12 hours ago
+            const now = Date.now();
+            const publishedAt = new Date(now - 12 * HOUR);
 
             // First call with updatedAt more than 2 hours ago - should update
-            const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000);
+            let updatedAt = new Date(now - 3 * HOUR);
             let post = {
                 id: postId,
                 publishedAt,
-                updatedAt: threeHoursAgo,
+                updatedAt,
             } as Post;
 
             vi.mocked(mockPostRepository.getById).mockResolvedValue(post);
@@ -151,11 +157,11 @@ describe('PostInteractionCountsService', () => {
             vi.clearAllMocks();
 
             // Second call with updatedAt 1 hour ago - should skip
-            const oneHourAgo = new Date(Date.now() - 1 * 60 * 60 * 1000);
+            updatedAt = new Date(now - 1 * HOUR);
             post = {
                 id: postId,
                 publishedAt,
-                updatedAt: oneHourAgo,
+                updatedAt,
             } as Post;
 
             vi.mocked(mockPostRepository.getById).mockResolvedValue(post);
@@ -173,14 +179,15 @@ describe('PostInteractionCountsService', () => {
 
         it('does not update a post published between 1-7 days ago more than once every 6 hours', async () => {
             const postId = 1;
-            const publishedAt = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000); // 3 days ago
+            const now = Date.now();
+            const publishedAt = new Date(now - 3 * DAY);
 
             // First call with updatedAt more than 6 hours ago - should update
-            const sevenHoursAgo = new Date(Date.now() - 7 * 60 * 60 * 1000);
+            let updatedAt = new Date(now - 7 * HOUR);
             let post = {
                 id: postId,
                 publishedAt,
-                updatedAt: sevenHoursAgo,
+                updatedAt,
             } as Post;
 
             vi.mocked(mockPostRepository.getById).mockResolvedValue(post);
@@ -202,11 +209,12 @@ describe('PostInteractionCountsService', () => {
             vi.clearAllMocks();
 
             // Second call with updatedAt 4 hours ago - should skip
-            const fourHoursAgo = new Date(Date.now() - 4 * 60 * 60 * 1000);
+            updatedAt = new Date(now - 4 * HOUR);
+
             post = {
                 id: postId,
                 publishedAt,
-                updatedAt: fourHoursAgo,
+                updatedAt,
             } as Post;
 
             vi.mocked(mockPostRepository.getById).mockResolvedValue(post);
@@ -224,16 +232,15 @@ describe('PostInteractionCountsService', () => {
 
         it('does not update a post published more than 7 days ago more than once a day', async () => {
             const postId = 1;
-            const publishedAt = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000); // 10 days ago
+            const now = Date.now();
+            const publishedAt = new Date(now - 10 * DAY);
 
             // First call with updatedAt more than 24 hours ago - should update
-            const twentyFiveHoursAgo = new Date(
-                Date.now() - 25 * 60 * 60 * 1000,
-            );
+            let updatedAt = new Date(now - 25 * HOUR);
             let post = {
                 id: postId,
                 publishedAt,
-                updatedAt: twentyFiveHoursAgo,
+                updatedAt,
             } as Post;
 
             vi.mocked(mockPostRepository.getById).mockResolvedValue(post);
@@ -255,11 +262,11 @@ describe('PostInteractionCountsService', () => {
             vi.clearAllMocks();
 
             // Second call with updatedAt 12 hours ago - should skip
-            const twelveHoursAgo = new Date(Date.now() - 12 * 60 * 60 * 1000);
+            updatedAt = new Date(now - 12 * HOUR);
             post = {
                 id: postId,
                 publishedAt,
-                updatedAt: twelveHoursAgo,
+                updatedAt,
             } as Post;
 
             vi.mocked(mockPostRepository.getById).mockResolvedValue(post);

--- a/src/post/post-interaction-counts.service.unit.test.ts
+++ b/src/post/post-interaction-counts.service.unit.test.ts
@@ -1,0 +1,278 @@
+import type { Logger } from '@logtape/logtape';
+import { error, ok } from 'core/result';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PostInteractionCountsService } from './post-interaction-counts.service';
+import type { Post } from './post.entity';
+import type { KnexPostRepository } from './post.repository.knex';
+import type { PostService } from './post.service';
+
+describe('PostInteractionCountsService', () => {
+    let service: PostInteractionCountsService;
+    let mockPostService: PostService;
+    let mockPostRepository: KnexPostRepository;
+    let mockLogger: Logger;
+
+    beforeEach(() => {
+        mockPostService = {
+            updateInteractionCounts: vi.fn(),
+        } as unknown as PostService;
+        mockPostRepository = {
+            getById: vi.fn(),
+        } as unknown as KnexPostRepository;
+        mockLogger = {
+            info: vi.fn(),
+            error: vi.fn(),
+        } as unknown as Logger;
+        service = new PostInteractionCountsService(
+            mockPostService,
+            mockPostRepository,
+            mockLogger,
+        );
+    });
+
+    describe('updateInteractionCounts', () => {
+        it('skips updating interaction counts if post is not found and logs an error', async () => {
+            const postId = 999;
+            vi.mocked(mockPostRepository.getById).mockResolvedValue(null);
+
+            await service.updateInteractionCounts([postId]);
+
+            expect(
+                mockPostService.updateInteractionCounts,
+            ).not.toHaveBeenCalled();
+            expect(mockLogger.error).toHaveBeenCalledWith(
+                'Post with ID {postId} not found when updating interaction counts - Skipping',
+                { postId },
+            );
+        });
+
+        it('logs an error if updating interaction counts fails', async () => {
+            const postId = 1;
+            const publishedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+            const updatedAt = new Date(Date.now() - 15 * 60 * 1000);
+            const post = {
+                id: postId,
+                publishedAt,
+                updatedAt,
+            } as Post;
+
+            vi.mocked(mockPostRepository.getById).mockResolvedValue(post);
+            vi.mocked(
+                mockPostService.updateInteractionCounts,
+            ).mockResolvedValue(error('upstream-error'));
+
+            await service.updateInteractionCounts([postId]);
+
+            expect(mockLogger.error).toHaveBeenCalledWith(
+                'Error updating interaction counts for post with ID {postId}: {error}',
+                { postId, error: 'upstream-error' },
+            );
+        });
+
+        it('does not update a post published less than 6 hours ago more than once every 10 minutes', async () => {
+            const postId = 1;
+            const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+            const publishedAt = twoHoursAgo;
+
+            // First call with updatedAt null - should update
+            let post = {
+                id: postId,
+                publishedAt,
+                updatedAt: null,
+            } as Post;
+
+            vi.mocked(mockPostRepository.getById).mockResolvedValue(post);
+            vi.mocked(
+                mockPostService.updateInteractionCounts,
+            ).mockResolvedValue(ok(post));
+
+            await service.updateInteractionCounts([postId]);
+
+            expect(
+                mockPostService.updateInteractionCounts,
+            ).toHaveBeenCalledWith(post);
+            expect(mockLogger.info).toHaveBeenCalledWith(
+                'Successfully updated interaction counts for post with ID {postId}',
+                { postId },
+            );
+
+            // Reset mocks for second call
+            vi.clearAllMocks();
+
+            // Second call with updatedAt 5 minutes ago - should skip
+            const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
+            post = {
+                id: postId,
+                publishedAt,
+                updatedAt: fiveMinutesAgo,
+            } as Post;
+
+            vi.mocked(mockPostRepository.getById).mockResolvedValue(post);
+
+            await service.updateInteractionCounts([postId]);
+
+            expect(
+                mockPostService.updateInteractionCounts,
+            ).not.toHaveBeenCalled();
+            expect(mockLogger.info).toHaveBeenCalledWith(
+                'Post with ID {postId} is not due for an update of interaction counts - Skipping',
+                { postId },
+            );
+        });
+
+        it('does not update a post published between 6-24 hours ago more than once every 2 hours', async () => {
+            const postId = 1;
+            const publishedAt = new Date(Date.now() - 12 * 60 * 60 * 1000); // 12 hours ago
+
+            // First call with updatedAt more than 2 hours ago - should update
+            const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000);
+            let post = {
+                id: postId,
+                publishedAt,
+                updatedAt: threeHoursAgo,
+            } as Post;
+
+            vi.mocked(mockPostRepository.getById).mockResolvedValue(post);
+            vi.mocked(
+                mockPostService.updateInteractionCounts,
+            ).mockResolvedValue(ok(post));
+
+            await service.updateInteractionCounts([postId]);
+
+            expect(
+                mockPostService.updateInteractionCounts,
+            ).toHaveBeenCalledWith(post);
+            expect(mockLogger.info).toHaveBeenCalledWith(
+                'Successfully updated interaction counts for post with ID {postId}',
+                { postId },
+            );
+
+            // Reset mocks for second call
+            vi.clearAllMocks();
+
+            // Second call with updatedAt 1 hour ago - should skip
+            const oneHourAgo = new Date(Date.now() - 1 * 60 * 60 * 1000);
+            post = {
+                id: postId,
+                publishedAt,
+                updatedAt: oneHourAgo,
+            } as Post;
+
+            vi.mocked(mockPostRepository.getById).mockResolvedValue(post);
+
+            await service.updateInteractionCounts([postId]);
+
+            expect(
+                mockPostService.updateInteractionCounts,
+            ).not.toHaveBeenCalled();
+            expect(mockLogger.info).toHaveBeenCalledWith(
+                'Post with ID {postId} is not due for an update of interaction counts - Skipping',
+                { postId },
+            );
+        });
+
+        it('does not update a post published between 1-7 days ago more than once every 6 hours', async () => {
+            const postId = 1;
+            const publishedAt = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000); // 3 days ago
+
+            // First call with updatedAt more than 6 hours ago - should update
+            const sevenHoursAgo = new Date(Date.now() - 7 * 60 * 60 * 1000);
+            let post = {
+                id: postId,
+                publishedAt,
+                updatedAt: sevenHoursAgo,
+            } as Post;
+
+            vi.mocked(mockPostRepository.getById).mockResolvedValue(post);
+            vi.mocked(
+                mockPostService.updateInteractionCounts,
+            ).mockResolvedValue(ok(post));
+
+            await service.updateInteractionCounts([postId]);
+
+            expect(
+                mockPostService.updateInteractionCounts,
+            ).toHaveBeenCalledWith(post);
+            expect(mockLogger.info).toHaveBeenCalledWith(
+                'Successfully updated interaction counts for post with ID {postId}',
+                { postId },
+            );
+
+            // Reset mocks for second call
+            vi.clearAllMocks();
+
+            // Second call with updatedAt 4 hours ago - should skip
+            const fourHoursAgo = new Date(Date.now() - 4 * 60 * 60 * 1000);
+            post = {
+                id: postId,
+                publishedAt,
+                updatedAt: fourHoursAgo,
+            } as Post;
+
+            vi.mocked(mockPostRepository.getById).mockResolvedValue(post);
+
+            await service.updateInteractionCounts([postId]);
+
+            expect(
+                mockPostService.updateInteractionCounts,
+            ).not.toHaveBeenCalled();
+            expect(mockLogger.info).toHaveBeenCalledWith(
+                'Post with ID {postId} is not due for an update of interaction counts - Skipping',
+                { postId },
+            );
+        });
+
+        it('does not update a post published more than 7 days ago more than once a day', async () => {
+            const postId = 1;
+            const publishedAt = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000); // 10 days ago
+
+            // First call with updatedAt more than 24 hours ago - should update
+            const twentyFiveHoursAgo = new Date(
+                Date.now() - 25 * 60 * 60 * 1000,
+            );
+            let post = {
+                id: postId,
+                publishedAt,
+                updatedAt: twentyFiveHoursAgo,
+            } as Post;
+
+            vi.mocked(mockPostRepository.getById).mockResolvedValue(post);
+            vi.mocked(
+                mockPostService.updateInteractionCounts,
+            ).mockResolvedValue(ok(post));
+
+            await service.updateInteractionCounts([postId]);
+
+            expect(
+                mockPostService.updateInteractionCounts,
+            ).toHaveBeenCalledWith(post);
+            expect(mockLogger.info).toHaveBeenCalledWith(
+                'Successfully updated interaction counts for post with ID {postId}',
+                { postId },
+            );
+
+            // Reset mocks for second call
+            vi.clearAllMocks();
+
+            // Second call with updatedAt 12 hours ago - should skip
+            const twelveHoursAgo = new Date(Date.now() - 12 * 60 * 60 * 1000);
+            post = {
+                id: postId,
+                publishedAt,
+                updatedAt: twelveHoursAgo,
+            } as Post;
+
+            vi.mocked(mockPostRepository.getById).mockResolvedValue(post);
+
+            await service.updateInteractionCounts([postId]);
+
+            expect(
+                mockPostService.updateInteractionCounts,
+            ).not.toHaveBeenCalled();
+            expect(mockLogger.info).toHaveBeenCalledWith(
+                'Post with ID {postId} is not due for an update of interaction counts - Skipping',
+                { postId },
+            );
+        });
+    });
+});

--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -134,6 +134,7 @@ export class Post extends BaseEntity {
         public readonly attachments: PostAttachment[] = [],
         apId: URL | null = null,
         _deleted = false,
+        public readonly updatedAt: Date | null = null,
     ) {
         super(id);
         if (uuid === null) {

--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -290,6 +290,7 @@ export class KnexPostRepository {
                 'posts.in_reply_to',
                 'posts.thread_root',
                 'posts.deleted_at',
+                'posts.updated_at',
                 // Author account fields
                 'accounts.id as author_id',
                 'accounts.username',
@@ -397,6 +398,7 @@ export class KnexPostRepository {
                 attachments,
                 new URL(row.ap_id),
                 row.deleted_at !== null,
+                row.updated_at ? new Date(row.updated_at) : null,
             );
 
             if (post.id) {

--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -52,6 +52,7 @@ export class KnexPostRepository {
                 'posts.thread_root',
                 'posts.deleted_at',
                 'posts.metadata',
+                'posts.updated_at',
                 'accounts.id as author_id',
                 'accounts.username',
                 'accounts.uuid as author_uuid',
@@ -131,6 +132,7 @@ export class KnexPostRepository {
             attachments,
             new URL(row.ap_id),
             row.deleted_at !== null,
+            row.updated_at ? new Date(row.updated_at) : null,
         );
 
         if (post.id) {

--- a/src/post/post.service.integration.test.ts
+++ b/src/post/post.service.integration.test.ts
@@ -626,7 +626,7 @@ describe('PostService', () => {
                 await fixtureManager.createInternalAccount();
             const post = await fixtureManager.createPost(author);
 
-            const result = await postService.updateInteractionCounts(post.id!);
+            const result = await postService.updateInteractionCounts(post);
 
             expect(isError(result)).toBe(true);
             expect(getError(result as Err<string>)).toBe('post-is-internal');
@@ -636,7 +636,7 @@ describe('PostService', () => {
             const author = await fixtureManager.createExternalAccount();
             const post = await fixtureManager.createPost(author);
 
-            const result = await postService.updateInteractionCounts(post.id!);
+            const result = await postService.updateInteractionCounts(post);
 
             expect(isError(result)).toBe(true);
             expect(getError(result as Err<string>)).toBe('upstream-error');
@@ -656,6 +656,8 @@ describe('PostService', () => {
             await postService.likePost(likeAccount2, post);
             await postService.repostByApId(repostAccount, post.apId);
 
+            const updatedPost = await postRepository.getById(post.id!);
+
             // Set up spies on the post methods
             const setLikeCountSpy = vi.spyOn(post, 'setLikeCount');
             const setRepostCountSpy = vi.spyOn(post, 'setRepostCount');
@@ -672,7 +674,7 @@ describe('PostService', () => {
                     }),
                 }),
             );
-            const result = await postService.updateInteractionCounts(post.id!);
+            const result = await postService.updateInteractionCounts(updatedPost!);
 
             expect(isError(result)).toBe(false);
             expect(setLikeCountSpy).not.toHaveBeenCalled();
@@ -699,6 +701,8 @@ describe('PostService', () => {
             await postService.likePost(likeAccount2, post);
             await postService.repostByApId(repostAccount, post.apId);
 
+            const updatedPost = await postRepository.getById(post.id!);
+
             // Now update interactions counts (there is one more like and one less repost)
             vi.mocked(lookupObject).mockResolvedValue(
                 new Note({
@@ -711,7 +715,7 @@ describe('PostService', () => {
                     }),
                 }),
             );
-            const result = await postService.updateInteractionCounts(post.id!);
+            const result = await postService.updateInteractionCounts(updatedPost!);
 
             expect(isError(result)).toBe(false);
 

--- a/src/post/post.service.integration.test.ts
+++ b/src/post/post.service.integration.test.ts
@@ -674,7 +674,9 @@ describe('PostService', () => {
                     }),
                 }),
             );
-            const result = await postService.updateInteractionCounts(updatedPost!);
+            const result = await postService.updateInteractionCounts(
+                updatedPost!,
+            );
 
             expect(isError(result)).toBe(false);
             expect(setLikeCountSpy).not.toHaveBeenCalled();
@@ -715,7 +717,9 @@ describe('PostService', () => {
                     }),
                 }),
             );
-            const result = await postService.updateInteractionCounts(updatedPost!);
+            const result = await postService.updateInteractionCounts(
+                updatedPost!,
+            );
 
             expect(isError(result)).toBe(false);
 

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -425,14 +425,8 @@ export class PostService {
     }
 
     async updateInteractionCounts(
-        postId: number,
+        post: Post,
     ): Promise<Result<Post, UpdateInteractionCountsError>> {
-        const post = await this.postRepository.getById(postId);
-
-        if (!post) {
-            return error('post-not-found');
-        }
-
         if (post.isInternal) {
             return error('post-is-internal');
         }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-699

- for remote posts, we want to update interactions counts:
    - if they're actively rendered in feeds
    - at a lower frequency for older posts
    
- the update frequency is based on when the post was published:

| Post published            | Refresh interaction counts           |
|----------------------|----------------------------------|
| < 6 hours ago             | At most once every 10 minutes    |
| 6–24 hours ago          | At most once every 2 hours         |
| 1-7 days ago               | At most once every 6 hours         |
| > 7 days ago               | At most once per day                    |