### PR TITLE
Added `updated` to fedifyObject

### DIFF
--- a/src/activitypub/__snapshots__/publish-note-create-activity-with-mentions.json
+++ b/src/activitypub/__snapshots__/publish-note-create-activity-with-mentions.json
@@ -46,7 +46,7 @@
     },
     "to": "as:Public",
     "type": "Note",
-    "updated": "2025-01-15T10:30:00Z",
+    "updated": "2025-01-01T00:00:00Z",
   },
   "to": "as:Public",
   "type": "Create",

--- a/src/activitypub/__snapshots__/publish-note-create-activity.json
+++ b/src/activitypub/__snapshots__/publish-note-create-activity.json
@@ -35,7 +35,7 @@
     "published": "2025-01-01T00:00:00Z",
     "to": "as:Public",
     "type": "Note",
-    "updated": "2025-01-15T10:30:00Z",
+    "updated": "2025-01-01T00:00:00Z",
   },
   "to": "as:Public",
   "type": "Create",

--- a/src/activitypub/__snapshots__/publish-post-create-activity.json
+++ b/src/activitypub/__snapshots__/publish-post-create-activity.json
@@ -42,7 +42,7 @@
     "published": "2025-01-12T10:30:00Z",
     "to": "as:Public",
     "type": "Article",
-    "updated": "2025-01-15T10:30:00Z",
+    "updated": "2025-01-12T10:30:00Z",
     "url": "https://example.com/post/post-123",
   },
   "to": "as:Public",

--- a/src/activitypub/fediverse-bridge.unit.test.ts
+++ b/src/activitypub/fediverse-bridge.unit.test.ts
@@ -16,25 +16,6 @@ import type { UriBuilder } from './uri';
 
 const nextTick = () => new Promise((resolve) => process.nextTick(resolve));
 
-vi.mock('@js-temporal/polyfill', async () => {
-    const original = await vi.importActual<
-        typeof import('@js-temporal/polyfill')
-    >('@js-temporal/polyfill');
-    return {
-        Temporal: {
-            ...original.Temporal,
-            Now: {
-                // Return a fixed instant for deterministic testing
-                instant: vi
-                    .fn()
-                    .mockReturnValue(
-                        original.Temporal.Instant.from('2025-01-15T10:30:00Z'),
-                    ),
-            },
-        },
-    };
-});
-
 describe('FediverseBridge', () => {
     let events: EventEmitter;
     let accountService: AccountService;

--- a/src/helpers/activitypub/__snapshots__/article-create-activity.json
+++ b/src/helpers/activitypub/__snapshots__/article-create-activity.json
@@ -42,7 +42,7 @@
     "published": "2025-01-12T10:30:00Z",
     "to": "as:Public",
     "type": "Article",
-    "updated": "2025-01-12T10:30:00Z",
+    "updated": "2025-01-15T10:30:00Z",
     "url": "https://example.com/post/post-123",
   },
   "to": "as:Public",

--- a/src/helpers/activitypub/__snapshots__/article-object.json
+++ b/src/helpers/activitypub/__snapshots__/article-object.json
@@ -32,6 +32,6 @@
   "published": "2025-01-12T10:30:00Z",
   "to": "as:Public",
   "type": "Article",
-  "updated": "2025-01-12T10:30:00Z",
+  "updated": "2025-01-15T10:30:00Z",
   "url": "https://example.com/post/post-123",
 }

--- a/src/helpers/activitypub/__snapshots__/note-create-activity.json
+++ b/src/helpers/activitypub/__snapshots__/note-create-activity.json
@@ -35,7 +35,7 @@
     "published": "2025-01-01T00:00:00Z",
     "to": "as:Public",
     "type": "Note",
-    "updated": "2025-01-01T00:00:00Z",
+    "updated": "2025-01-15T00:00:00Z",
   },
   "to": "as:Public",
   "type": "Create",

--- a/src/helpers/activitypub/__snapshots__/note-object.json
+++ b/src/helpers/activitypub/__snapshots__/note-object.json
@@ -25,5 +25,5 @@
   "published": "2025-01-01T00:00:00Z",
   "to": "as:Public",
   "type": "Note",
-  "updated": "2025-01-01T00:00:00Z",
+  "updated": "2025-01-15T00:00:00Z",
 }

--- a/src/helpers/activitypub/__snapshots__/note-with-image-create-activity.json
+++ b/src/helpers/activitypub/__snapshots__/note-with-image-create-activity.json
@@ -40,7 +40,7 @@
     "published": "2025-01-01T00:00:00Z",
     "to": "as:Public",
     "type": "Note",
