### PR TITLE
Added /feed/notes and /feed/reader APIs

### DIFF
--- a/features/feed.feature
+++ b/features/feed.feature
@@ -20,7 +20,7 @@ Feature: Feed
     And a "Create(Note)" Activity "Note2" by "Alice"
     And "Alice" sends "Note2" to the Inbox
     And the note "Note2" is in our feed
-    When an authenticated request is made to "/.ghost/activitypub/feed"
+    When an authenticated request is made to "/.ghost/activitypub/feed/notes"
     Then the request is accepted
     And post "1" in the "feed" response is "Note2"
     And post "2" in the "feed" response is "Note1"
@@ -35,18 +35,18 @@ Feature: Feed
     And a "Create(Note)" Activity "Note3" by "Alice"
     And "Alice" sends "Note3" to the Inbox
     And the note "Note3" is in our feed
-    When an authenticated request is made to "/.ghost/activitypub/feed?limit=2"
+    When an authenticated request is made to "/.ghost/activitypub/feed/notes?limit=2"
     Then the request is accepted
     And "Note3" is in the feed
     And "Note2" is in the feed
     And "Note1" is not in the feed
     And the feed response has a next cursor
-    When an authenticated request is made to "/.ghost/activitypub/feed?limit=3"
+    When an authenticated request is made to "/.ghost/activitypub/feed/notes?limit=3"
     Then the request is accepted
     And "Note1" is in the feed
 
   Scenario: Requests with limit over 100 are rejected
-    When an authenticated request is made to "/.ghost/activitypub/feed?limit=200"
+    When an authenticated request is made to "/.ghost/activitypub/feed/notes?limit=200"
     Then the request is rejected with a 400
 
   Scenario: Feed includes our own posts

--- a/features/handle-delete.feature
+++ b/features/handle-delete.feature
@@ -11,13 +11,13 @@ Feature: Delete(Note)
 
   Scenario: We receive a Delete(Note) activity from someone we follow
     Given a "Delete(AliceNote)" Activity "DeleteNote" by "Alice"
-    When an authenticated request is made to "/.ghost/activitypub/feed"
+    When an authenticated request is made to "/.ghost/activitypub/feed/notes"
     Then the request is accepted
     And "AliceNote" is not in the feed
 
   Scenario: We receive a Delete(Note) activity from someone who didn't create the post
     Given a "Delete(AliceNote)" Activity "DeleteNote" by "Bob"
-    When an authenticated request is made to "/.ghost/activitypub/feed"
+    When an authenticated request is made to "/.ghost/activitypub/feed/notes"
     Then the request is accepted
     And "AliceNote" is not in the feed
 

--- a/features/step_definitions/feed_steps.js
+++ b/features/step_definitions/feed_steps.js
@@ -1,23 +1,8 @@
 import assert from 'node:assert';
 
-import { Then, When } from '@cucumber/cucumber';
+import { Then } from '@cucumber/cucumber';
 
 import { waitForAPObjectInFeed } from '../support/feed.js';
