### PR TITLE
Added handling of non-standard HTTP codes in error analysis

### DIFF
--- a/src/mq/gcloud-pubsub-push/error-utils.ts
+++ b/src/mq/gcloud-pubsub-push/error-utils.ts
@@ -60,6 +60,29 @@ function analyzeFedifyDeliveryError(error: Error): ErrorAnalysis {
     // Extract status code from the Fedify delivery error
     const statusCode = Number.parseInt(fedifyMatch[1], 10);
 
+    const standardStatusCodes = new Set([
+        // 1xx Informational
+        100, 101,
+        // 2xx Success
+        200, 201, 202, 203, 204, 205, 206,
+        // 3xx Redirection
+        300, 301, 302, 303, 304, 305, 306, 307, 308,
+        // 4xx Client Error
+        400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413,
+        414, 415, 416, 417, 418, 421, 422, 423, 424, 425, 426, 428, 429, 431,
+        451,
+        // 5xx Server Error
+        500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511,
+    ]);
+
+    // Non-standard status codes are not retryable and not reportable
+    if (!standardStatusCodes.has(statusCode)) {
+        return {
+            isRetryable: false,
+            isReportable: false,
+        };
+    }
+
     const permanentFailureCodes = [
         400, // Bad Request
         401, // Unauthorized

--- a/src/mq/gcloud-pubsub-push/error-utils.ts
+++ b/src/mq/gcloud-pubsub-push/error-utils.ts
@@ -62,17 +62,16 @@ function analyzeFedifyDeliveryError(error: Error): ErrorAnalysis {
 
     const standardStatusCodes = new Set([
         // 1xx Informational
-        100, 101,
+        100, 101, 102, 103, 104,
         // 2xx Success
-        200, 201, 202, 203, 204, 205, 206,
+        200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
         // 3xx Redirection
         300, 301, 302, 303, 304, 305, 306, 307, 308,
         // 4xx Client Error
         400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413,
-        414, 415, 416, 417, 418, 421, 422, 423, 424, 425, 426, 428, 429, 431,
-        451,
+        414, 415, 416, 417, 421, 422, 423, 424, 425, 426, 428, 429, 431, 451,
         // 5xx Server Error
-        500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511,
+        500, 501, 502, 503, 504, 505, 506, 507, 508, 511,
     ]);
 
     // Non-standard status codes are not retryable and not reportable
@@ -83,7 +82,7 @@ function analyzeFedifyDeliveryError(error: Error): ErrorAnalysis {
         };
     }
 
-    const permanentFailureCodes = [
+    const permanentFailureStatusCodes = [
         400, // Bad Request
         401, // Unauthorized
         403, // Forbidden
@@ -94,7 +93,7 @@ function analyzeFedifyDeliveryError(error: Error): ErrorAnalysis {
         501, // Not Implemented
     ];
 
-    const isRetryable = !permanentFailureCodes.includes(statusCode);
+    const isRetryable = !permanentFailureStatusCodes.includes(statusCode);
 
     return {
         isRetryable,

--- a/src/mq/gcloud-pubsub-push/error-utils.unit.test.ts
+++ b/src/mq/gcloud-pubsub-push/error-utils.unit.test.ts
@@ -246,7 +246,7 @@ describe('analyzeError', () => {
         });
 
         it('should handle non-standard 5xx codes as non-retryable', () => {
-            const nonStandardCodes = [
+            const nonStandardStatusCodes = [
                 520, // Cloudflare: Web server returns an unknown error
                 521, // Cloudflare: Web server is down
                 522, // Cloudflare: Connection timed out
@@ -260,9 +260,9 @@ describe('analyzeError', () => {
                 599, // Network connect timeout error
             ];
 
-            for (const code of nonStandardCodes) {
+            for (const statusCode of nonStandardStatusCodes) {
                 const error = new Error(
-                    `Failed to send activity https://example.com/activity/123 to https://other.com/inbox (${code} Custom Error):\nProvider specific error`,
+                    `Failed to send activity https://example.com/activity/123 to https://other.com/inbox (${statusCode} Custom Error):\nProvider specific error`,
                 );
 
                 const result = analyzeError(error);
@@ -273,7 +273,7 @@ describe('analyzeError', () => {
         });
 
         it('should handle non-standard 4xx codes as non-retryable', () => {
-            const nonStandardCodes = [
+            const nonStandardStatusCodes = [
                 419, // Non-standard
                 420, // Non-standard
                 430, // Non-standard
@@ -291,9 +291,9 @@ describe('analyzeError', () => {
                 499, // nginx: Client Closed Request
             ];
 
-            for (const code of nonStandardCodes) {
+            for (const statusCode of nonStandardStatusCodes) {
                 const error = new Error(
-                    `Failed to send activity https://example.com/activity/123 to https://other.com/inbox (${code} Custom Error):\nProvider specific error`,
+                    `Failed to send activity https://example.com/activity/123 to https://other.com/inbox (${statusCode} Custom Error):\nProvider specific error`,
                 );
 
                 const result = analyzeError(error);
@@ -304,19 +304,18 @@ describe('analyzeError', () => {
         });
 
         it('should handle standard 5xx codes as retryable', () => {
-            const standardRetryableCodes = [
+            const standardRetryableStatusCodes = [
                 502, // Bad Gateway
                 503, // Service Unavailable
                 504, // Gateway Timeout
                 507, // Insufficient Storage
                 508, // Loop Detected
-                510, // Not Extended
                 511, // Network Authentication Required
             ];
 
-            for (const code of standardRetryableCodes) {
+            for (const statusCode of standardRetryableStatusCodes) {
                 const error = new Error(
-                    `Failed to send activity https://example.com/activity/123 to https://other.com/inbox (${code} Standard Error):\nStandard error`,
+                    `Failed to send activity https://example.com/activity/123 to https://other.com/inbox (${statusCode} Standard Error):\nStandard error`,
                 );
 
                 const result = analyzeError(error);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2210
ref https://github.com/TryGhost/ActivityPub/pull/994

Added handling for non-standard HTTP codes in error analysis - Any error with a non-standard HTTP code will be treated as a permanent failure and will not be retried