### PR TITLE
Added initial populate-explore-json job

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -613,3 +613,61 @@ jobs:
           status: ${{ job.status }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  build-populate-explore-json-job:
+    name: Build & Push populate explore json job
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Check for changes in populate explore json job"
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            populate-explore-json:
+              - 'jobs/populate-explore-json/**'
+
+      - name: "Authenticate with GCP"
+        if: steps.changes.outputs.populate-explore-json == 'true'
+        id: gcp-auth
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: access_token
+          workload_identity_provider: projects/687476608778/locations/global/workloadIdentityPools/github-oidc-activitypub/providers/github-provider-activitypub
+          service_account: stg-activitypub-cicd@ghost-activitypub.iam.gserviceaccount.com
+
+      - name: "Login to GCP Artifact Registry"
+        if: steps.changes.outputs.populate-explore-json == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: europe-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
+      - name: "Docker metadata"
+        if: steps.changes.outputs.populate-explore-json == 'true'
+        id: populate-explore-json-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: europe-docker.pkg.dev/ghost-activitypub/activitypub/populate-explore-json
+          tags: |
+            type=sha
+            type=edge,branch=main
+
+      - name: "Build & Push populate explore json job image"
+        if: steps.changes.outputs.populate-explore-json == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: jobs/populate-explore-json
+          push: true
+          tags: ${{ steps.populate-explore-json-meta.outputs.tags }}
+
+      - uses: tryghost/actions/actions/slack-build@main
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/jobs/populate-explore-json/Dockerfile
+++ b/jobs/populate-explore-json/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:22.14-alpine
+
+WORKDIR /app
+
+# Install dumb-init for proper signal handling
+RUN apk add --no-cache dumb-init
+
+# Copy package files
+COPY package.json package-lock.json* ./
+
+# Install dependencies
+RUN npm ci --production
+
+# Copy source
+COPY index.ts ./
+
+# Install tsx to run TypeScript directly
+RUN npm install -g tsx
+
+# Run as non-root user
+USER node
+
+# Use dumb-init to handle signals properly
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["tsx", "index.ts"]

--- a/jobs/populate-explore-json/README.md
+++ b/jobs/populate-explore-json/README.md
@@ -1,0 +1,36 @@
+# Populate Explore JSON
+
+A Cloud Run Job that generates a JSON file containing ActivityPub profiles for
+the explore page by fetching the following list from a curator account.
+
+## Configuration
+
+Environment variables:
+
+- `S3_BUCKET_NAME` - S3 bucket name (default: `explore-data`)
+- `S3_FILE_PATH` - Path within bucket (default: `explore/accounts.json`)
+- `S3_ENDPOINT` - S3 endpoint URL (for MinIO/custom S3)
+- `S3_ACCESS_KEY_ID` - S3 access key
+- `S3_SECRET_ACCESS_KEY` - S3 secret key
+
+## Local Development
+
+```bash
+# View logs
+docker compose logs app
+
+# Access MinIO console at http://localhost:9001 (minioadmin/minioadmin)
+# View generated JSON at http://localhost:9000/explore-data/explore/accounts.json
+
+# Run with file watching (auto-restart on changes)
+docker compose run --rm -v $(pwd)/index.ts:/app/index.ts app tsx watch index.ts
+
+# Check MinIO logs
+docker compose logs minio
+
+# Run with verbose output
+docker compose run --rm app
+
+# Check generated file
+curl -s http://localhost:9000/explore-data/explore/accounts.json | gunzip | jq '.'
+```

--- a/jobs/populate-explore-json/docker-compose.yml
+++ b/jobs/populate-explore-json/docker-compose.yml
@@ -1,0 +1,76 @@
+version: '3.8'
+
+services:
+  minio:
+    image: minio/minio:latest
+    container_name: populate-explore-minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+  # Create bucket on MinIO startup
+  minio-setup:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 minioadmin minioadmin;
+      mc mb local/explore-data || true;
+      mc anonymous set public local/explore-data || true;
+      echo 'MinIO setup complete';
+      "
+
+  # The main app service
+  app:
+    build: .
+    depends_on:
+      minio-setup:
+        condition: service_completed_successfully
+    environment:
+      # Curator configuration
+      CURATOR_ACCOUNT_HANDLE: ${CURATOR_ACCOUNT_HANDLE:-@index@pubactivity.ghost.io}
+
+      # S3 configuration for MinIO
+      S3_ENDPOINT: http://minio:9000
+      S3_BUCKET_NAME: explore-data
+      S3_FILE_PATH: explore/accounts.json
+      S3_REGION: us-east-1
+      S3_ACCESS_KEY_ID: minioadmin
+      S3_SECRET_ACCESS_KEY: minioadmin
+
+      # Request configuration
+      MAX_CONCURRENT_REQUESTS: ${MAX_CONCURRENT_REQUESTS:-10}
+
+  populate-explore-json-dev:
+    build: .
+    volumes:
+      - .:/app
+      - /app/node_modules
+    environment:
+      - S3_ENDPOINT=http://minio:9000
+      - S3_ACCESS_KEY_ID=minioadmin
+      - S3_SECRET_ACCESS_KEY=minioadmin
+      - S3_BUCKET_NAME=explore-data
+      - CURATOR_ACCOUNT_HANDLE=${CURATOR_ACCOUNT_HANDLE:-@index@activitypub.ghost.org}
+    command: tsx watch index.ts
+    depends_on:
+      minio:
+        condition: service_healthy
+      minio-setup:
+        condition: service_completed_successfully
+
+volumes:
+  minio_data:

--- a/jobs/populate-explore-json/index.ts
+++ b/jobs/populate-explore-json/index.ts
@@ -1,0 +1,63 @@
+import { promisify } from 'node:util';
+import { gzip } from 'node:zlib';
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+
+const gzipAsync = promisify(gzip);
+
+// Simple environment configuration
+const config = {
+    s3Endpoint: process.env.S3_ENDPOINT || 'https://storage.googleapis.com',
+    s3Region: process.env.S3_REGION || 'auto',
+    s3Bucket: process.env.S3_BUCKET_NAME || 'explore-data',
+    s3FilePath: process.env.S3_FILE_PATH || 'explore/accounts.json',
+    s3AccessKeyId: process.env.S3_ACCESS_KEY_ID,
+    s3SecretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
+};
+
+// Upload to S3-compatible storage
+async function uploadToS3(data: object) {
+    const json = JSON.stringify(data, null, 2);
+    const compressed = await gzipAsync(json);
+
+    console.log(
+        `Uploading ${compressed.length} bytes (compressed from ${json.length} bytes)`,
+    );
+
+    const s3Client = new S3Client({
+        endpoint: config.s3Endpoint,
+        region: config.s3Region,
+        forcePathStyle: true, // Required for MinIO and non-AWS S3
+        credentials:
+            config.s3AccessKeyId && config.s3SecretAccessKey
+                ? {
+                      accessKeyId: config.s3AccessKeyId,
+                      secretAccessKey: config.s3SecretAccessKey,
+                  }
+                : undefined,
+    });
+
+    await s3Client.send(
+        new PutObjectCommand({
+            Bucket: config.s3Bucket,
+            Key: config.s3FilePath,
+            Body: compressed,
+            ContentType: 'application/json',
+            ContentEncoding: 'gzip',
+        }),
+    );
+
+    console.log(`Uploaded to s3://${config.s3Bucket}/${config.s3FilePath}`);
+}
+
+// Main function
+async function main() {
+    await uploadToS3({
+        generated_at: new Date().toISOString(),
+        accounts: [],
+    });
+
+    process.exit(0);
+}
+
+// Run
+main().catch(console.error);

--- a/jobs/populate-explore-json/package.json
+++ b/jobs/populate-explore-json/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "populate-explore-json",
+  "version": "1.0.0",
+  "description": "Generate JSON file for ActivityPub explore page",
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts",
+    "dev": "tsx watch index.ts"
+  },
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.729.0",
+    "@fedify/fedify": "^1.6.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0"
+  }
+}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2011

We want to be able to generate a static JSON file for populating the
accounts for the epxlore page. The idea here is to run this job in the
background and update it periodically to keep counts and order in sync.

This is just to get the thing wired up, and then we can start
implementing it afterwards