-import { fetchActivityPub } from '../support/request.js';
-
-When('we request the feed with the next cursor', async function () {
-    const responseJson = await this.response.clone().json();
-    const nextCursor = responseJson.next;
-
-    this.response = await fetchActivityPub(
-        `http://fake-ghost-activitypub.test/.ghost/activitypub/feed/index?next=${encodeURIComponent(nextCursor)}`,
-        {
-            headers: {
-                Accept: 'application/json',
-            },
-        },
-    );
-});
 
 Then(
     'the {string} in the feed has content {string}',

--- a/features/step_definitions/repost_steps.js
+++ b/features/step_definitions/repost_steps.js
@@ -18,7 +18,7 @@ When('we repost the object {string}', async function (name) {
 
 Then('the object {string} should be reposted', async function (name) {
     const response = await fetchActivityPub(
-        'http://fake-ghost-activitypub.test/.ghost/activitypub/feed',
+        'http://fake-ghost-activitypub.test/.ghost/activitypub/feed/notes',
         {
             headers: {
                 Accept: 'application/ld+json',
@@ -38,7 +38,7 @@ Then(
     'the object {string} should have a repost count of {int}',
     async function (name, repostCount) {
         const response = await fetchActivityPub(
-            'http://fake-ghost-activitypub.test/.ghost/activitypub/feed',
+            'http://fake-ghost-activitypub.test/.ghost/activitypub/feed/notes',
             {
                 headers: {
                     Accept: 'application/ld+json',
@@ -67,7 +67,7 @@ When('we undo the repost of the object {string}', async function (name) {
 
 Then('the object {string} should not be reposted', async function (name) {
     const response = await fetchActivityPub(
-        'http://fake-ghost-activitypub.test/.ghost/activitypub/feed',
+        'http://fake-ghost-activitypub.test/.ghost/activitypub/feed/notes',
         {
             headers: {
                 Accept: 'application/ld+json',

--- a/features/support/feed.js
+++ b/features/support/feed.js
@@ -10,7 +10,7 @@ export async function waitForItemInFeed(
     const MAX_RETRIES = 5;
 
     const response = await fetchActivityPub(
-        'http://fake-ghost-activitypub.test/.ghost/activitypub/feed',
+        'http://fake-ghost-activitypub.test/.ghost/activitypub/feed/notes',
         {
             headers: {
                 Accept: 'application/ld+json',
@@ -54,7 +54,7 @@ export async function waitForAPObjectInFeed(
     const MAX_RETRIES = 5;
 
     const response = await fetchActivityPub(
-        'http://fake-ghost-activitypub.test/.ghost/activitypub/feed',
+        'http://fake-ghost-activitypub.test/.ghost/activitypub/feed/notes',
         {
             headers: {
                 Accept: 'application/ld+json',

--- a/features/support/inbox.js
+++ b/features/support/inbox.js
@@ -10,7 +10,7 @@ export async function waitForItemInInbox(
     const MAX_RETRIES = 5;
 
     const response = await fetchActivityPub(
-        'http://fake-ghost-activitypub.test/.ghost/activitypub/inbox',
+        'http://fake-ghost-activitypub.test/.ghost/activitypub/feed/reader',
         {
             headers: {
                 Accept: 'application/ld+json',
@@ -54,7 +54,7 @@ export async function waitForAPObjectInInbox(
     const MAX_RETRIES = 5;
 
     const response = await fetchActivityPub(
-        'http://fake-ghost-activitypub.test/.ghost/activitypub/inbox',
+        'http://fake-ghost-activitypub.test/.ghost/activitypub/feed/reader',
         {
             headers: {
                 Accept: 'application/ld+json',

--- a/src/app.ts
+++ b/src/app.ts
@@ -1122,6 +1122,22 @@ app.get(
     }),
 );
 app.get(
+    '/.ghost/activitypub/feed/notes',
+    requireRole(GhostRole.Owner, GhostRole.Administrator),
+    spanWrapper((ctx: AppContext) => {
+        const handlerFactory = container.resolve('getFeedHandler');
+        return handlerFactory('Feed')(ctx);
+    }),
+);
+app.get(
+    '/.ghost/activitypub/feed/reader',
+    requireRole(GhostRole.Owner, GhostRole.Administrator),
+    spanWrapper((ctx: AppContext) => {
+        const handlerFactory = container.resolve('getFeedHandler');
+        return handlerFactory('Inbox')(ctx);
+    }),
+);
+app.get(
     '/.ghost/activitypub/post/:post_ap_id',
     requireRole(GhostRole.Owner, GhostRole.Administrator),
     spanWrapper((ctx: AppContext) => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2186
ref https://linear.app/ghost/issue/PROD-2184

We want to rename these concepts in the UI and I'd like to update the API now while we can, so we keep everything in sync.