### PR TITLE
Fixed workflow for running public image deploys

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -12,6 +12,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*.*.*'  # Trigger on semantic version tags like v1.0.0
 
 permissions:
   id-token: write
@@ -83,7 +85,7 @@ jobs:
 
       - name: "ActivityPub Docker metadata for public registry"
         id: activitypub-docker-metadata-public
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         uses: docker/metadata-action@v5
         with:
           images: |
@@ -119,7 +121,7 @@ jobs:
 
       - name: "ActivityPub Migrations Docker metadata for public registry"
         id: activitypub-migrations-docker-metadata-public
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         uses: docker/metadata-action@v5
         with:
           images: |
@@ -157,7 +159,7 @@ jobs:
         run: yarn test
 
       - name: "Authenticate with GCP"
-        if: github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened' || github.event.action == 'labeled' || github.event.action == 'unlabeled'))
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened' || github.event.action == 'labeled' || github.event.action == 'unlabeled'))
         id: gcp-auth
         uses: google-github-actions/auth@v2
         with:
@@ -174,7 +176,7 @@ jobs:
           password: ${{ steps.gcp-auth.outputs.access_token }}
 
       - name: "Login to GitHub Container Registry (public registry)"
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -192,7 +194,7 @@ jobs:
           platforms: linux/amd64
 
       - name: "Push ActivityPub Docker image to public registry"
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -210,7 +212,7 @@ jobs:
           tags: ${{ steps.migrations-docker-metadata.outputs.tags }}
 
       - name: "Push Migrations Docker image to public registry"
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         uses: docker/build-push-action@v6
         with:
           context: migrate


### PR DESCRIPTION
This was not being run when tags are pushed, which means the v1.x images were not being built and pushed.