### PR TITLE
Ensured posts from announced `Create` activities are reposted

### DIFF
--- a/dev/wordpress/README.md
+++ b/dev/wordpress/README.md
@@ -1,0 +1,21 @@
+# WordPress ActivityPub
+
+Start a new WordPress instance on a dedicated domain with ActivityPub enabled
+
+This is useful for testing interoperability between Ghost ActivityPub and
+WordPress ActivityPub
+
+Data is ephemeral and will be lost when the script is stopped
+
+## Prerequisites
+
+- Ensure you have `cloudflared` installed
+- Ensure you have the main project containers running (`yarn dev`)
+
+## Usage
+
+From the root of the project, run:
+
+```bash
+./dev/wordpress/start.sh
+```

--- a/dev/wordpress/start.sh
+++ b/dev/wordpress/start.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Change these at your own peril 💣💣💣
+WP_DEV_CONTAINER_NAME="ap-wp-dev"
+WP_DEV_CONTAINER_PORT=8888
+WP_DEV_DB_NAME="wordpress"
+WP_DEV_DB_USER="wordpress"
+WP_DEV_DB_PASSWORD="wordpress"
+DOCKER_NETWORK_NAME="activitypub_default"
+MYSQL_CONTAINER_NAME=$(docker ps --format "{{.Names}}" | grep 'activitypub-mysql' | head -1)
+DOCKER_NETWORK_MYSQL_HOST="mysql"
+DOCKER_NETWORK_MYSQL_PORT=3306
+
+# Clean up existing wp-dev container
+echo "Cleaning up existing wp-dev container..."
+docker stop $WP_DEV_CONTAINER_NAME &>/dev/null || true
+docker rm $WP_DEV_CONTAINER_NAME &>/dev/null || true
+
+# Check if cloudflared is installed
+if ! command -v cloudflared &>/dev/null; then
+    echo "cloudflared is not installed"
+    exit 1
+fi
+
+# Check if port is already in use
+if lsof -Pi :$WP_DEV_CONTAINER_PORT -sTCP:LISTEN -t >/dev/null 2>&1; then
+    echo "Port $WP_DEV_CONTAINER_PORT is already in use"
+    exit 1
+fi
+
+# Check docker network exists
+if ! docker network ls | grep -q "$DOCKER_NETWORK_NAME"; then
+    echo "Docker network: $DOCKER_NETWORK_NAME not found"
+    exit 1
+fi
+
+# Check mysql container exists
+if ! docker ps | grep -q "$MYSQL_CONTAINER_NAME"; then
+    echo "MySQL container: $MYSQL_CONTAINER_NAME not found"
+    exit 1
+fi
+
+# Start cloudflared tunnel
+echo "Starting Cloudflare tunnel..."
+cloudflared tunnel --url http://localhost:$WP_DEV_CONTAINER_PORT >tunnel.log 2>&1 &
+TUNNEL_PID=$!
+
+# Wait for tunnel URL
+echo "Waiting for tunnel URL..."
+TUNNEL_URL=""
+for i in {1..30}; do
+    if [ -f tunnel.log ]; then
+        TUNNEL_URL=$(grep -o 'https://[^[:space:]]*\.trycloudflare\.com' tunnel.log | head -1)
+        if [ ! -z "$TUNNEL_URL" ]; then
+            break
+        fi
+    fi
+    sleep 1
+done
+
+if [ -z "$TUNNEL_URL" ]; then
+    echo "Failed to get tunnel URL"
+    kill $TUNNEL_PID 2>/dev/null
+    exit 1
+fi
+
+echo "Tunnel URL: $TUNNEL_URL"
+
+# Ensure WordPress database exists
+echo "Setting up WordPress database..."
+docker exec $MYSQL_CONTAINER_NAME mysql -uroot -proot -e "
+    DROP DATABASE IF EXISTS $WP_DEV_DB_NAME;
+    CREATE DATABASE $WP_DEV_DB_NAME;
+
+    -- Drop user if exists (to handle re-runs)
+    DROP USER IF EXISTS '$WP_DEV_DB_USER'@'%';
+
+    -- Create user
+    CREATE USER '$WP_DEV_DB_USER'@'%' IDENTIFIED BY '$WP_DEV_DB_PASSWORD';
+
+    -- Grant privileges
+    GRANT ALL PRIVILEGES ON $WP_DEV_DB_NAME.* TO '$WP_DEV_DB_USER'@'%';
+
+    -- Apply changes
+    FLUSH PRIVILEGES;
+" 2>/dev/null || echo "Database setup completed"
+
+# Start WordPress container
+echo "Starting WordPress container..."
+docker run -d \
+    --name $WP_DEV_CONTAINER_NAME \
+    --network $DOCKER_NETWORK_NAME \
+    -p $WP_DEV_CONTAINER_PORT:80 \
+    -e WORDPRESS_DB_HOST=$DOCKER_NETWORK_MYSQL_HOST:$DOCKER_NETWORK_MYSQL_PORT \
+    -e WORDPRESS_DB_USER=$WP_DEV_DB_USER \
+    -e WORDPRESS_DB_PASSWORD=$WP_DEV_DB_PASSWORD \
+    -e WORDPRESS_DB_NAME=$WP_DEV_DB_NAME \
+    -e WORDPRESS_TABLE_PREFIX=wp_ \
+    -e WORDPRESS_DEBUG=1 \
+    -e WORDPRESS_CONFIG_EXTRA="
+define('WP_HOME', '${TUNNEL_URL}');
+define('WP_SITEURL', '${TUNNEL_URL}');
+define('FORCE_SSL_ADMIN', true);
+define('WP_DEBUG_LOG', true);
+define('WP_DEBUG_DISPLAY', false);
+
+// Disable WordPress fatal error handler emails
+define('WP_DISABLE_FATAL_ERROR_HANDLER', true);
+
+// Handle reverse proxy
+if (!empty(\$_SERVER['HTTP_X_FORWARDED_PROTO']) && \$_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+    \$_SERVER['HTTPS'] = 'on';
+}
+if (!empty(\$_SERVER['HTTP_X_FORWARDED_HOST'])) {
+    \$_SERVER['HTTP_HOST'] = \$_SERVER['HTTP_X_FORWARDED_HOST'];
+}
+" \
+    wordpress:6.7-php8.3-apache \
+    &>/dev/null
+
+# Wait for WordPress to be ready
+echo "Waiting for WordPress to start..."
+for i in {1..30}; do
+    if curl -s -o /dev/null -w "%{http_code}" http://localhost:$WP_DEV_CONTAINER_PORT | grep -q "200\|302"; then
+        echo "WordPress is ready!"
+        break
+    fi
+    sleep 1
+done
+
+# Install WP-CLI in the container
+echo "Installing WP-CLI..."
+docker exec $WP_DEV_CONTAINER_NAME bash -c "
+    curl -sO https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar &&
+    chmod +x wp-cli.phar &&
+    mv wp-cli.phar /usr/local/bin/wp
+"
+
+# Install WordPress
+echo "Installing WordPress..."
+docker exec $WP_DEV_CONTAINER_NAME wp core install \
+    --url="$TUNNEL_URL" \
+    --title="WordPress ActivityPub Test" \
+    --admin_user="admin" \
+    --admin_password="password" \
+    --admin_email="admin@example.com" \
+    --skip-email \
+    --allow-root
+
+# Install plugins
+echo "Installing ActivityPub plugin..."
+docker exec $WP_DEV_CONTAINER_NAME wp plugin install activitypub --activate --allow-root --quiet 2>/dev/null && echo "ActivityPub plugin installed"
+
+echo "Installing Friends plugin..."
+docker exec $WP_DEV_CONTAINER_NAME wp plugin install friends --activate --allow-root --quiet 2>/dev/null && echo "Friends plugin installed"
+
+# Configure ActivityPub settings
+echo "Configuring ActivityPub settings..."
+docker exec $WP_DEV_CONTAINER_NAME wp option update activitypub_actor_mode "actor_blog" --allow-root
+docker exec $WP_DEV_CONTAINER_NAME wp option update activitypub_blog_identifier "blog" --allow-root
+
+# Create test authors
+echo "Creating test authors..."
+docker exec $WP_DEV_CONTAINER_NAME wp user create alice alice@example.com --role=author --user_pass=password --display_name="Alice" --allow-root
+docker exec $WP_DEV_CONTAINER_NAME wp user create bob bob@example.com --role=author --user_pass=password --display_name="Bob" --allow-root
+docker exec $WP_DEV_CONTAINER_NAME wp user create charlie charlie@example.com --role=author --user_pass=password --display_name="Charlie" --allow-root
+
+# Set up permalinks
+echo "Setting up permalinks..."
+docker exec $WP_DEV_CONTAINER_NAME wp rewrite structure '/%postname%/' --allow-root
+docker exec $WP_DEV_CONTAINER_NAME wp rewrite flush --allow-root
+
+# Create a test post
+echo "Creating test post..."
+docker exec $WP_DEV_CONTAINER_NAME wp post create \
+    --post_title="Hello from WordPress ActivityPub!" \
+    --post_content="This is a test post from WordPress with ActivityPub enabled. You can follow this blog at @blog@${TUNNEL_URL#https://}" \
+    --post_status=publish \
+    --allow-root
+
+echo ""
+echo "========================================================================="
+echo ""
+echo "WordPress is running at:"
+echo ""
+echo "  $TUNNEL_URL"
+echo ""
+echo "Admin login:"
+echo ""
+echo "  $TUNNEL_URL/wp-admin"
+echo ""
+echo "Users (all passwords are 'password'):"
+echo ""
+echo "  admin, alice, bob, charlie"
+echo ""
+echo "ActivityPub handles:"
+echo "  Blog:    @blog@${TUNNEL_URL#https://}"
+echo "  Admin:   @admin@${TUNNEL_URL#https://}"
+echo "  Alice:   @alice@${TUNNEL_URL#https://}"
+echo "  Bob:     @bob@${TUNNEL_URL#https://}"
+echo "  Charlie: @charlie@${TUNNEL_URL#https://}"
+echo ""
+echo "========================================================================="
+echo ""
+echo "Press Ctrl+C to stop WordPress and the tunnel"
+echo ""
+echo "Tunnel Logs:"
+echo ""
+
+# Cleanup
+cleanup() {
+    echo ""
+    echo "Stopping..."
+    docker stop $WP_DEV_CONTAINER_NAME &>/dev/null
+    docker rm $WP_DEV_CONTAINER_NAME &>/dev/null
+    kill $TUNNEL_PID 2>/dev/null
+    exit 0
+}
+
+trap cleanup INT TERM
+
+# Keep the script running
+tail -f tunnel.log

