### PR TITLE
Replaced `next` with `hasMore` for ancestors & reply chains

### DIFF
--- a/src/http/api/views/reply.chain.view.ts
+++ b/src/http/api/views/reply.chain.view.ts
@@ -7,13 +7,13 @@ import type { PostDTO } from '../types';
 export type ReplyChain = {
     ancestors: {
         chain: PostDTO[];
-        next: string | null;
+        hasMore: boolean;
     };
     post: PostDTO;
     children: {
         post: PostDTO;
         chain: PostDTO[];
-        next: string | null;
+        hasMore: boolean;
     }[];
     next: string | null;
 };
@@ -400,16 +400,13 @@ export class ReplyChainView {
             .map((child) => ({
                 post: child.post,
                 chain: child.chain.slice(0, ReplyChainView.MAX_CHILDREN_DEPTH),
-                next:
-                    child.chain.length > ReplyChainView.MAX_CHILDREN_DEPTH
-                        ? 'TODO'
-                        : null,
+                hasMore: child.chain.length > ReplyChainView.MAX_CHILDREN_DEPTH,
             }));
 
         return ok({
             ancestors: {
                 chain: ancestors.map(this.mapToPostDTO),
-                next: ancestors[0]?.post_in_reply_to !== null ? 'TODO' : null,
+                hasMore: ancestors[0]?.post_in_reply_to !== null,
             },
             post: this.mapToPostDTO(currentPost, accountId),
             children,


### PR DESCRIPTION
We're not using a new APi to fetch more ancestors or reply chain depth, instead we're using the existing API and just starting at a different point, higher or lower in the chain. Because of this the concept of `next` doesn't make sense - it's not a parameter we can pass. Instead we're going to use a `hasMore` property which indicates to the client if it's worth fetching more data.

We didn't end up needing separate API's to fetch more ancestors/reply chains, as we can just use the existing API