### PR TITLE
Removed redundant `/mq` endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,7 @@ services:
       - MQ_PUBSUB_PROJECT_ID=activitypub
       - MQ_PUBSUB_HOST=pubsub:8085
       - MQ_PUBSUB_TOPIC_NAME=fedify-topic
-      - MQ_PUBSUB_SUBSCRIPTION_NAME=fedify-subscription
       - MQ_PUBSUB_GHOST_TOPIC_NAME=ghost-topic
-      - MQ_PUBSUB_GHOST_SUBSCRIPTION_NAME=ghost-subscription
       - GCP_BUCKET_NAME=activitypub
       - GCP_STORAGE_EMULATOR_HOST=http://fake-gcs:4443
       - ACTIVITYPUB_COLLECTION_PAGE_SIZE=20
@@ -111,7 +109,7 @@ services:
       - PROJECT_ID=activitypub
       - FEDIFY_TOPIC_NAME=fedify-topic
       - FEDIFY_SUBSCRIPTION_NAME=fedify-subscription
-      - FEDIFY_PUSH_ENDPOINT=http://activitypub:8080/.ghost/activitypub/mq
+      - FEDIFY_PUSH_ENDPOINT=http://activitypub:8080/.ghost/activitypub/pubsub/fedify/push
       - GHOST_TOPIC_NAME=ghost-topic
       - GHOST_SUBSCRIPTION_NAME=ghost-subscription
       - GHOST_PUSH_ENDPOINT=http://activitypub:8080/.ghost/activitypub/pubsub/ghost/push
@@ -148,9 +146,7 @@ services:
       - MQ_PUBSUB_PROJECT_ID=activitypub
       - MQ_PUBSUB_HOST=pubsub-testing:8085
       - MQ_PUBSUB_TOPIC_NAME=fedify-topic
-      - MQ_PUBSUB_SUBSCRIPTION_NAME=fedify-subscription
       - MQ_PUBSUB_GHOST_TOPIC_NAME=ghost-topic
-      - MQ_PUBSUB_GHOST_SUBSCRIPTION_NAME=ghost-subscription
       - GCP_BUCKET_NAME=activitypub
       - GCP_STORAGE_EMULATOR_HOST=http://fake-gcs:4443
       - ACTIVITYPUB_COLLECTION_PAGE_SIZE=2
@@ -248,7 +244,7 @@ services:
       - PROJECT_ID=activitypub
       - FEDIFY_TOPIC_NAME=fedify-topic
       - FEDIFY_SUBSCRIPTION_NAME=fedify-subscription
-      - FEDIFY_PUSH_ENDPOINT=http://activitypub-testing:8083/.ghost/activitypub/mq
+      - FEDIFY_PUSH_ENDPOINT=http://activitypub-testing:8083/.ghost/activitypub/pubsub/fedify/push
       - GHOST_TOPIC_NAME=ghost-topic
       - GHOST_SUBSCRIPTION_NAME=ghost-subscription
       - GHOST_PUSH_ENDPOINT=http://activitypub-testing:8083/.ghost/activitypub/pubsub/ghost/push

--- a/src/app.ts
+++ b/src/app.ts
@@ -619,11 +619,10 @@ app.post('/.ghost/activitypub/pubsub/ghost/push', async (ctx) => {
 // This needs to go before the middleware which loads the site
 // because this endpoint does not require the site to exist
 if (globalQueue instanceof GCloudPubSubPushMessageQueue) {
-    const mqMessageHandler = spanWrapper(
-        createPushMessageHandler(globalQueue, globalLogging),
+    app.post(
+        '/.ghost/activitypub/pubsub/fedify/push',
+        spanWrapper(createPushMessageHandler(globalQueue, globalLogging)),
     );
-    app.post('/.ghost/activitypub/mq', mqMessageHandler);
-    app.post('/.ghost/activitypub/pubsub/fedify/push', mqMessageHandler);
 }
 
 app.use(


### PR DESCRIPTION
no ref

The `/mq` endpoint has been removed in favour of the `/pubsub/fedfiy/push` endpoint that is currently deployed. This change also removes the redundant `MQ_*_SUBSCRIPTION` environment variables that are no longer used