### PR TITLE
Fixed author's fallback URL

### DIFF
--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -1042,7 +1042,7 @@ export class KnexPostRepository {
             username: row.username,
             name: row.name,
             bio: row.bio,
-            url: parseURL(row.author_url) || new URL(row.ap_id),
+            url: parseURL(row.author_url) || new URL(row.author_ap_id),
             avatarUrl: parseURL(row.avatar_url),
             bannerImageUrl: parseURL(row.banner_image_url),
             apId: new URL(row.author_ap_id),


### PR DESCRIPTION
no issue

- This was using the post AP ID instead of the author AP ID
- This bug has been silently there in the codebase
- coderabbitai found this issue in one of my refactoring PRs yesterday. Details [here](https://github.com/TryGhost/ActivityPub/pull/881#discussion_r2154683921)