--- a/features/handle-group-announce-create.feature
+++ b/features/handle-group-announce-create.feature
@@ -1,0 +1,27 @@
+Feature: Handling Create activities announced by a Group
+  When a Group announces a Create activity from one of its members,
+  followers of the Group should see the post in their feed even if
+  they don't follow the original author
+
+  Background:
+    Given an Actor "Person(Charlie)"
+    And we are following "Group(Wonderland)"
+
+  Scenario: We receive an announced create note activity from a group we follow
+    Given a "Create(Note)" Activity "N" by "Charlie" with content "Hello from the group member"
+    When "Wonderland" announces "N"
+    Then the note "N" is in our feed
+    And the note "N" is reposted by "Wonderland"
+
+  Scenario: We receive an announced create article activity from a group we follow
+    Given a "Create(Article)" Activity "A" by "Charlie"
+    When "Wonderland" announces "A"
+    Then the article "A" is in our Inbox feed
+    And the article "A" is reposted by "Wonderland"
+
+  Scenario: The announced post is not shown if we don't follow the group
+    Given an Actor "Group(Unknown)"
+    And we are not following "Unknown"
+    And a "Create(Note)" Activity "N" by "Charlie" with content "You shouldn't see this"
+    When "Unknown" announces "N"
+    Then the note "N" is not in our feed

