### PR TITLE
Fixed Mentions for Ghost AP user's post

### DIFF
--- a/src/http/api/views/account.posts.view.ts
+++ b/src/http/api/views/account.posts.view.ts
@@ -437,15 +437,18 @@ export class AccountPostsView {
                         ? activity.object.tag
                         : [activity.object.tag];
 
-                    for await (const tag of tags) {
-                        if (tag.type === 'Mention') {
-                            const mention = await this.getMentionedAccount(
-                                new URL(tag.href),
-                                tag.name,
-                            );
-                            if (!isError(mention)) {
-                                mentionedAccounts.push(getValue(mention));
-                            }
+                    const mentions = tags.filter(
+                        (tag) => tag.type === 'Mention',
+                    );
+
+                    for (const mention of mentions) {
+                        const account = await this.getMentionedAccount(
+                            new URL(mention.href),
+                            mention.name,
+                        );
+
+                        if (!isError(account)) {
+                            mentionedAccounts.push(getValue(account));
                         }
                     }
                     activity.object.content = ContentPreparer.updateMentions(

--- a/src/http/api/views/account.posts.view.ts
+++ b/src/http/api/views/account.posts.view.ts
@@ -433,7 +433,11 @@ export class AccountPostsView {
 
                 if (activity.object.tag && activity.object.type === 'Note') {
                     const mentionedAccounts: Mention[] = [];
-                    for await (const tag of activity.object.tag) {
+                    const tags = Array.isArray(activity.object.tag)
+                        ? activity.object.tag
+                        : [activity.object.tag];
+
+                    for await (const tag of tags) {
                         if (tag.type === 'Mention') {
                             const mention = await this.getMentionedAccount(
                                 new URL(tag.href),

--- a/src/http/api/views/account.posts.view.unit.test.ts
+++ b/src/http/api/views/account.posts.view.unit.test.ts
@@ -1,9 +1,18 @@
+import { Activity, type Actor, isActor, lookupObject } from '@fedify/fedify';
 import type { FedifyContextFactory } from 'activitypub/fedify-context.factory';
+import { getError, getValue, isError, ok } from 'core/result';
 import type { Knex } from 'knex';
 import { PostType } from 'post/post.entity';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AccountPostsView } from './account.posts.view';
+
+// Mock the fedify modules
+vi.mock('@fedify/fedify', () => ({
+    isActor: vi.fn(),
+    lookupObject: vi.fn(),
+    Activity: class MockActivity {},
+}));
 
 describe('Account Posts View', () => {
     let view: AccountPostsView;
@@ -23,6 +32,216 @@ describe('Account Posts View', () => {
             getFedifyContext: vi.fn(),
         } as unknown as FedifyContextFactory;
         view = new AccountPostsView(db, fedifyContextFactory);
+    });
+
+    describe('getPostsByRemoteLookUp', () => {
+        const mockDocumentLoader = {};
+        const mockContext = {
+            getDocumentLoader: vi.fn().mockResolvedValue(mockDocumentLoader),
+        } as unknown as ReturnType<
+            typeof fedifyContextFactory.getFedifyContext
+        >;
+        let mockGetByApId: ReturnType<typeof vi.fn>;
+        let mockGetMentionedAccount: ReturnType<typeof vi.fn>;
+
+        beforeEach(() => {
+            mockGetByApId = vi.fn().mockResolvedValue(null);
+            mockGetMentionedAccount = vi.fn().mockResolvedValue(
+                ok({
+                    name: 'testuser',
+                    href: new URL('https://example.com/users/1'),
+                    account: {},
+                }),
+            );
+
+            Object.assign(view, {
+                getByApId: mockGetByApId,
+                getMentionedAccount: mockGetMentionedAccount,
+            });
+        });
+
+        it('should process mentions when tag is an object', async () => {
+            const mockActivity = {
+                getObject: vi.fn().mockResolvedValue({
+                    id: 'https://example.com/posts/123',
+                    type: 'Note',
+                    name: 'Test Post',
+                    content: 'Test content @testuser@example.com',
+                    url: 'https://example.com/posts/123',
+                    published: '2024-01-01T00:00:00Z',
+                    attributedTo: {
+                        id: 'https://example.com/users/1',
+                        preferredUsername: 'testuser',
+                        name: 'Test User',
+                    },
+                }),
+                toJsonLd: vi.fn().mockResolvedValue({
+                    type: 'Create',
+                    object: {
+                        id: 'https://example.com/posts/123',
+                        type: 'Note',
+                        name: 'Test Post',
+                        content: 'Test content @testuser@example.com',
+                        url: 'https://example.com/posts/123',
+                        published: '2024-01-01T00:00:00Z',
+                        tag: {
+                            type: 'Mention',
+                            name: '@testuser@example.com',
+                            href: 'https://example.com/users/1',
+                        },
+                        attributedTo: {
+                            id: 'https://example.com/users/1',
+                            preferredUsername: 'testuser',
+                            name: 'Test User',
+                        },
+                    },
+                    actor: {
+                        id: 'https://example.com/users/1',
+                        preferredUsername: 'testuser',
+                        name: 'Test User',
+                    },
+                }),
+            };
+
+            const mockActivityInstance = Object.create(
+                vi.mocked(Activity).prototype,
+            );
+            Object.assign(mockActivityInstance, mockActivity);
+
+            const mockPage = {
+                getItems: vi.fn().mockReturnValue([mockActivityInstance]),
+                nextId: null,
+            };
+            const mockOutbox = {
+                getFirst: vi.fn().mockResolvedValue(mockPage),
+            };
+
+            const mockActor = {
+                id: new URL('https://remote.com/users/2'),
+                getOutbox: vi.fn().mockResolvedValue(mockOutbox),
+            } as unknown as Actor;
+
+            vi.mocked(fedifyContextFactory.getFedifyContext).mockReturnValue(
+                mockContext,
+            );
+            vi.mocked(lookupObject).mockResolvedValue(mockActor);
+            vi.mocked(isActor).mockReturnValue(true);
+
+            const result = await view.getPostsByRemoteLookUp(
+                1,
+                new URL('https://example.com/users/1'),
+                new URL('https://remote.com/users/2'),
+                null,
+            );
+
+            if (isError(result)) {
+                throw new Error(getError(result));
+            }
+            const posts = getValue(result);
+            expect(posts.results).toHaveLength(1);
+            expect(mockGetMentionedAccount).toHaveBeenCalledWith(
+                new URL('https://example.com/users/1'),
+                '@testuser@example.com',
+            );
+        });
+
+        it('should process mentions when tag is an array', async () => {
+            const mockActivity = {
+                getObject: vi.fn().mockResolvedValue({
+                    id: 'https://example.com/posts/123',
+                    type: 'Note',
+                    name: 'Test Post',
+                    content:
+                        'Test content @testuser@example.com @anotheruser@example.com',
+                    url: 'https://example.com/posts/123',
+                    published: '2024-01-01T00:00:00Z',
+                    attributedTo: {
+                        id: 'https://example.com/users/1',
+                        preferredUsername: 'testuser',
+                        name: 'Test User',
+                    },
+                }),
+                toJsonLd: vi.fn().mockResolvedValue({
+                    type: 'Create',
+                    object: {
+                        id: 'https://example.com/posts/123',
+                        type: 'Note',
+                        name: 'Test Post',
+                        content:
+                            'Test content @testuser@example.com @anotheruser@example.com',
+                        url: 'https://example.com/posts/123',
+                        published: '2024-01-01T00:00:00Z',
+                        tag: [
+                            {
+                                type: 'Mention',
+                                name: '@testuser@example.com',
+                                href: 'https://example.com/users/1',
+                            },
+                            {
+                                type: 'Mention',
+                                name: '@anotheruser@example.com',
+                                href: 'https://example.com/users/2',
+                            },
+                        ],
+                        attributedTo: {
+                            id: 'https://example.com/users/1',
+                            preferredUsername: 'testuser',
+                            name: 'Test User',
+                        },
+                    },
+                    actor: {
+                        id: 'https://example.com/users/1',
+                        preferredUsername: 'testuser',
+                        name: 'Test User',
+                    },
+                }),
+            };
+
+            const mockActivityInstance = Object.create(
+                vi.mocked(Activity).prototype,
+            );
+            Object.assign(mockActivityInstance, mockActivity);
+
+            const mockPage = {
+                getItems: vi.fn().mockReturnValue([mockActivityInstance]),
+                nextId: null,
+            };
+            const mockOutbox = {
+                getFirst: vi.fn().mockResolvedValue(mockPage),
+            };
+            const mockActor = {
+                id: new URL('https://remote.com/users/2'),
+                getOutbox: vi.fn().mockResolvedValue(mockOutbox),
+            } as unknown as Actor;
+
+            vi.mocked(fedifyContextFactory.getFedifyContext).mockReturnValue(
+                mockContext,
+            );
+            vi.mocked(lookupObject).mockResolvedValue(mockActor);
+            vi.mocked(isActor).mockReturnValue(true);
+
+            const result = await view.getPostsByRemoteLookUp(
+                1,
+                new URL('https://example.com/users/1'),
+                new URL('https://remote.com/users/2'),
+                null,
+            );
+
+            if (isError(result)) {
+                throw new Error(getError(result));
+            }
+            const posts = getValue(result);
+            expect(posts.results).toHaveLength(1);
+            expect(mockGetMentionedAccount).toHaveBeenCalledTimes(2);
+            expect(mockGetMentionedAccount).toHaveBeenCalledWith(
+                new URL('https://example.com/users/1'),
+                '@testuser@example.com',
+            );
+            expect(mockGetMentionedAccount).toHaveBeenCalledWith(
+                new URL('https://example.com/users/2'),
+                '@anotheruser@example.com',
+            );
+        });
     });
 
     describe('mapActivityToPostDTO', () => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2066/

- `tags` can be an object when there is only one item in tag
- Handled this so that we correctly render mentions in both cases - 1. When tag is array, 2. When tag is an object