### PR TITLE
Updated Create Activity to use Note publishedAt time

### DIFF
--- a/src/activitypub/__snapshots__/publish-note-create-activity-with-mentions.json
+++ b/src/activitypub/__snapshots__/publish-note-create-activity-with-mentions.json
@@ -35,7 +35,7 @@
     ],
     "content": "Hello! @test@example.com",
     "id": "https://example.com/note/post-123",
-    "published": "2025-01-17T10:30:00Z",
+    "published": "2025-01-01T00:00:00Z",
     "tag": {
       "href": "https://example.com/@test",
       "name": "@test@example.com",

--- a/src/activitypub/__snapshots__/publish-note-create-activity.json
+++ b/src/activitypub/__snapshots__/publish-note-create-activity.json
@@ -29,7 +29,7 @@
     "cc": "https://example.com/user/foo/followers",
     "content": "Note content",
     "id": "https://example.com/note/post-123",
-    "published": "2025-01-17T10:30:00Z",
+    "published": "2025-01-01T00:00:00Z",
     "to": "as:Public",
     "type": "Note",
   },

--- a/src/activitypub/fediverse-bridge.unit.test.ts
+++ b/src/activitypub/fediverse-bridge.unit.test.ts
@@ -14,24 +14,6 @@ import type { FedifyContextFactory } from './fedify-context.factory';
 import { FediverseBridge } from './fediverse-bridge';
 import type { UriBuilder } from './uri';
 
