### PR TITLE
Prevented unecessary like & repost count updates

### DIFF
--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -113,6 +113,8 @@ export class Post extends BaseEntity {
     private repostsToAdd: Set<number> = new Set();
     private repostsToRemove: Set<number> = new Set();
     private deleted = false;
+    private _likeCountDirty = false;
+    private _repostCountDirty = false;
     public readonly content: string | null;
     public readonly mentions: MentionedAccount[] = [];
 
@@ -269,6 +271,7 @@ export class Post extends BaseEntity {
         }
 
         this._likeCount = count;
+        this._likeCountDirty = true;
     }
 
     get repostCount() {
@@ -283,6 +286,20 @@ export class Post extends BaseEntity {
         }
 
         this._repostCount = count;
+        this._repostCountDirty = true;
+    }
+
+    get isLikeCountDirty() {
+        return this._likeCountDirty;
+    }
+
+    get isRepostCountDirty() {
+        return this._repostCountDirty;
+    }
+
+    clearDirtyFlags() {
+        this._likeCountDirty = false;
+        this._repostCountDirty = false;
     }
 
     static async createArticleFromGhostPost(

--- a/src/post/post.entity.unit.test.ts
+++ b/src/post/post.entity.unit.test.ts
@@ -1068,4 +1068,110 @@ describe('Post', () => {
             expect(post.repostCount).toBe(10);
         });
     });
+
+    describe('dirty flags', () => {
+        describe('setLikeCount with dirty flag', () => {
+            it('should set the dirty flag when like count is changed', async () => {
+                const author = await externalAccount();
+                const apId = new URL('https://example.com/post');
+
+                const post = Post.createFromData(author, {
+                    type: PostType.Note,
+                    content: 'This is a test note',
+                    apId,
+                });
+
+                expect(post.isLikeCountDirty).toBe(false);
+
+                post.setLikeCount(10);
+
+                expect(post.isLikeCountDirty).toBe(true);
+                expect(post.likeCount).toBe(10);
+            });
+
+            it('should clear dirty flag when clearDirtyFlags is called', async () => {
+                const author = await externalAccount();
+                const apId = new URL('https://example.com/post');
+
+                const post = Post.createFromData(author, {
+                    type: PostType.Note,
+                    content: 'This is a test note',
+                    apId,
+                });
+
+                post.setLikeCount(10);
+                expect(post.isLikeCountDirty).toBe(true);
+
+                post.clearDirtyFlags();
+
+                expect(post.isLikeCountDirty).toBe(false);
+                expect(post.likeCount).toBe(10); // Count should remain unchanged
+            });
+        });
+
+        describe('setRepostCount with dirty flag', () => {
+            it('should set the dirty flag when repost count is changed', async () => {
+                const author = await externalAccount();
+                const apId = new URL('https://example.com/post');
+
+                const post = Post.createFromData(author, {
+                    type: PostType.Note,
+                    content: 'This is a test note',
+                    apId,
+                });
+
+                expect(post.isRepostCountDirty).toBe(false);
+
+                post.setRepostCount(5);
+
+                expect(post.isRepostCountDirty).toBe(true);
+                expect(post.repostCount).toBe(5);
+            });
+
+            it('should clear dirty flag when clearDirtyFlags is called', async () => {
+                const author = await externalAccount();
+                const apId = new URL('https://example.com/post');
+
+                const post = Post.createFromData(author, {
+                    type: PostType.Note,
+                    content: 'This is a test note',
+                    apId,
+                });
+
+                post.setRepostCount(5);
+                expect(post.isRepostCountDirty).toBe(true);
+
+                post.clearDirtyFlags();
+
+                expect(post.isRepostCountDirty).toBe(false);
+                expect(post.repostCount).toBe(5); // Count should remain unchanged
+            });
+        });
+
+        describe('clearDirtyFlags', () => {
+            it('should clear both like and repost dirty flags', async () => {
+                const author = await externalAccount();
+                const apId = new URL('https://example.com/post');
+
+                const post = Post.createFromData(author, {
+                    type: PostType.Note,
+                    content: 'This is a test note',
+                    apId,
+                });
+
+                post.setLikeCount(10);
+                post.setRepostCount(5);
+
+                expect(post.isLikeCountDirty).toBe(true);
+                expect(post.isRepostCountDirty).toBe(true);
+
+                post.clearDirtyFlags();
+
+                expect(post.isLikeCountDirty).toBe(false);
+                expect(post.isRepostCountDirty).toBe(false);
+                expect(post.likeCount).toBe(10);
+                expect(post.repostCount).toBe(5);
+            });
+        });
+    });
 });

--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -336,7 +336,7 @@ export class KnexPostRepository {
                     // If no likes were added or removed, and the post is
                     // external, update the like count in the database to
                     // account for manual changes to the post's like count
-                    if (!post.isInternal) {
+                    if (!post.isInternal && post.isLikeCountDirty) {
                         await transaction('posts')
                             .update({
                                 like_count: post.likeCount,
@@ -409,7 +409,7 @@ export class KnexPostRepository {
                     // If no reposts were added or removed, and the post is
                     // external, update the repost count in the database to
                     // account for manual changes to the post's repost count
-                    if (!post.isInternal) {
+                    if (!post.isInternal && post.isRepostCountDirty) {
                         await transaction('posts')
                             .update({
                                 repost_count: post.repostCount,
@@ -420,6 +420,9 @@ export class KnexPostRepository {
             }
 
             await transaction.commit();
+
+            // Clear dirty flags after successful save
+            post.clearDirtyFlags();
 
             if (isNewPost) {
                 await this.events.emitAsync(


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2098

We think that the unecessary updates to these columns is causing
contention on the rows, and resulting in slow queries. This solution is
a little bit dirty, pun intended, but a fast way to validate the problem.
