### PR TITLE
Removed unused PubSub topic deploys from CI

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -306,8 +306,7 @@ jobs:
           export TF_VAR_primary_region_name=netherlands
           export TF_VAR_migrations_image=europe-docker.pkg.dev/ghost-activitypub/activitypub/migrations:pr-${{ github.event.pull_request.number }}
           export TF_VAR_api_image=europe-docker.pkg.dev/ghost-activitypub/activitypub/activitypub:pr-${{ github.event.pull_request.number }}
-          export TF_VAR_fedify_queue_image=europe-docker.pkg.dev/ghost-activitypub/activitypub/activitypub:pr-${{ github.event.pull_request.number }}
-          export TF_VAR_ghost_queue_image=europe-docker.pkg.dev/ghost-activitypub/activitypub/activitypub:pr-${{ github.event.pull_request.number }}
+          export TF_VAR_queue_image=europe-docker.pkg.dev/ghost-activitypub/activitypub/activitypub:pr-${{ github.event.pull_request.number }}
           terraform apply -auto-approve
 
       - name: "Deploy Migrations to Cloud Run"
@@ -440,26 +439,6 @@ jobs:
           labels: |-
             commit-sha=${{ github.sha }}
 
-      - name: "Deploy ActivityPub Fedify Queue to Cloud Run"
-        uses: google-github-actions/deploy-cloudrun@v2
-        with:
-          image: europe-docker.pkg.dev/ghost-activitypub/activitypub/activitypub:${{ needs.build-test-push.outputs.activitypub_docker_version }}
-          region: ${{ matrix.region }}
-          service: stg-${{ matrix.region_name }}-activitypub-fedify-queue
-          skip_default_labels: true
-          labels: |-
-            commit-sha=${{ github.sha }}
-
-      - name: "Deploy ActivityPub Ghost Queue to Cloud Run"
-        uses: google-github-actions/deploy-cloudrun@v2
-        with:
-          image: europe-docker.pkg.dev/ghost-activitypub/activitypub/activitypub:${{ needs.build-test-push.outputs.activitypub_docker_version }}
-          region: ${{ matrix.region }}
-          service: stg-${{ matrix.region_name }}-activitypub-ghost-queue
-          skip_default_labels: true
-          labels: |-
-            commit-sha=${{ github.sha }}
-
       - name: "Deploy ActivityPub Queue to Cloud Run"
         uses: google-github-actions/deploy-cloudrun@v2
         with:
@@ -520,26 +499,6 @@ jobs:
           region: ${{ matrix.region }}
           job: prd-${{ matrix.region_name }}-activitypub-migrations
           flags: --wait --execute-now
-          skip_default_labels: true
-          labels: |-
-            commit-sha=${{ github.sha }}
-
-      - name: "Deploy ActivityPub Fedify Queue to Cloud Run"
-        uses: google-github-actions/deploy-cloudrun@v2
-        with:
-          image: europe-docker.pkg.dev/ghost-activitypub/activitypub/activitypub:${{ needs.build-test-push.outputs.activitypub_docker_version }}
-          region: ${{ matrix.region }}
-          service: prd-${{ matrix.region_name }}-activitypub-fedify-queue
-          skip_default_labels: true
-          labels: |-
-            commit-sha=${{ github.sha }}
-
-      - name: "Deploy ActivityPub Ghost Queue to Cloud Run"
-        uses: google-github-actions/deploy-cloudrun@v2
-        with:
-          image: europe-docker.pkg.dev/ghost-activitypub/activitypub/activitypub:${{ needs.build-test-push.outputs.activitypub_docker_version }}
-          region: ${{ matrix.region }}
-          service: prd-${{ matrix.region_name }}-activitypub-ghost-queue
           skip_default_labels: true
           labels: |-
             commit-sha=${{ github.sha }}


### PR DESCRIPTION
This reverts commit 4d43925d3cc572b3666cfc35451adc9a818c6aae.

These topics are not used, and they are failing to deploy, blocking CI.