### PR TITLE
Restricted Renovate auto-merge to Mon/Tue/Wed during working hours

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,9 @@
 {
   "extends": ["github>tryghost/renovate-config"],
+  // Automerge only on Monday, Tuesday and Wednesday, during common working hours (08:00 - 16:00 UTC)
+  // Rationale: merging to main ships to production, so we want to avoid automerging when no engineer is online
+  // Note: this doesn't restrict when the PRs are opened by Renovate, only when they are merged
+  "automergeSchedule": ["* 8-15 * * 1,2,3"],
   "packageRules": [
     {
       "matchPaths": ["cedar/**", "jobs/**"],


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2078

- merging to main ships to production, therefore we want to auto-merge dependency updates only when engineers are online and preferrably earlier in the week