### PR TITLE
Fixed cucumber tests for notification counts

### DIFF
--- a/features/notifications.feature
+++ b/features/notifications.feature
@@ -8,23 +8,21 @@ Feature: Notifications
     Then the request is rejected with a 400
 
   Scenario: Requests for unread notifications count
-    Given an Actor "Person(Alice)"
-    And an Actor "Person(Bob)"
-    And we publish an article
-    And "Bob" likes our article
-    And "Alice" likes our article
-    And "Bob" sends us a reply to our article
-    And "Alice" sends us a reply to our article
+    Given we are following "Alice"
+    And we are not following "Bob"
+    When we get a like notification from "Alice"
+    And we get a like notification from "Bob"
+    And we get a reply notification from "Alice"
+    And we get a reply notification from "Bob"
     Then the unread notifications count is 4
 
   Scenario: Reset unread notifications count
-    Given an Actor "Person(Alice)"
-    And an Actor "Person(Bob)"
-    And we publish an article
-    And "Bob" likes our article
-    And "Alice" likes our article
-    And "Bob" sends us a reply to our article
-    And "Alice" sends us a reply to our article
+    Given we are following "Alice"
+    And we are not following "Bob"
+    And we get a like notification from "Alice"
+    And we get a like notification from "Bob"
+    And we get a reply notification from "Alice"
+    And we get a reply notification from "Bob"
     And the unread notifications count is 4
     When we reset unread notifications count
     Then the unread notifications count is 0

--- a/features/step_definitions/notifications_steps.js
+++ b/features/step_definitions/notifications_steps.js
@@ -1,11 +1,83 @@
 import assert from 'node:assert';
 import { Then, When } from '@cucumber/cucumber';
-import { waitForUnreadNotifications } from '../support/notifications.js';
+import { publishArticle } from '../support/content.js';
+import { createActivity, createObject } from '../support/fixtures.js';
+import {
+    waitForItemInNotifications,
+    waitForUnreadNotifications,
+} from '../support/notifications.js';
 import { fetchActivityPub } from '../support/request.js';
 
 Then('the unread notifications count is {int}', async (count) => {
     const found = await waitForUnreadNotifications(count);
     assert(found);
+});
+
+When('we get a like notification from {string}', async function (actorName) {
+    if (!this.articleId) {
+        const article = await publishArticle();
+        this.articleId = article.id;
+    }
+
+    const actor = this.actors[actorName];
+    if (!actor) {
+        throw new Error(
+            `Actor ${actorName} not found - did you forget a step?`,
+        );
+    }
+
+    const activity = await createActivity('Like', this.articleId, actor);
+    await fetchActivityPub(
+        'http://fake-ghost-activitypub.test/.ghost/activitypub/inbox/index',
+        {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/ld+json',
+            },
+            body: JSON.stringify(activity),
+        },
+    );
+
+    await waitForItemInNotifications((notification) => {
+        return (
+            notification.type === 'like' &&
+            notification.post?.id === this.articleId &&
+            notification.actor?.url === actor.id
+        );
+    });
+});
+
+When('we get a reply notification from {string}', async function (actorName) {
+    if (!this.articleId) {
+        const article = await publishArticle();
+        this.articleId = article.id;
+    }
+
+    const actor = this.actors[actorName];
+    if (!actor) {
+        throw new Error(
+            `Actor ${actorName} not found - did you forget a step?`,
+        );
+    }
+
+    const object = await createObject('Note', actor, {
+        content: 'This is a reply',
+        inReplyTo: this.articleId,
+    });
+    const activity = await createActivity('Create', object, actor);
+
+    await fetchActivityPub(
+        'http://fake-ghost-activitypub.test/.ghost/activitypub/inbox/index',
+        {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/ld+json',
+            },
+            body: JSON.stringify(activity),
+        },
+    );
+
+    await waitForItemInNotifications(object.id);
 });
 
 When('we reset unread notifications count', async () => {

--- a/features/support/notifications.js
+++ b/features/support/notifications.js
@@ -1,12 +1,21 @@
 import { fetchActivityPub } from './request.js';
 
 export async function waitForItemInNotifications(
-    itemId,
+    input,
     options = {
         retryCount: 0,
         delay: 0,
     },
 ) {
+    let matcher;
+    if (typeof input === 'string') {
+        matcher = (notification) => {
+            return notification.post?.id === input;
+        };
+    } else {
+        matcher = input;
+    }
+
     const MAX_RETRIES = 5;
 
     const response = await fetchActivityPub(
@@ -21,7 +30,7 @@ export async function waitForItemInNotifications(
     const json = await response.json();
 
     const found = json.notifications.find((notificiation) => {
-        return notificiation.post?.id === itemId;
+        return matcher(notificiation);
     });
 
     if (found) {
@@ -30,7 +39,7 @@ export async function waitForItemInNotifications(
 
     if (options.retryCount === MAX_RETRIES) {
         throw new Error(
-            `Max retries reached (${MAX_RETRIES}) when waiting on item ${itemId} in notifications`,
+            `Max retries reached (${MAX_RETRIES}) when waiting on item in notifications`,
         );
     }
 
@@ -38,7 +47,7 @@ export async function waitForItemInNotifications(
         await new Promise((resolve) => setTimeout(resolve, options.delay));
     }
 
-    return await waitForItemInNotifications(itemId, {
+    return await waitForItemInNotifications(matcher, {
         retryCount: options.retryCount + 1,
         delay: options.delay + 500,
     });


### PR DESCRIPTION
no-issue

The previous tests were not waiting for the notification to be present before checking for the counts. I've updated the tests to be a little more focused on what we're testing, and pushed some complexity into the step definitions, rather than adding extra steps which verify the notification has been received.

Note that we pass a custom matcher when finding like notifications because matching on the post.id isn't unique enough, as it refers to the post which was liked.