### PR TITLE
Added table to track account delivery failure backoffs

### DIFF
--- a/migrate/migrations/000060_add-account-delivery-backoffs-table.down.sql
+++ b/migrate/migrations/000060_add-account-delivery-backoffs-table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS account_delivery_backoffs;

--- a/migrate/migrations/000060_add-account-delivery-backoffs-table.up.sql
+++ b/migrate/migrations/000060_add-account-delivery-backoffs-table.up.sql
@@ -1,0 +1,23 @@
+CREATE TABLE account_delivery_backoffs (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    created_at TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+
+    -- The account that we failed to deliver to
+    account_id INT UNSIGNED NOT NULL,
+
+    -- Track failure details
+    last_failure_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    last_failure_reason TEXT,
+
+    -- Exponential backoff tracking
+    backoff_until TIMESTAMP(6) NOT NULL,
+    backoff_seconds INT UNSIGNED NOT NULL DEFAULT 60,
+
+    UNIQUE KEY idx_account_delivery_backoffs_account (account_id),
+    KEY idx_account_delivery_backoffs_backoff (backoff_until),
+
+    CONSTRAINT fk_account_delivery_backoffs_account
+        FOREIGN KEY (account_id) REFERENCES accounts(id)
+        ON DELETE CASCADE
+);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2274

Added a new table to track account delivery failure backoffs

- `last_failure_at` & `last_failure_reason` are just for informational purposes
- `backoff_until` & `backoff_seconds` will be used to determine when to retry sending
    - `backoff_seconds` doubles on each failure
    - `backoff_until` = `NOW()` + `backoff_seconds` after each failure
    - When current time < `backoff_until`, we skip sending to the account
- Indexes add on `account_id` & `backoff_until`
    - `account_id` for fast lookups on an account
    - `backoff_until` for filtering out accounts with backoffs (i.e in followers dispatcher)