### PR TITLE
Fixed regex for errors containing non-standard HTTP codes

### DIFF
--- a/src/mq/gcloud-pubsub-push/error-utils.ts
+++ b/src/mq/gcloud-pubsub-push/error-utils.ts
@@ -67,7 +67,7 @@ function analyzeUpstreamCertificateError(error: Error): ErrorAnalysis {
 }
 
 const FEDIFY_DELIVERY_ERROR_REGEX =
-    /^Failed to send activity .+ to .+ \((\d{3})\s+[\w\s]+\):/;
+    /^Failed to send activity .+ to .+ \((\d{3})\s+.+?\):/;
 
 function isFedifyDeliveryError(error: Error): boolean {
     return error.message.match(FEDIFY_DELIVERY_ERROR_REGEX) !== null;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2210
ref https://github.com/TryGhost/ActivityPub/pull/994

The regex for detecting the expected error message was failing due to not expecting error messages containing non-standard HTTP codes:

```
Failed to send activity https://example.com/.ghost/activitypub/create/abc123 to https://example.com/inbox (522 <none>)`
```

`<none>` was causing the regex to fail

This has now been fixed