### PR TITLE
Bumped Node.js to v22.14.0

### DIFF
--- a/.nix/flakes/nodejs/flake.lock
+++ b/.nix/flakes/nodejs/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719082008,
-        "narHash": "sha256-jHJSUH619zBQ6WdC21fFAlDxHErKVDJ5fpN0Hgx4sjs=",
+        "lastModified": 1749558678,
+        "narHash": "sha256-DUVAe8E2X2QM0dAnTGlTiqemMqUMMyIeCH7UeNo0g64=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9693852a2070b398ee123a329e68f0dab5526681",
+        "rev": "a12f3a99614894502e73eb816e9e076b0ab05730",
         "type": "github"
       },
       "original": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.18.0-alpine
+FROM node:22.14.0-alpine
 
 WORKDIR /opt/activitypub
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1989

The latest version of Fedify depends on Node.js 22.x