-    "updated": "2025-01-15T10:30:00Z",
+    "updated": "2025-01-01T00:00:00Z",
   },
   "to": "as:Public",
   "type": "Create",

--- a/src/helpers/activitypub/__snapshots__/note-with-image-object.json
+++ b/src/helpers/activitypub/__snapshots__/note-with-image-object.json
@@ -30,5 +30,5 @@
   "published": "2025-01-01T00:00:00Z",
   "to": "as:Public",
   "type": "Note",
-  "updated": "2025-01-15T10:30:00Z",
+  "updated": "2025-01-01T00:00:00Z",
 }

--- a/src/helpers/activitypub/__snapshots__/note-with-mentions-create-activity.json
+++ b/src/helpers/activitypub/__snapshots__/note-with-mentions-create-activity.json
@@ -46,7 +46,7 @@
     },
     "to": "as:Public",
     "type": "Note",
-    "updated": "2025-01-15T10:30:00Z",
+    "updated": "2025-01-01T00:00:00Z",
   },
   "to": "as:Public",
   "type": "Create",

--- a/src/helpers/activitypub/__snapshots__/note-with-mentions-object.json
+++ b/src/helpers/activitypub/__snapshots__/note-with-mentions-object.json
@@ -33,5 +33,5 @@
   },
   "to": "as:Public",
   "type": "Note",
-  "updated": "2025-01-15T10:30:00Z",
+  "updated": "2025-01-01T00:00:00Z",
 }

--- a/src/helpers/activitypub/activity.ts
+++ b/src/helpers/activitypub/activity.ts
@@ -22,7 +22,7 @@ async function getFedifyObjectForPost(
     let ccs: URL[] = [];
     const updatedAt = post.updatedAt
         ? Temporal.Instant.from(post.updatedAt.toISOString())
-        : Temporal.Now.instant();
+        : Temporal.Instant.from(post.publishedAt.toISOString());
 
     if (post.type === PostType.Note) {
         mentions = post.mentions.map(

--- a/src/helpers/activitypub/activity.unit.test.ts
+++ b/src/helpers/activitypub/activity.unit.test.ts
@@ -15,25 +15,6 @@ import {
     buildCreateActivityAndObjectFromPost,
 } from './activity';
 
-vi.mock('@js-temporal/polyfill', async () => {
-    const original = await vi.importActual<
-        typeof import('@js-temporal/polyfill')
-    >('@js-temporal/polyfill');
-    return {
-        Temporal: {
-            ...original.Temporal,
-            Now: {
-                // Return a fixed instant for deterministic testing
-                instant: vi
-                    .fn()
-                    .mockReturnValue(
-                        original.Temporal.Instant.from('2025-01-15T10:30:00Z'),
-                    ),
-            },
-        },
-    };
-});
-
 describe('Build activity', () => {
     let context: FedifyContext;
     let mockUriBuilder: UriBuilder<FedifyObject>;
@@ -82,7 +63,7 @@ describe('Build activity', () => {
             post.mentions = [];
             post.uuid = 'cb1e7e92-5560-4ceb-9272-7e9d0e2a7da4';
             post.publishedAt = new Date('2025-01-01T00:00:00Z');
-            post.updatedAt = new Date('2025-01-01T00:00:00Z');
+            post.updatedAt = new Date('2025-01-15T00:00:00Z');
 
             const result = await buildCreateActivityAndObjectFromPost(
                 post,
@@ -212,7 +193,7 @@ describe('Build activity', () => {
                 'https://example.com/img/post-123_feature.jpg',
             );
             post.publishedAt = new Date('2025-01-12T10:30:00Z');
-            post.updatedAt = new Date('2025-01-12T10:30:00Z');
+            post.updatedAt = new Date('2025-01-15T10:30:00Z');
             post.url = new URL('https://example.com/post/post-123');
             post.apId = new URL('https://example.com/article/post-123');
             post.uuid = 'cb1e7e92-5560-4ceb-9272-7e9d0e2a7da4';
@@ -246,6 +227,7 @@ describe('Build activity', () => {
             post.author = author;
             post.type = 5;
             post.apId = new URL('https://example.com/post/123');
+            post.publishedAt = new Date('2025-01-12T10:30:00Z');
 
             await expect(
                 buildCreateActivityAndObjectFromPost(post, context),


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2217/

- Update activity needs the `updated` field. Mastodon Docs [here](https://docs-p.joinmastodon.org/spec/activitypub/#supported-activities-for-statuses)
- Added it as a pre requisite for sending Update activity. 
- Added `updated` to the `getFedifyObjectForPost` method which will be shared between Create and Update activity.