### PR TITLE
Consolidated queue services

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -306,8 +306,7 @@ jobs:
           export TF_VAR_primary_region_name=netherlands
           export TF_VAR_migrations_image=europe-docker.pkg.dev/ghost-activitypub/activitypub/migrations:pr-${{ github.event.pull_request.number }}
           export TF_VAR_api_image=europe-docker.pkg.dev/ghost-activitypub/activitypub/activitypub:pr-${{ github.event.pull_request.number }}
-          export TF_VAR_fedify_queue_image=europe-docker.pkg.dev/ghost-activitypub/activitypub/activitypub:pr-${{ github.event.pull_request.number }}
-          export TF_VAR_ghost_queue_image=europe-docker.pkg.dev/ghost-activitypub/activitypub/activitypub:pr-${{ github.event.pull_request.number }}
+          export TF_VAR_queue_image=europe-docker.pkg.dev/ghost-activitypub/activitypub/activitypub:pr-${{ github.event.pull_request.number }}
           terraform apply -auto-approve
 
       - name: "Deploy Migrations to Cloud Run"
@@ -416,22 +415,12 @@ jobs:
           labels: |-
             commit-sha=${{ github.sha }}
 
-      - name: "Deploy ActivityPub Fedify Queue to Cloud Run"
+      - name: "Deploy ActivityPub Queue to Cloud Run"
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           image: europe-docker.pkg.dev/ghost-activitypub/activitypub/activitypub:${{ needs.build-test-push.outputs.activitypub_docker_version }}
           region: ${{ matrix.region }}
-          service: stg-${{ matrix.region_name }}-activitypub-fedify-queue
-          skip_default_labels: true
-          labels: |-
-            commit-sha=${{ github.sha }}
-
-      - name: "Deploy ActivityPub Ghost Queue to Cloud Run"
-        uses: google-github-actions/deploy-cloudrun@v2
-        with:
-          image: europe-docker.pkg.dev/ghost-activitypub/activitypub/activitypub:${{ needs.build-test-push.outputs.activitypub_docker_version }}
-          region: ${{ matrix.region }}
-          service: stg-${{ matrix.region_name }}-activitypub-ghost-queue
+          service: stg-${{ matrix.region_name }}-activitypub-queue
           skip_default_labels: true
           labels: |-
             commit-sha=${{ github.sha }}
@@ -497,22 +486,12 @@ jobs:
           labels: |-
             commit-sha=${{ github.sha }}
 
-      - name: "Deploy ActivityPub Fedify Queue to Cloud Run"
+      - name: "Deploy ActivityPub Queue to Cloud Run"
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           image: europe-docker.pkg.dev/ghost-activitypub/activitypub/activitypub:${{ needs.build-test-push.outputs.activitypub_docker_version }}
           region: ${{ matrix.region }}
-          service: prd-${{ matrix.region_name }}-activitypub-fedify-queue
-          skip_default_labels: true
-          labels: |-
-            commit-sha=${{ github.sha }}
-
-      - name: "Deploy ActivityPub Ghost Queue to Cloud Run"
-        uses: google-github-actions/deploy-cloudrun@v2
-        with:
-          image: europe-docker.pkg.dev/ghost-activitypub/activitypub/activitypub:${{ needs.build-test-push.outputs.activitypub_docker_version }}
-          region: ${{ matrix.region }}
-          service: prd-${{ matrix.region_name }}-activitypub-ghost-queue
+          service: prd-${{ matrix.region_name }}-activitypub-queue
           skip_default_labels: true
           labels: |-
             commit-sha=${{ github.sha }}


### PR DESCRIPTION
ref no-issue

- Consolidated fedify-queue and ghost-queue services. These were created due to the terraform module only supporting one pubsub subscription. The module has been refactored and now these services can be merged.