### PR TITLE
Enabled auto-merge for Docker

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,10 +1,22 @@
 {
-  "extends": ["github>tryghost/renovate-config"],
+  "extends": [
+    "github>tryghost/renovate-config",
+    // Pin Docker image digests for reproducible builds
+    // See: https://docs.renovatebot.com/presets-docker/#dockerpindigests
+    "docker:pinDigests",
+    // Disable major version updates for Docker images
+    // See: https://docs.renovatebot.com/presets-docker/#dockerdisablemajor
+    "docker:disableMajor"
+  ],
   // Automerge only on Monday, Tuesday and Wednesday, during common working hours (08:00 - 16:00 UTC)
   // Rationale: merging to main ships to production, so we want to avoid automerging when no engineer is online
   // Note: this doesn't restrict when the PRs are opened by Renovate, only when they are merged
   "automergeSchedule": ["* 8-15 * * 1,2,3"],
   "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "automerge": true
+    },
     {
       "matchPackageNames": ["@fedify/fedify", "@fedify/fedify-cli"],
       "automerge": false


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2078

- Renovate will now auto-merge minor / patch upgrades for Docker images (but not major upgrades)
- Renovate will also pin Docker digests, so that builds are reproducible