### PR TITLE
Fleshed out AccountDraft with missing properties

### DIFF
--- a/src/account/account.entity.ts
+++ b/src/account/account.entity.ts
@@ -49,7 +49,13 @@ export interface AccountDraft {
     bannerImageUrl: URL | null;
     apId: URL;
     apFollowers: URL | null;
+    apFollowing: URL | null;
     apInbox: URL | null;
+    apSharedInbox: URL | null;
+    apOutbox: URL | null;
+    apLiked: URL | null;
+    apPublicKey: CryptoKey;
+    apPrivateKey: CryptoKey | null;
     isInternal: boolean;
 }
 
@@ -112,7 +118,19 @@ export class AccountEntity implements Account {
         const apInbox = !from.isInternal
             ? from.apInbox
             : new URL('/.ghost/activitypub/inbox/index', from.host);
+        const apSharedInbox = !from.isInternal ? from.apSharedInbox : null;
+        const apOutbox = !from.isInternal
+            ? from.apOutbox
+            : new URL('/.ghost/activitypub/outbox/index', from.host);
+        const apFollowing = !from.isInternal
+            ? from.apFollowing
+            : new URL('/.ghost/activitypub/following/index', from.host);
+        const apLiked = !from.isInternal
+            ? from.apLiked
+            : new URL('/.ghost/activitypub/liked/index', from.host);
         const url = from.url || apId;
+        const apPrivateKey = !from.isInternal ? null : from.apPrivateKey;
+
         return {
             ...from,
             uuid,
@@ -120,6 +138,11 @@ export class AccountEntity implements Account {
             apId,
             apFollowers,
             apInbox,
+            apSharedInbox,
+            apOutbox,
+            apFollowing,
+            apLiked,
+            apPrivateKey,
         };
     }
 
@@ -259,6 +282,8 @@ type InternalAccountDraftData = {
     url: URL | null;
     avatarUrl: URL | null;
     bannerImageUrl: URL | null;
+    apPublicKey: CryptoKey;
+    apPrivateKey: CryptoKey;
 };
 
 /**
@@ -275,6 +300,11 @@ type ExternalAccountDraftData = {
     apId: URL;
     apFollowers: URL | null;
     apInbox: URL | null;
+    apSharedInbox: URL | null;
+    apOutbox: URL | null;
+    apFollowing: URL | null;
+    apLiked: URL | null;
+    apPublicKey: CryptoKey;
 };
 
 type AccountDraftData = InternalAccountDraftData | ExternalAccountDraftData;

--- a/src/account/account.entity.unit.test.ts
+++ b/src/account/account.entity.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { AccountEntity } from 'account/account.entity';
 import { PostType } from 'post/post.entity';
+import { createInternalAccountDraftData } from '../test/account-entity-test-helpers';
 import { AccountBlockedEvent } from './account-blocked.event';
 import { AccountFollowedEvent } from './account-followed.event';
 import { AccountUnblockedEvent } from './account-unblocked.event';
@@ -12,9 +13,8 @@ import { DomainUnblockedEvent } from './domain-unblocked.event';
 import { NotificationsReadEvent } from './notifications-read-event';
 
 describe('AccountEntity', () => {
-    it('Uses the apId if the url is missing', () => {
-        const draft = AccountEntity.draft({
-            isInternal: true,
+    it('Uses the apId if the url is missing', async () => {
+        const draftData = await createInternalAccountDraftData({
             host: new URL('http://foobar.com'),
             username: 'foobar',
             name: 'Foo Bar',
@@ -23,6 +23,8 @@ describe('AccountEntity', () => {
             avatarUrl: new URL('http://foobar.com/avatar/foobar.png'),
             bannerImageUrl: new URL('http://foobar.com/banner/foobar.png'),
         });
+
+        const draft = AccountEntity.draft(draftData);
 
         const account = AccountEntity.create({
             id: 1,
@@ -32,9 +34,8 @@ describe('AccountEntity', () => {
         expect(account.url).toEqual(account.apId);
     });
 
-    it('Can generate the apId', () => {
-        const draft = AccountEntity.draft({
-            isInternal: true,
+    it('Can generate the apId', async () => {
+        const draftData = await createInternalAccountDraftData({
             host: new URL('http://foobar.com'),
             username: 'foobar',
             name: 'Foo Bar',
@@ -43,6 +44,8 @@ describe('AccountEntity', () => {
             avatarUrl: new URL('http://foobar.com/avatar/foobar.png'),
             bannerImageUrl: new URL('http://foobar.com/banner/foobar.png'),
         });
+
+        const draft = AccountEntity.draft(draftData);
 
         const account = AccountEntity.create({
             id: 1,
@@ -55,9 +58,8 @@ describe('AccountEntity', () => {
         expect(account.url).toEqual(account.apId);
     });
 
-    it('Can generate the apFollowers', () => {
-        const draft = AccountEntity.draft({
-            isInternal: true,
+    it('Can generate the apFollowers', async () => {
+        const draftData = await createInternalAccountDraftData({
             host: new URL('http://foobar.com'),
             username: 'foobar',
             name: 'Foo Bar',
@@ -66,6 +68,8 @@ describe('AccountEntity', () => {
             avatarUrl: new URL('http://foobar.com/avatar/foobar.png'),
             bannerImageUrl: new URL('http://foobar.com/banner/foobar.png'),
         });
+
+        const draft = AccountEntity.draft(draftData);
 
         const account = AccountEntity.create({
             id: 1,
@@ -78,9 +82,8 @@ describe('AccountEntity', () => {
     });
 
     describe('getApIdForPost', () => {
-        it('Can get the ap id for an article', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('Can get the ap id for an article', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://foobar.com'),
                 username: 'foobar',
                 name: 'Foo Bar',
@@ -89,6 +92,8 @@ describe('AccountEntity', () => {
                 avatarUrl: new URL('http://foobar.com/avatar/foobar.png'),
                 bannerImageUrl: new URL('http://foobar.com/banner/foobar.png'),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -105,9 +110,8 @@ describe('AccountEntity', () => {
             );
         });
 
-        it('Can get the ap id for a note', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('Can get the ap id for a note', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://foobar.com'),
                 username: 'foobar',
                 name: 'Foo Bar',
@@ -116,6 +120,8 @@ describe('AccountEntity', () => {
                 avatarUrl: new URL('http://foobar.com/avatar/foobar.png'),
                 bannerImageUrl: new URL('http://foobar.com/banner/foobar.png'),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -134,9 +140,8 @@ describe('AccountEntity', () => {
     });
 
     describe('updateProfile', () => {
-        it('can update name', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('can update name', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://example.com'),
                 username: 'testuser',
                 name: 'Original Name',
@@ -147,6 +152,8 @@ describe('AccountEntity', () => {
                     'http://example.com/original-banner.png',
                 ),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -166,9 +173,8 @@ describe('AccountEntity', () => {
             );
         });
 
-        it('can update bio', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('can update bio', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://example.com'),
                 username: 'testuser',
                 name: 'Original Name',
@@ -179,6 +185,8 @@ describe('AccountEntity', () => {
                     'http://example.com/original-banner.png',
                 ),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -198,9 +206,8 @@ describe('AccountEntity', () => {
             );
         });
 
-        it('can update username', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('can update username', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://example.com'),
                 username: 'testuser',
                 name: 'Original Name',
@@ -211,6 +218,8 @@ describe('AccountEntity', () => {
                     'http://example.com/original-banner.png',
                 ),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -231,9 +240,8 @@ describe('AccountEntity', () => {
             );
         });
 
-        it('can update avatarUrl', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('can update avatarUrl', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://example.com'),
                 username: 'testuser',
                 name: 'Original Name',
@@ -244,6 +252,8 @@ describe('AccountEntity', () => {
                     'http://example.com/original-banner.png',
                 ),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -265,9 +275,8 @@ describe('AccountEntity', () => {
             );
         });
 
-        it('can update bannerImageUrl', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('can update bannerImageUrl', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://example.com'),
                 username: 'testuser',
                 name: 'Original Name',
@@ -278,6 +287,8 @@ describe('AccountEntity', () => {
                     'http://example.com/original-banner.png',
                 ),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -301,9 +312,8 @@ describe('AccountEntity', () => {
             );
         });
 
-        it('can update multiple properties at once', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('can update multiple properties at once', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://example.com'),
                 username: 'testuser',
                 name: 'Original Name',
@@ -314,6 +324,8 @@ describe('AccountEntity', () => {
                     'http://example.com/original-banner.png',
                 ),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -341,9 +353,8 @@ describe('AccountEntity', () => {
             );
         });
 
-        it('can set values to null', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('can set values to null', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://example.com'),
                 username: 'testuser',
                 name: 'Original Name',
@@ -354,6 +365,8 @@ describe('AccountEntity', () => {
                     'http://example.com/original-banner.png',
                 ),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -374,9 +387,8 @@ describe('AccountEntity', () => {
             );
         });
 
-        it('should emit AccountUpdatedEvent when data changes', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('should emit AccountUpdatedEvent when data changes', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://example.com'),
                 username: 'testuser',
                 name: 'Original Name',
@@ -387,6 +399,8 @@ describe('AccountEntity', () => {
                     'http://example.com/original-banner.png',
                 ),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -402,9 +416,8 @@ describe('AccountEntity', () => {
             expect(events[0]).toBeInstanceOf(AccountUpdatedEvent);
         });
 
-        it('should not emit AccountUpdatedEvent when data is the same', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('should not emit AccountUpdatedEvent when data is the same', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://example.com'),
                 username: 'testuser',
                 name: 'Original Name',
@@ -415,6 +428,8 @@ describe('AccountEntity', () => {
                     'http://example.com/original-banner.png',
                 ),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -437,9 +452,8 @@ describe('AccountEntity', () => {
     });
 
     describe('block and unblock', () => {
-        it('You cannot block yourself', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('You cannot block yourself', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://example.com'),
                 username: 'testuser',
                 name: 'Original Name',
@@ -450,6 +464,8 @@ describe('AccountEntity', () => {
                     'http://example.com/original-banner.png',
                 ),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -461,9 +477,8 @@ describe('AccountEntity', () => {
             expect(AccountEntity.pullEvents(updated)).toStrictEqual([]);
         });
 
-        it('You can block another account', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('You can block another account', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://example.com'),
                 username: 'testuser',
                 name: 'Original Name',
@@ -474,6 +489,8 @@ describe('AccountEntity', () => {
                     'http://example.com/original-banner.png',
                 ),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -492,9 +509,8 @@ describe('AccountEntity', () => {
             ]);
         });
 
-        it('You cannot unblock yourself', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('You cannot unblock yourself', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://example.com'),
                 username: 'testuser',
                 name: 'Original Name',
@@ -505,6 +521,8 @@ describe('AccountEntity', () => {
                     'http://example.com/original-banner.png',
                 ),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -516,9 +534,8 @@ describe('AccountEntity', () => {
             expect(AccountEntity.pullEvents(updated)).toStrictEqual([]);
         });
 
-        it('You can unblock another account', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('You can unblock another account', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://example.com'),
                 username: 'testuser',
                 name: 'Original Name',
@@ -529,6 +546,8 @@ describe('AccountEntity', () => {
                     'http://example.com/original-banner.png',
                 ),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -549,9 +568,8 @@ describe('AccountEntity', () => {
     });
 
     describe('blockDomain and unblockDomain', () => {
-        it('should block domain', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('should block domain', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://example.com'),
                 username: 'testuser',
                 name: 'Original Name',
@@ -562,6 +580,8 @@ describe('AccountEntity', () => {
                     'http://example.com/original-banner.png',
                 ),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -581,9 +601,8 @@ describe('AccountEntity', () => {
             }
         });
 
-        it('should unblock domain', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('should unblock domain', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://example.com'),
                 username: 'testuser',
                 name: 'Original Name',
@@ -594,6 +613,8 @@ describe('AccountEntity', () => {
                     'http://example.com/original-banner.png',
                 ),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -615,9 +636,8 @@ describe('AccountEntity', () => {
     });
 
     describe('follow and unfollow', () => {
-        it('You cannot follow yourself', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('You cannot follow yourself', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://example.com'),
                 username: 'testuser',
                 name: 'Original Name',
@@ -628,6 +648,8 @@ describe('AccountEntity', () => {
                     'http://example.com/original-banner.png',
                 ),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -639,9 +661,8 @@ describe('AccountEntity', () => {
             expect(AccountEntity.pullEvents(updated)).toStrictEqual([]);
         });
 
-        it('You can follow another account', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('You can follow another account', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://example.com'),
                 username: 'testuser',
                 name: 'Original Name',
@@ -652,6 +673,8 @@ describe('AccountEntity', () => {
                     'http://example.com/original-banner.png',
                 ),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -670,9 +693,8 @@ describe('AccountEntity', () => {
             ]);
         });
 
-        it('You cannot unfollow yourself', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('You cannot unfollow yourself', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://example.com'),
                 username: 'testuser',
                 name: 'Original Name',
@@ -683,6 +705,8 @@ describe('AccountEntity', () => {
                     'http://example.com/original-banner.png',
                 ),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -694,9 +718,8 @@ describe('AccountEntity', () => {
             expect(AccountEntity.pullEvents(updated)).toStrictEqual([]);
         });
 
-        it('You can unfollow another account', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('You can unfollow another account', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://example.com'),
                 username: 'testuser',
                 name: 'Original Name',
@@ -707,6 +730,8 @@ describe('AccountEntity', () => {
                     'http://example.com/original-banner.png',
                 ),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,
@@ -727,9 +752,8 @@ describe('AccountEntity', () => {
     });
 
     describe('readAllNotifications', () => {
-        it('should read all notifications', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('should read all notifications', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('http://example.com'),
                 username: 'testuser',
                 name: 'Original Name',
@@ -740,6 +764,8 @@ describe('AccountEntity', () => {
                     'http://example.com/original-banner.png',
                 ),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const account = AccountEntity.create({
                 id: 1,

--- a/src/feed/feed-update.service.unit.test.ts
+++ b/src/feed/feed-update.service.unit.test.ts
@@ -13,6 +13,7 @@ import { PostDeletedEvent } from 'post/post-deleted.event';
 import { PostDerepostedEvent } from 'post/post-dereposted.event';
 import { PostRepostedEvent } from 'post/post-reposted.event';
 import { Audience, Post, PostType } from 'post/post.entity';
+import { createInternalAccountDraftData } from '../test/account-entity-test-helpers';
 
 describe('FeedUpdateService', () => {
     let events: EventEmitter;
@@ -21,7 +22,7 @@ describe('FeedUpdateService', () => {
 
     let account: AccountEntity;
 
-    beforeEach(() => {
+    beforeEach(async () => {
         vi.useFakeTimers();
 
         events = new EventEmitter();
@@ -33,8 +34,7 @@ describe('FeedUpdateService', () => {
             removeUnfollowedAccountPostsFromFeed: vi.fn(),
         } as unknown as FeedService;
 
-        const draft = AccountEntity.draft({
-            isInternal: true,
+        const draftData = await createInternalAccountDraftData({
             host: new URL('https://example.com'),
             username: 'foobar',
             name: 'Foo Bar',
@@ -43,6 +43,8 @@ describe('FeedUpdateService', () => {
             bannerImageUrl: new URL('https://example.com/banners/foobar.png'),
             url: new URL('https://example.com/users/456'),
         });
+
+        const draft = AccountEntity.draft(draftData);
 
         account = AccountEntity.create({
             id: 456,
@@ -184,9 +186,8 @@ describe('FeedUpdateService', () => {
     });
 
     describe('handling a blocked account', () => {
-        it('should remove blocked account posts from feeds', () => {
-            const draft = AccountEntity.draft({
-                isInternal: true,
+        it('should remove blocked account posts from feeds', async () => {
+            const draftData = await createInternalAccountDraftData({
                 host: new URL('https://example.com'),
                 username: 'bazqux',
                 name: 'Baz Qux',
@@ -197,6 +198,8 @@ describe('FeedUpdateService', () => {
                 ),
                 url: new URL('https://blocked.com/users/789'),
             });
+
+            const draft = AccountEntity.draft(draftData);
 
             const blockedAccount = AccountEntity.create({
                 id: 789,

--- a/src/http/api/feed.unit.test.ts
+++ b/src/http/api/feed.unit.test.ts
@@ -9,6 +9,7 @@ import type { FeedService } from 'feed/feed.service';
 import type { PostInteractionCountsService } from 'post/post-interaction-counts.service';
 import { PostType } from 'post/post.entity';
 import type { Site } from 'site/site.service';
+import { createInternalAccountDraftData } from '../../test/account-entity-test-helpers';
 import { createGetFeedHandler } from './feed';
 
 vi.mock('@sentry/node', () => {
@@ -122,7 +123,7 @@ describe('Feed API', () => {
         };
     }
 
-    beforeEach(() => {
+    beforeEach(async () => {
         vi.setSystemTime(new Date('2025-02-24T16:40:00Z'));
 
         site = {
@@ -131,8 +132,7 @@ describe('Feed API', () => {
             webhook_secret: 'secret',
         };
 
-        const draft = AccountEntity.draft({
-            isInternal: true,
+        const draftData = await createInternalAccountDraftData({
             host: new URL('http://example.com'),
             username: 'foobar',
             name: 'Foo Bar',
@@ -141,6 +141,9 @@ describe('Feed API', () => {
             avatarUrl: new URL('http://example.com/avatar/foobar.png'),
             bannerImageUrl: new URL('http://example.com/banner/foobar.png'),
         });
+
+        const draft = AccountEntity.draft(draftData);
+
         account = AccountEntity.create({
             id: 456,
             ...draft,

--- a/src/http/api/helpers/post.unit.test.ts
+++ b/src/http/api/helpers/post.unit.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import { AccountEntity } from 'account/account.entity';
 import { Post, PostType } from 'post/post.entity';
+import { createInternalAccountDraftData } from '../../../test/account-entity-test-helpers';
 import { postToDTO } from './post';
 
-function createAuthor() {
-    const draft = AccountEntity.draft({
-        isInternal: true,
+async function createAuthor() {
+    const draftData = await createInternalAccountDraftData({
         host: new URL('http://foobar.com'),
         username: 'foobar',
         name: 'Foo Bar',
@@ -16,6 +16,8 @@ function createAuthor() {
         bannerImageUrl: new URL('http://foobar.com/banner/foobar.png'),
     });
 
+    const draft = AccountEntity.draft(draftData);
+
     return AccountEntity.create({
         id: 123,
         ...draft,
@@ -23,8 +25,8 @@ function createAuthor() {
 }
 
 describe('postToPostDTO', () => {
-    it('Should use apIds as the id', () => {
-        const author = createAuthor();
+    it('Should use apIds as the id', async () => {
+        const author = await createAuthor();
         const post = Post.createFromData(author, {
             type: PostType.Note,
             content: 'Hello, world!',
@@ -36,8 +38,8 @@ describe('postToPostDTO', () => {
         expect(dto.author.id).toEqual(post.author.apId.href);
     });
 
-    it('Should default title, excerpt and content to empty strings', () => {
-        const author = createAuthor();
+    it('Should default title, excerpt and content to empty strings', async () => {
+        const author = await createAuthor();
 
         const post = Post.createFromData(author, {
             type: PostType.Note,
@@ -50,8 +52,8 @@ describe('postToPostDTO', () => {
         expect(dto.content).toEqual('');
     });
 
-    it('should default to a metadata object with an empty ghostAuthors array', () => {
-        const author = createAuthor();
+    it('should default to a metadata object with an empty ghostAuthors array', async () => {
+        const author = await createAuthor();
 
         const post = Post.createFromData(author, {
             type: PostType.Note,
@@ -63,8 +65,8 @@ describe('postToPostDTO', () => {
         expect(dto.metadata).toEqual({ ghostAuthors: [] });
     });
 
-    it('Should include summary in the DTO', () => {
-        const author = createAuthor();
+    it('Should include summary in the DTO', async () => {
+        const author = await createAuthor();
 
         const post = Post.createFromData(author, {
             type: PostType.Article,
@@ -82,8 +84,8 @@ describe('postToPostDTO', () => {
         expect(dto.content).toEqual('Test content');
     });
 
-    it('Should default summary to null', () => {
-        const author = createAuthor();
+    it('Should default summary to null', async () => {
+        const author = await createAuthor();
 
         const post = Post.createFromData(author, {
             type: PostType.Note,

--- a/src/http/api/post.unit.test.ts
+++ b/src/http/api/post.unit.test.ts
@@ -7,6 +7,7 @@ import { error, ok } from 'core/result';
 import { Audience, Post, PostType } from 'post/post.entity';
 import type { PostService } from 'post/post.service';
 import type { Site } from 'site/site.service';
+import { createInternalAccountDraftData } from '../../test/account-entity-test-helpers';
 import { createGetPostHandler } from './post';
 
 describe('Post API', () => {
@@ -66,7 +67,7 @@ describe('Post API', () => {
         );
     }
 
-    beforeEach(() => {
+    beforeEach(async () => {
         vi.setSystemTime(new Date('2025-03-25T14:00:00Z'));
 
         site = {
@@ -74,8 +75,7 @@ describe('Post API', () => {
             host: 'example.com',
             webhook_secret: 'secret',
         };
-        const draft = AccountEntity.draft({
-            isInternal: true,
+        const draftData = await createInternalAccountDraftData({
             host: new URL('http://example.com'),
             username: 'foobar',
             name: 'Foo Bar',
@@ -84,6 +84,9 @@ describe('Post API', () => {
             avatarUrl: new URL('http://example.com/avatar/foobar.png'),
             bannerImageUrl: new URL('http://example.com/banner/foobar.png'),
         });
+
+        const draft = AccountEntity.draft(draftData);
+
         account = AccountEntity.create({
             id: 456,
             ...draft,

--- a/src/http/api/thread.unit.test.ts
+++ b/src/http/api/thread.unit.test.ts
@@ -6,6 +6,7 @@ import type { AppContext } from 'app';
 import { Audience, Post, PostType } from 'post/post.entity';
 import type { KnexPostRepository } from 'post/post.repository.knex';
 import type { Site } from 'site/site.service';
+import { createInternalAccountDraftData } from '../../test/account-entity-test-helpers';
 import { createGetThreadHandler } from './thread';
 
 describe('Thread API', () => {
@@ -14,7 +15,7 @@ describe('Thread API', () => {
     let account: Account;
     let postRepository: KnexPostRepository;
 
-    beforeEach(() => {
+    beforeEach(async () => {
         vi.setSystemTime(new Date('2025-02-27T15:40:00Z'));
 
         site = {
@@ -22,8 +23,7 @@ describe('Thread API', () => {
             host: 'example.com',
             webhook_secret: 'secret',
         };
-        const draft = AccountEntity.draft({
-            isInternal: true,
+        const draftData = await createInternalAccountDraftData({
             host: new URL('http://example.com'),
             username: 'foobar',
             name: 'Foo Bar',
@@ -32,6 +32,9 @@ describe('Thread API', () => {
             avatarUrl: new URL('http://example.com/avatar/foobar.png'),
             bannerImageUrl: new URL('http://example.com/banner/foobar.png'),
         });
+
+        const draft = AccountEntity.draft(draftData);
+
         account = AccountEntity.create({
             id: 456,
             ...draft,

--- a/src/test/account-entity-test-helpers.ts
+++ b/src/test/account-entity-test-helpers.ts
@@ -1,0 +1,112 @@
+import { AccountEntity } from '../account/account.entity';
+import { generateTestCryptoKeyPair } from './crypto-key-pair';
+
+export async function createInternalAccountDraftData(overrides: {
+    host: URL;
+    username: string;
+    name: string;
+    bio: string | null;
+    url: URL | null;
+    avatarUrl: URL | null;
+    bannerImageUrl: URL | null;
+}) {
+    const keyPair = await generateTestCryptoKeyPair();
+
+    return {
+        isInternal: true as const,
+        host: overrides.host,
+        username: overrides.username,
+        name: overrides.name,
+        bio: overrides.bio,
+        url: overrides.url,
+        avatarUrl: overrides.avatarUrl,
+        bannerImageUrl: overrides.bannerImageUrl,
+        apPublicKey: keyPair.publicKey,
+        apPrivateKey: keyPair.privateKey,
+    };
+}
+
+export async function createExternalAccountDraftData(overrides: {
+    username: string;
+    name: string;
+    bio: string | null;
+    url: URL | null;
+    avatarUrl: URL | null;
+    bannerImageUrl: URL | null;
+    apId: URL;
+    apFollowers: URL | null;
+    apInbox: URL | null;
+    apSharedInbox?: URL | null;
+    apOutbox?: URL | null;
+    apFollowing?: URL | null;
+    apLiked?: URL | null;
+}) {
+    const keyPair = await generateTestCryptoKeyPair();
+
+    return {
+        isInternal: false as const,
+        username: overrides.username,
+        name: overrides.name,
+        bio: overrides.bio,
+        url: overrides.url,
+        avatarUrl: overrides.avatarUrl,
+        bannerImageUrl: overrides.bannerImageUrl,
+        apId: overrides.apId,
+        apFollowers: overrides.apFollowers,
+        apInbox: overrides.apInbox,
+        apSharedInbox: overrides.apSharedInbox || null,
+        apOutbox: overrides.apOutbox || null,
+        apFollowing: overrides.apFollowing || null,
+        apLiked: overrides.apLiked || null,
+        apPublicKey: keyPair.publicKey,
+    };
+}
+
+// Helper functions that create full account entities
+export async function createTestInternalAccount(
+    id: number,
+    overrides: {
+        host: URL;
+        username: string;
+        name: string;
+        bio: string | null;
+        url: URL | null;
+        avatarUrl: URL | null;
+        bannerImageUrl: URL | null;
+    },
+) {
+    const draftData = await createInternalAccountDraftData(overrides);
+    const draft = AccountEntity.draft(draftData);
+
+    return AccountEntity.create({
+        id,
+        ...draft,
+    });
+}
+
+export async function createTestExternalAccount(
+    id: number,
+    overrides: {
+        username: string;
+        name: string;
+        bio: string | null;
+        url: URL | null;
+        avatarUrl: URL | null;
+        bannerImageUrl: URL | null;
+        apId: URL;
+        apFollowers: URL | null;
+        apInbox: URL | null;
+        apSharedInbox?: URL | null;
+        apOutbox?: URL | null;
+        apFollowing?: URL | null;
+        apLiked?: URL | null;
+    },
+) {
+    const draftData = await createExternalAccountDraftData(overrides);
+    const draft = AccountEntity.draft(draftData);
+
+    return AccountEntity.create({
+        id,
+        ...draft,
+    });
+}


### PR DESCRIPTION
no-issue

Up until now, we were unable to actually save an AccountDraft because they didn't contain all of the necessary data. This adds the missing data so we can start to wire them up to the repository.