--- a/features/step_definitions/activitypub_steps.js
+++ b/features/step_definitions/activitypub_steps.js
@@ -475,3 +475,32 @@ Then('{string} has the content {string}', function (postName, content) {
     const object = this.objects[postName];
     assert.equal(object.content, content);
 });
+
+When('{string} announces {string}', async function (actorName, activityName) {
+    const actor = this.actors[actorName];
+    if (!actor) {
+        throw new Error(`Could not find Actor ${actorName}`);
+    }
+
+    const targetActivity = this.activities[activityName];
+    if (!targetActivity) {
+        throw new Error(`Could not find Activity ${activityName}`);
+    }
+
+    const announceActivity = await createActivity(
+        'Announce',
+        targetActivity,
+        actor,
+    );
+
+    await fetchActivityPub(
+        'http://fake-ghost-activitypub.test/.ghost/activitypub/inbox/index',
+        {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/ld+json',
+            },
+            body: JSON.stringify(announceActivity),
+        },
+    );
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2227

Announced `Create` activities usually come from `Group` actors announcing `Create` activities from members of the group. If you followed the group and not the author account, you would not see the announced posts from the group in your feed (because you are not following the author account and this is checked when adding to the feed). These are now correctly reposted by the group account so they can appear in the feeds of followers of the group

This changeset also includes a dev script for spinning up a local WordPress instance for testing interop