### PR TITLE
Filtered on `ap_id_hash` instead of `ap_id`

### DIFF
--- a/src/http/api/views/reply.chain.view.ts
+++ b/src/http/api/views/reply.chain.view.ts
@@ -116,7 +116,9 @@ export class ReplyChainView {
                 .withRecursive('ancestor_ids', (qb) => {
                     qb.select('id', 'in_reply_to', db.raw('0 AS depth'))
                         .from('posts')
-                        .where('ap_id', postApId.href)
+                        .whereRaw('posts.ap_id_hash = UNHEX(SHA2(?, 256))', [
+                            postApId.href,
+                        ])
                         .unionAll(function () {
                             this.select(
                                 'p.id',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1969

The `ap_id` column is not indexed, which means we need to do a full table scan when filtering on it, which kills performance. Instead we have the `ap_id_hash` column for this filter, which is indexed.

Running the original query in production takes ~1s, this one takes ~0.2ms