### PR TITLE
Marked all existing notifications in the db as read

### DIFF
--- a/migrate/migrations/000059_reset-unread-notifications-count.down.sql
+++ b/migrate/migrations/000059_reset-unread-notifications-count.down.sql
@@ -1,0 +1,1 @@
+UPDATE notifications SET `read` = FALSE;

--- a/migrate/migrations/000059_reset-unread-notifications-count.up.sql
+++ b/migrate/migrations/000059_reset-unread-notifications-count.up.sql
@@ -1,0 +1,1 @@
+UPDATE notifications SET `read` = TRUE;


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2015

- The db has existing notifications and currently all are marked as unread because default for `read` column is `false`
- Before releasing the notification badge feature we want to mark all exiting notifications as read so that users see the badge for only new notifications