### PR TITLE
Used post `uuid` for creating `Create` activity id

### DIFF
--- a/src/activitypub/fediverse-bridge.ts
+++ b/src/activitypub/fediverse-bridge.ts
@@ -156,7 +156,7 @@ export class FediverseBridge {
         }
 
         const createActivity = new Create({
-            id: ctx.getObjectUri(Create, { id: uuidv4() }),
+            id: ctx.getObjectUri(Create, { id: post.uuid }),
             actor: post.author.apId,
             object: fedifyObject,
             to: PUBLIC_COLLECTION,

--- a/src/activitypub/fediverse-bridge.unit.test.ts
+++ b/src/activitypub/fediverse-bridge.unit.test.ts
@@ -14,10 +14,6 @@ import type { FedifyContextFactory } from './fedify-context.factory';
 import { FediverseBridge } from './fediverse-bridge';
 import type { UriBuilder } from './uri';
 
-vi.mock('uuid', () => ({
-    v4: vi.fn().mockReturnValue('cb1e7e92-5560-4ceb-9272-7e9d0e2a7da4'),
-}));
-
 vi.mock('@js-temporal/polyfill', async () => {
     const original = await import('@js-temporal/polyfill');
 
@@ -395,6 +391,7 @@ describe('FediverseBridge', () => {
         post.content = 'Note content';
         post.apId = new URL('https://example.com/note/post-123');
         post.mentions = [];
+        post.uuid = 'cb1e7e92-5560-4ceb-9272-7e9d0e2a7da4';
 
         const event = new PostCreatedEvent(post);
         events.emit(PostCreatedEvent.getName(), event);
@@ -439,6 +436,7 @@ describe('FediverseBridge', () => {
         post.content = 'Hello! @test@example.com';
         post.apId = new URL('https://example.com/note/post-123');
         post.mentions = [mentionedAccount];
+        post.uuid = 'cb1e7e92-5560-4ceb-9272-7e9d0e2a7da4';
 
         const event = new PostCreatedEvent(post);
         events.emit(PostCreatedEvent.getName(), event);
@@ -480,6 +478,7 @@ describe('FediverseBridge', () => {
         post.publishedAt = new Date('2025-01-12T10:30:00Z');
         post.url = new URL('https://example.com/post/post-123');
         post.apId = new URL('https://example.com/article/post-123');
+        post.uuid = 'cb1e7e92-5560-4ceb-9272-7e9d0e2a7da4';
 
         const event = new PostCreatedEvent(post);
         events.emit(PostCreatedEvent.getName(), event);

--- a/src/http/api/reply.ts
+++ b/src/http/api/reply.ts
@@ -7,7 +7,6 @@ import {
     PUBLIC_COLLECTION,
 } from '@fedify/fedify';
 import { Temporal } from '@js-temporal/polyfill';
-import { v4 as uuidv4 } from 'uuid';
 import z from 'zod';
 
 import { type AppContext, globalFedify } from 'app';
@@ -228,12 +227,8 @@ export async function handleCreateReply(
         ccs: cc,
     });
 
-    const createId = apCtx.getObjectUri(Create, {
-        id: uuidv4(),
-    });
-
     const create = new Create({
-        id: createId,
+        id: apCtx.getObjectUri(Create, { id: newReply.uuid }),
         actor: actor,
         object: reply,
         to: to,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2076/

- Currently we generate the Create activity id with a random uuid. We can reuse the post uuid for that so that the create activity ids are deterministic. 