-vi.mock('@js-temporal/polyfill', async () => {
-    const original = await import('@js-temporal/polyfill');
-
-    return {
-        Temporal: {
-            ...original.Temporal,
-            Now: {
-                // Return a fixed instant for deterministic testing
-                instant: vi
-                    .fn()
-                    .mockReturnValue(
-                        original.Temporal.Instant.from('2025-01-17T10:30:00Z'),
-                    ),
-            },
-        },
-    };
-});
-
 const nextTick = () => new Promise((resolve) => process.nextTick(resolve));
 
 describe('FediverseBridge', () => {
@@ -392,6 +374,7 @@ describe('FediverseBridge', () => {
         post.apId = new URL('https://example.com/note/post-123');
         post.mentions = [];
         post.uuid = 'cb1e7e92-5560-4ceb-9272-7e9d0e2a7da4';
+        post.publishedAt = new Date('2025-01-01T00:00:00Z');
 
         const event = new PostCreatedEvent(post);
         events.emit(PostCreatedEvent.getName(), event);
@@ -437,6 +420,7 @@ describe('FediverseBridge', () => {
         post.apId = new URL('https://example.com/note/post-123');
         post.mentions = [mentionedAccount];
         post.uuid = 'cb1e7e92-5560-4ceb-9272-7e9d0e2a7da4';
+        post.publishedAt = new Date('2025-01-01T00:00:00Z');
 
         const event = new PostCreatedEvent(post);
         events.emit(PostCreatedEvent.getName(), event);

--- a/src/helpers/activitypub/__snapshots__/note-create-activity.json
+++ b/src/helpers/activitypub/__snapshots__/note-create-activity.json
@@ -29,7 +29,7 @@
     "cc": "https://example.com/user/foo/followers",
     "content": "Note content",
     "id": "https://example.com/note/post-123",
-    "published": "2025-01-17T10:30:00Z",
+    "published": "2025-01-01T00:00:00Z",
     "to": "as:Public",
     "type": "Note",
   },

--- a/src/helpers/activitypub/__snapshots__/note-object.json
+++ b/src/helpers/activitypub/__snapshots__/note-object.json
@@ -22,7 +22,7 @@
   "cc": "https://example.com/user/foo/followers",
   "content": "Note content",
   "id": "https://example.com/note/post-123",
-  "published": "2025-01-17T10:30:00Z",
+  "published": "2025-01-01T00:00:00Z",
   "to": "as:Public",
   "type": "Note",
 }

--- a/src/helpers/activitypub/__snapshots__/note-with-image-create-activity.json
+++ b/src/helpers/activitypub/__snapshots__/note-with-image-create-activity.json
@@ -34,7 +34,7 @@
     "cc": "https://example.com/user/foo/followers",
     "content": "Note with image",
     "id": "https://example.com/note/post-123",
-    "published": "2025-01-17T10:30:00Z",
+    "published": "2025-01-01T00:00:00Z",
     "to": "as:Public",
     "type": "Note",
   },

--- a/src/helpers/activitypub/__snapshots__/note-with-image-object.json
+++ b/src/helpers/activitypub/__snapshots__/note-with-image-object.json
@@ -27,7 +27,7 @@
   "cc": "https://example.com/user/foo/followers",
   "content": "Note with image",
   "id": "https://example.com/note/post-123",
-  "published": "2025-01-17T10:30:00Z",
+  "published": "2025-01-01T00:00:00Z",
   "to": "as:Public",
   "type": "Note",
 }

--- a/src/helpers/activitypub/__snapshots__/note-with-mentions-create-activity.json
+++ b/src/helpers/activitypub/__snapshots__/note-with-mentions-create-activity.json
@@ -35,7 +35,7 @@
     ],
     "content": "Hello! @test@example.com",
     "id": "https://example.com/note/post-123",
-    "published": "2025-01-17T10:30:00Z",
+    "published": "2025-01-01T00:00:00Z",
     "tag": {
       "href": "https://example.com/@test",
       "name": "@test@example.com",

--- a/src/helpers/activitypub/__snapshots__/note-with-mentions-object.json
+++ b/src/helpers/activitypub/__snapshots__/note-with-mentions-object.json
@@ -25,7 +25,7 @@
   ],
   "content": "Hello! @test@example.com",
   "id": "https://example.com/note/post-123",
-  "published": "2025-01-17T10:30:00Z",
+  "published": "2025-01-01T00:00:00Z",
   "tag": {
     "href": "https://example.com/@test",
     "name": "@test@example.com",

--- a/src/helpers/activitypub/activity.ts
+++ b/src/helpers/activitypub/activity.ts
@@ -39,7 +39,7 @@ export async function buildCreateActivityAndObjectFromPost(
             attribution: post.author.apId,
             content: post.content,
             summary: post.summary,
-            published: Temporal.Now.instant(),
+            published: Temporal.Instant.from(post.publishedAt.toISOString()),
             attachments: post.attachments
                 ? post.attachments
                       .filter((attachment) => attachment.type === 'Image')

--- a/src/helpers/activitypub/activity.unit.test.ts
+++ b/src/helpers/activitypub/activity.unit.test.ts
@@ -15,24 +15,6 @@ import {
     buildCreateActivityAndObjectFromPost,
 } from './activity';
 
-vi.mock('@js-temporal/polyfill', async () => {
-    const original = await import('@js-temporal/polyfill');
-
-    return {
-        Temporal: {
-            ...original.Temporal,
-            Now: {
-                // Return a fixed instant for deterministic testing
-                instant: vi
-                    .fn()
-                    .mockReturnValue(
-                        original.Temporal.Instant.from('2025-01-17T10:30:00Z'),
-                    ),
-            },
-        },
-    };
-});
-
 describe('Build activity', () => {
     let context: FedifyContext;
     let mockUriBuilder: UriBuilder<FedifyObject>;
@@ -80,6 +62,7 @@ describe('Build activity', () => {
             post.apId = new URL('https://example.com/note/post-123');
             post.mentions = [];
             post.uuid = 'cb1e7e92-5560-4ceb-9272-7e9d0e2a7da4';
+            post.publishedAt = new Date('2025-01-01T00:00:00Z');
 
             const result = await buildCreateActivityAndObjectFromPost(
                 post,
@@ -122,6 +105,7 @@ describe('Build activity', () => {
             post.apId = new URL('https://example.com/note/post-123');
             post.mentions = [mentionedAccount];
             post.uuid = 'cb1e7e92-5560-4ceb-9272-7e9d0e2a7da4';
+            post.publishedAt = new Date('2025-01-01T00:00:00Z');
 
             const result = await buildCreateActivityAndObjectFromPost(
                 post,
@@ -159,6 +143,7 @@ describe('Build activity', () => {
             post.apId = new URL('https://example.com/note/post-123');
             post.mentions = [];
             post.uuid = 'cb1e7e92-5560-4ceb-9272-7e9d0e2a7da4';
+            post.publishedAt = new Date('2025-01-01T00:00:00Z');
             post.attachments = [
                 {
                     type: 'Image',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2236/

- We are currently using `Temporal.Now.instant()` - this is okay while building a create activity for Note which is created just now but we use this same method for creating activities for outbox and this `Temporal.Now.instant()` will give wrong publishedAt for the outbox posts. 
- While building the create activity for Notes we can directly use the `publishedAt` field from Post
- `publishedAt` is a non Null field in Post entity