### PR TITLE
Removed unnessary Renovate rule for /cedar and /jobs repos

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,10 +2,6 @@
   "extends": ["github>tryghost/renovate-config"],
   "packageRules": [
     {
-      "matchPaths": ["cedar/**", "jobs/**"],
-      "automerge": true
-    },
-    {
       "matchPackageNames": ["@fedify/fedify", "@fedify/fedify-cli"],
       "automerge": false
     }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2078

- there shouldn't be a need for a specific rule for the /cedar and /jobs subdirectories
- the reason why past dependency updates in cedar/jobs needed manual approval was because they were on the 0 major