### PR TITLE
Added logic to update a post

### DIFF
--- a/src/post/post-updated.event.ts
+++ b/src/post/post-updated.event.ts
@@ -1,0 +1,13 @@
+import type { Post } from './post.entity';
+
+export class PostUpdatedEvent {
+    constructor(private readonly post: Post) {}
+
+    getPost(): Post {
+        return this.post;
+    }
+
+    static getName(): string {
+        return 'post.updated';
+    }
+}

--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -9,6 +9,7 @@ import { PostDeletedEvent } from './post-deleted.event';
 import { PostDerepostedEvent } from './post-dereposted.event';
 import { PostLikedEvent } from './post-liked.event';
 import { PostRepostedEvent } from './post-reposted.event';
+import { PostUpdatedEvent } from './post-updated.event';
 import {
     type Audience,
     type CreatePostType,
@@ -457,7 +458,10 @@ export class KnexPostRepository {
             }
 
             if (wasUpdated) {
-                //TODO: Send post updated event
+                await this.events.emitAsync(
+                    PostUpdatedEvent.getName(),
+                    new PostUpdatedEvent(post),
+                );
             }
 
             for (const accountId of likeAccountIds) {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2287/

- These changes add the post update logic to entity and repository
- `PostUpdateParams` are the fields that can be updated
- A post update even is emitted when a post is updated