### PR TITLE
Removed explicit pubsub topic / subscription check

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -225,27 +225,12 @@ let queue: GCloudPubSubPushMessageQueue | undefined;
 if (process.env.USE_MQ === 'true') {
     globalLogging.info('Message queue is enabled');
 
-    if (!process.env.MQ_PUBSUB_HOST) {
-        throw new Error('MQ_PUBSUB_HOST is not set');
-    }
-    if (!process.env.MQ_PUBSUB_PROJECT_ID) {
-        throw new Error('MQ_PUBSUB_PROJECT_ID is not set');
-    }
-    if (!process.env.MQ_PUBSUB_TOPIC_NAME) {
-        throw new Error('MQ_PUBSUB_TOPIC_NAME is not set');
-    }
-    if (!process.env.MQ_PUBSUB_SUBSCRIPTION_NAME) {
-        throw new Error('MQ_PUBSUB_SUBSCRIPTION_NAME is not set');
-    }
-
-    const pubSubClient = await initPubSubClient({
-        host: process.env.MQ_PUBSUB_HOST,
+    const pubSubClient = initPubSubClient({
+        host: process.env.MQ_PUBSUB_HOST || 'unknown_pubsub_host',
         isEmulator: !['staging', 'production'].includes(
-            process.env.NODE_ENV || '',
+            process.env.NODE_ENV || 'unknown_node_env',
         ),
-        projectId: process.env.MQ_PUBSUB_PROJECT_ID,
-        topics: [process.env.MQ_PUBSUB_TOPIC_NAME],
-        subscriptions: [process.env.MQ_PUBSUB_SUBSCRIPTION_NAME],
+        projectId: process.env.MQ_PUBSUB_PROJECT_ID || 'unknown_project_id',
     });
 
     try {
@@ -254,7 +239,7 @@ if (process.env.USE_MQ === 'true') {
             pubSubClient,
             getFullTopic(
                 pubSubClient.projectId,
-                process.env.MQ_PUBSUB_TOPIC_NAME,
+                process.env.MQ_PUBSUB_TOPIC_NAME || 'unknown_pubsub_topic_name',
             ),
         );
 

--- a/src/pubsub.integration.test.ts
+++ b/src/pubsub.integration.test.ts
@@ -10,8 +10,6 @@ vi.mock('@google-cloud/pubsub', () => ({
 
 const PROJECT_ID = 'test-project';
 const HOST = 'test-host';
-const TOPICS = ['test-topic-1', 'test-topic-2'];
-const SUBSCRIPTIONS = ['test-subscription-1', 'test-subscription-2'];
 
 describe('initPubSubClient', () => {
     let mockPubSubClient: Partial<PubSub>;
@@ -19,26 +17,6 @@ describe('initPubSubClient', () => {
     beforeEach(() => {
         mockPubSubClient = {
             projectId: PROJECT_ID,
-            getTopics: vi.fn().mockResolvedValue([
-                [
-                    {
-                        name: `projects/${PROJECT_ID}/topics/${TOPICS[0]}`,
-                    },
-                    {
-                        name: `projects/${PROJECT_ID}/topics/${TOPICS[1]}`,
-                    },
-                ],
-            ]),
-            getSubscriptions: vi.fn().mockResolvedValue([
-                [
-                    {
-                        name: `projects/${PROJECT_ID}/subscriptions/${SUBSCRIPTIONS[0]}`,
-                    },
-                    {
-                        name: `projects/${PROJECT_ID}/subscriptions/${SUBSCRIPTIONS[1]}`,
-                    },
-                ],
-            ]),
         };
 
         (PubSub as unknown as Mock).mockImplementation(() => mockPubSubClient);
@@ -49,8 +27,6 @@ describe('initPubSubClient', () => {
             projectId: PROJECT_ID,
             host: HOST,
             isEmulator: true,
-            topics: TOPICS,
-            subscriptions: SUBSCRIPTIONS,
         });
 
         expect(PubSub).toHaveBeenCalledWith({
@@ -60,32 +36,6 @@ describe('initPubSubClient', () => {
         });
 
         expect(pubSubClient).toBe(mockPubSubClient);
-    });
-
-    it('should throw an error if a topic does not exist', async () => {
-        await expect(
-            initPubSubClient({
-                projectId: PROJECT_ID,
-                host: HOST,
-                isEmulator: true,
-                topics: ['non-existent-topic'],
-                subscriptions: SUBSCRIPTIONS,
-            }),
-        ).rejects.toThrow('Topic [non-existent-topic] does not exist');
-    });
-
-    it('should throw an error if a subscription does not exist', async () => {
-        await expect(
-            initPubSubClient({
-                projectId: PROJECT_ID,
-                host: HOST,
-                isEmulator: true,
-                topics: TOPICS,
-                subscriptions: ['non-existent-subscription'],
-            }),
-        ).rejects.toThrow(
-            'Subscription [non-existent-subscription] does not exist',
-        );
     });
 });
 

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -13,67 +13,20 @@ interface InitClientConfig {
      * ID of the Pub/Sub project
      */
     projectId: string;
-    /**
-     * Array of Pub/Sub topics to publish messages to
-     */
-    topics: string[];
-    /**
-     * Array of Pub/Sub subscriptions to receive messages from
-     */
-    subscriptions: string[];
 }
 
 export function getFullTopic(projectId: string, topic: string) {
     return `projects/${projectId}/topics/${topic}`;
 }
 
-export async function initPubSubClient({
+export function initPubSubClient({
     host,
     isEmulator,
     projectId,
-    topics,
-    subscriptions,
 }: InitClientConfig) {
-    try {
-        // Initialise the Pub/Sub client
-        const pubSubClient = new PubSub({
-            apiEndpoint: host,
-            emulatorMode: isEmulator,
-            projectId,
-        });
-
-        // Check that the provided topics exist
-        const [existingTopics] = await pubSubClient.getTopics();
-
-        for (const topic of topics) {
-            const fullTopic = getFullTopic(pubSubClient.projectId, topic);
-
-            if (!existingTopics.some((t) => t.name === fullTopic)) {
-                throw new Error(`Topic [${topic}] does not exist`);
-            }
-        }
-
-        // Check that the provided subscriptions exist
-        const [existingSubscriptions] = await pubSubClient.getSubscriptions();
-
-        for (const subscription of subscriptions) {
-            const fullSubscription = `projects/${pubSubClient.projectId}/subscriptions/${subscription}`;
-
-            if (
-                !existingSubscriptions.some((s) => s.name === fullSubscription)
-            ) {
-                throw new Error(
-                    `Subscription [${subscription}] does not exist`,
-                );
-            }
-        }
-
-        return pubSubClient;
-    } catch (error) {
-        throw new Error(
-            `Failed to initialise Pub/Sub client: ${
-                error instanceof Error ? error.message : String(error)
-            }`,
-        );
-    }
+    return new PubSub({
+        apiEndpoint: host,
+        emulatorMode: isEmulator,
+        projectId,
+    });
 }


### PR DESCRIPTION
no ref

Removed explicit pubsub topic / subscription check on app boot as they did not really provide much value (just because topics / subscriptions exist at time of boot doesn't mean they will still exist when we use them) and increased app boot time. If the client tries to publish to a topic that does not exist, an error will be thrown. We currently do not use subscriptions for anything (making the existence check redundant)