### PR TITLE
Excluded jobs without automated tests from Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,6 +20,11 @@
     {
       "matchPackageNames": ["@fedify/fedify", "@fedify/fedify-cli"],
       "automerge": false
+    },
+    {
+      // Exclude dependencies in jobs that don't have automated tests
+      "matchPaths": ["jobs/populate-explore-json/**", "jobs/cleanup-expired-key-value-records/**"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2078/configure-renovate-to-auto-merge-deps-in-a-safe-way

- jobs populate-explore-json and cleanup-expired-key-value-records currently don't have automated tests, so we don't want to auto-merge dependency updates for them