### PR TITLE
Added alerting to failed staging and cleanup deploys

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -469,6 +469,13 @@ jobs:
           labels: |-
             commit-sha=${{ github.sha }}
 
+      - uses: tryghost/actions/actions/slack-build@main
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   deploy-production:
     if: github.ref == 'refs/heads/main'
     name: (production) Deploy
@@ -611,3 +618,10 @@ jobs:
           context: jobs/cleanup-expired-key-value-records
           push: true
           tags: ${{ steps.cleanup-meta.outputs.tags }}
+
+      - uses: tryghost/actions/actions/slack-build@main
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2006

When staging deploys fail, we don't continue with prod deploys, so we want to be alerted of them immediately.
The cleanup job is part of our prod infra, we want to be alerted on that too.