### PR TITLE
Injected PubSubEvents into the message handler

### DIFF
--- a/src/configuration/registrations.ts
+++ b/src/configuration/registrations.ts
@@ -134,6 +134,7 @@ export function registerDependencies(
 
     if (deps.globalPubSubEvents) {
         container.register('commandBus', asValue(deps.globalPubSubEvents));
+        container.register('pubSubEvents', asValue(deps.globalPubSubEvents));
     } else {
         container.register('commandBus', asValue(new AsyncEvents()));
     }

--- a/src/events/pubsub-http.ts
+++ b/src/events/pubsub-http.ts
@@ -21,7 +21,7 @@ const IncomingMessagePayloadSchema = z.object({
 });
 
 export function createIncomingPubSubMessageHandler(
-    events: PubSubEvents,
+    pubSubEvents: PubSubEvents,
     fedify: Federation<ContextData>,
     fedifyContextFactory: FedifyContextFactory,
 ) {
@@ -68,7 +68,7 @@ export function createIncomingPubSubMessageHandler(
             await fedifyContextFactory.registerContext(
                 hostFedifyCtx,
                 async () => {
-                    await events.handleIncomingMessage(
+                    await pubSubEvents.handleIncomingMessage(
                         payload.message.data,
                         payload.message.attributes,
                     );


### PR DESCRIPTION
ref https://github.com/TryGhost/ActivityPub/commit/b8de38e

During a refactor we inadvertently switched from injecting a PubSubEvents instance to an AsyncEvents instance which caused a runtime error. This adds a new dependency `pubSubEvents` which is specific to that type, and updates the handler to have it injected correctly.