### PR TITLE
Enabled auto-merge for minor and patch versions regardless of their version number

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,23 @@
   "extends": ["github>tryghost/renovate-config"],
   "packageRules": [
     {
+      // Override the base config to automerge minor and patch updates regardless of version
+      // This overrides the ">= 1.0.0" restriction from the shared config
+      "matchCurrentVersion": "/.*/",  // Match any version
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchDepTypes": [
+        "devDependencies",
+        "dependencies",
+        "optionalDependencies"
+      ],
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
+    {
       "matchPackageNames": ["@fedify/fedify", "@fedify/fedify-cli"],
       "automerge": false
     }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2078

- our shared config only allows auto-merge on minor and patch versions if the version number is higher than or equal to 1.0.0
- this commit overrides the shared behaviour and allows auto-merging patch/minor versions even if there are on major 0