### PR TITLE
Added center tag support to HTML sanitizer

### DIFF
--- a/src/helpers/html.ts
+++ b/src/helpers/html.ts
@@ -91,6 +91,7 @@ export function sanitizeHtml(content: string): string {
             'path',
             'audio',
             'video',
+            'center'
         ],
         allowedClasses: {
             '*': false,


### PR DESCRIPTION
no issues

- Added <center> HTML tag to allowed list in content sanitizer
- Enabled proper rendering of centered content in the reader