### PR TITLE
Added logging when remote post does not expose interaction counts

### DIFF
--- a/src/post/post-interaction-counts.service.unit.test.ts
+++ b/src/post/post-interaction-counts.service.unit.test.ts
@@ -6,7 +6,7 @@ import { PostInteractionCountsUpdateRequestedEvent } from './post-interaction-co
 import { PostInteractionCountsService } from './post-interaction-counts.service';
 import type { Post } from './post.entity';
 import type { KnexPostRepository } from './post.repository.knex';
-import type { PostService } from './post.service';
+import { INTERACTION_COUNTS_NOT_FOUND, type PostService } from './post.service';
 
 describe('PostInteractionCountsService', () => {
     let service: PostInteractionCountsService;
@@ -17,7 +17,7 @@ describe('PostInteractionCountsService', () => {
 
     beforeEach(() => {
         mockPostService = {
-            update: vi.fn(),
+            updateInteractionCounts: vi.fn(),
         } as unknown as PostService;
         mockPostRepository = {
             getById: vi.fn(),
@@ -93,9 +93,36 @@ describe('PostInteractionCountsService', () => {
 
             await service.update([postId]);
 
-            expect(mockPostService.update).not.toHaveBeenCalled();
+            expect(
+                mockPostService.updateInteractionCounts,
+            ).not.toHaveBeenCalled();
             expect(mockLogger.error).toHaveBeenCalledWith(
                 'Post with ID {postId} not found when updating interaction counts - Skipping',
+                { postId },
+            );
+        });
+
+        it('logs an info message if interaction counts are not found on remote post', async () => {
+            const postId = 1;
+            const now = Date.now();
+            const publishedAt = new Date(now - 2 * HOUR);
+            const updatedAt = new Date(now - 15 * MINUTE);
+            const post = {
+                id: postId,
+                publishedAt,
+                updatedAt,
+            } as Post;
+
+            vi.mocked(mockPostRepository.getById).mockResolvedValue(post);
+
+            vi.mocked(
+                mockPostService.updateInteractionCounts,
+            ).mockResolvedValue(error(INTERACTION_COUNTS_NOT_FOUND));
+
+            await service.update([postId]);
+
+            expect(mockLogger.info).toHaveBeenCalledWith(
+                'Post with ID {postId} does not expose interaction counts - Skipping',
                 { postId },
             );
         });
@@ -112,9 +139,9 @@ describe('PostInteractionCountsService', () => {
             } as Post;
 
             vi.mocked(mockPostRepository.getById).mockResolvedValue(post);
-            vi.mocked(mockPostService.update).mockResolvedValue(
-                error('upstream-error'),
-            );
+            vi.mocked(
+                mockPostService.updateInteractionCounts,
+            ).mockResolvedValue(error('upstream-error'));
 
             await service.update([postId]);
 
@@ -137,11 +164,15 @@ describe('PostInteractionCountsService', () => {
             } as Post;
 
             vi.mocked(mockPostRepository.getById).mockResolvedValue(post);
-            vi.mocked(mockPostService.update).mockResolvedValue(ok(post));
+            vi.mocked(
+                mockPostService.updateInteractionCounts,
+            ).mockResolvedValue(ok(post));
 
             await service.update([postId]);
 
-            expect(mockPostService.update).toHaveBeenCalledWith(post);
+            expect(
+                mockPostService.updateInteractionCounts,
+            ).toHaveBeenCalledWith(post);
             expect(mockLogger.info).toHaveBeenCalledWith(
                 'Successfully updated interaction counts for post with ID {postId}',
                 { postId },
@@ -162,7 +193,9 @@ describe('PostInteractionCountsService', () => {
 
             await service.update([postId]);
 
-            expect(mockPostService.update).not.toHaveBeenCalled();
+            expect(
+                mockPostService.updateInteractionCounts,
+            ).not.toHaveBeenCalled();
             expect(mockLogger.info).toHaveBeenCalledWith(
                 'Post with ID {postId} is not due for an update of interaction counts - Skipping',
                 { postId },
@@ -183,11 +216,15 @@ describe('PostInteractionCountsService', () => {
             } as Post;
 
             vi.mocked(mockPostRepository.getById).mockResolvedValue(post);
-            vi.mocked(mockPostService.update).mockResolvedValue(ok(post));
+            vi.mocked(
+                mockPostService.updateInteractionCounts,
+            ).mockResolvedValue(ok(post));
 
             await service.update([postId]);
 
-            expect(mockPostService.update).toHaveBeenCalledWith(post);
+            expect(
+                mockPostService.updateInteractionCounts,
+            ).toHaveBeenCalledWith(post);
             expect(mockLogger.info).toHaveBeenCalledWith(
                 'Successfully updated interaction counts for post with ID {postId}',
                 { postId },
@@ -208,7 +245,9 @@ describe('PostInteractionCountsService', () => {
 
             await service.update([postId]);
 
-            expect(mockPostService.update).not.toHaveBeenCalled();
+            expect(
+                mockPostService.updateInteractionCounts,
+            ).not.toHaveBeenCalled();
             expect(mockLogger.info).toHaveBeenCalledWith(
                 'Post with ID {postId} is not due for an update of interaction counts - Skipping',
                 { postId },
@@ -229,11 +268,15 @@ describe('PostInteractionCountsService', () => {
             } as Post;
 
             vi.mocked(mockPostRepository.getById).mockResolvedValue(post);
-            vi.mocked(mockPostService.update).mockResolvedValue(ok(post));
+            vi.mocked(
+                mockPostService.updateInteractionCounts,
+            ).mockResolvedValue(ok(post));
 
             await service.update([postId]);
 
-            expect(mockPostService.update).toHaveBeenCalledWith(post);
+            expect(
+                mockPostService.updateInteractionCounts,
+            ).toHaveBeenCalledWith(post);
             expect(mockLogger.info).toHaveBeenCalledWith(
                 'Successfully updated interaction counts for post with ID {postId}',
                 { postId },
@@ -255,7 +298,9 @@ describe('PostInteractionCountsService', () => {
 
             await service.update([postId]);
 
-            expect(mockPostService.update).not.toHaveBeenCalled();
+            expect(
+                mockPostService.updateInteractionCounts,
+            ).not.toHaveBeenCalled();
             expect(mockLogger.info).toHaveBeenCalledWith(
                 'Post with ID {postId} is not due for an update of interaction counts - Skipping',
                 { postId },
@@ -276,11 +321,15 @@ describe('PostInteractionCountsService', () => {
             } as Post;
 
             vi.mocked(mockPostRepository.getById).mockResolvedValue(post);
-            vi.mocked(mockPostService.update).mockResolvedValue(ok(post));
+            vi.mocked(
+                mockPostService.updateInteractionCounts,
+            ).mockResolvedValue(ok(post));
 
             await service.update([postId]);
 
-            expect(mockPostService.update).toHaveBeenCalledWith(post);
+            expect(
+                mockPostService.updateInteractionCounts,
+            ).toHaveBeenCalledWith(post);
             expect(mockLogger.info).toHaveBeenCalledWith(
                 'Successfully updated interaction counts for post with ID {postId}',
                 { postId },
@@ -301,7 +350,9 @@ describe('PostInteractionCountsService', () => {
 
             await service.update([postId]);
 
-            expect(mockPostService.update).not.toHaveBeenCalled();
+            expect(
+                mockPostService.updateInteractionCounts,
+            ).not.toHaveBeenCalled();
             expect(mockLogger.info).toHaveBeenCalledWith(
                 'Post with ID {postId} is not due for an update of interaction counts - Skipping',
                 { postId },

--- a/src/post/post.service.integration.test.ts
+++ b/src/post/post.service.integration.test.ts
@@ -620,13 +620,13 @@ describe('PostService', () => {
         });
     });
 
-    describe('update', () => {
+    describe('updateInteractionCounts', () => {
         it('returns an error if called for an internal account', async () => {
             const [author, _site, _number] =
                 await fixtureManager.createInternalAccount();
             const post = await fixtureManager.createPost(author);
 
-            const result = await postService.update(post);
+            const result = await postService.updateInteractionCounts(post);
 
             expect(isError(result)).toBe(true);
             expect(getError(result as Err<string>)).toBe('post-is-internal');
@@ -636,7 +636,7 @@ describe('PostService', () => {
             const author = await fixtureManager.createExternalAccount();
             const post = await fixtureManager.createPost(author);
 
-            const result = await postService.update(post);
+            const result = await postService.updateInteractionCounts(post);
 
             expect(isError(result)).toBe(true);
             expect(getError(result as Err<string>)).toBe('upstream-error');
@@ -674,7 +674,9 @@ describe('PostService', () => {
                     }),
                 }),
             );
-            const result = await postService.update(updatedPost!);
+            const result = await postService.updateInteractionCounts(
+                updatedPost!,
+            );
 
             expect(isError(result)).toBe(false);
             expect(setLikeCountSpy).not.toHaveBeenCalled();
@@ -715,7 +717,9 @@ describe('PostService', () => {
                     }),
                 }),
             );
-            const result = await postService.update(updatedPost!);
+            const result = await postService.updateInteractionCounts(
+                updatedPost!,
+            );
 
             expect(isError(result)).toBe(false);
 

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -55,11 +55,13 @@ export type RepostError =
 
 export type GhostPostError = CreatePostError | 'post-already-exists';
 
+export const INTERACTION_COUNTS_NOT_FOUND = 'interaction-counts-not-found';
 export type UpdateInteractionCountsError =
     | 'post-not-found'
     | 'post-is-internal'
     | 'upstream-error'
-    | 'not-a-post';
+    | 'not-a-post'
+    | typeof INTERACTION_COUNTS_NOT_FOUND;
 
 export class PostService {
     constructor(
@@ -432,7 +434,7 @@ export class PostService {
         return ok(post);
     }
 
-    async update(
+    async updateInteractionCounts(
         post: Post,
     ): Promise<Result<Post, UpdateInteractionCountsError>> {
         if (post.isInternal) {
@@ -455,6 +457,10 @@ export class PostService {
 
         const likeCount = await getLikeCountFromRemote(object);
         const repostCount = await getRepostCountFromRemote(object);
+
+        if (likeCount === null && repostCount === null) {
+            return error(INTERACTION_COUNTS_NOT_FOUND);
+        }
 
         const shouldUpdateLikeCount =
             likeCount !== null && likeCount !== post.likeCount;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-699/better-likerepost-counts-in-feedpost-view

- before, when the remote object didn't expose like/repost counts, we would log a misleading "Successfully updated interaction counts for post with ID {postId}"
- now, we instead log "Post with ID {postId} does not expose interaction counts - Skipping"
- also, renamed `postService.update()` to `postService.updateInteractionCounts()` to be more explicit