### PR TITLE
Added APIs to handle Ghost Post webhook events

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -883,6 +883,36 @@ app.post(
     }),
 );
 
+app.post(
+    '/.ghost/activitypub/v1/webhooks/post/unpublished',
+    validateWebhook(),
+    spanWrapper((ctx: AppContext) => {
+        const webhookController =
+            container.resolve<WebhookController>('webhookController');
+        return webhookController.handlePostUnpublished(ctx);
+    }),
+);
+
+app.post(
+    '/.ghost/activitypub/v1/webhooks/post/updated',
+    validateWebhook(),
+    spanWrapper((ctx: AppContext) => {
+        const webhookController =
+            container.resolve<WebhookController>('webhookController');
+        return webhookController.handlePostUpdated(ctx);
+    }),
+);
+
+app.post(
+    '/.ghost/activitypub/v1/webhooks/post/deleted',
+    validateWebhook(),
+    spanWrapper((ctx: AppContext) => {
+        const webhookController =
+            container.resolve<WebhookController>('webhookController');
+        return webhookController.handlePostDeleted(ctx);
+    }),
+);
+
 routeRegistry.registerController('webFingerController', WebFingerController);
 routeRegistry.registerController('followController', FollowController);
 routeRegistry.registerController('likeController', LikeController);

--- a/src/http/api/webhook.controller.ts
+++ b/src/http/api/webhook.controller.ts
@@ -93,4 +93,22 @@ export class WebhookController {
             status: 200,
         });
     }
+
+    async handlePostUnpublished(ctx: AppContext) {
+        return new Response(null, {
+            status: 200,
+        });
+    }
+
+    async handlePostUpdated(ctx: AppContext) {
+        return new Response(null, {
+            status: 200,
+        });
+    }
+
+    async handlePostDeleted(ctx: AppContext) {
+        return new Response(null, {
+            status: 200,
+        });
+    }
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2288/

- I have added webhook for post update, delete and unpublish events in the client: https://github.com/TryGhost/Ghost/pull/24333
- Added these dummy APIs so that these urls don't throw errors. 
- I'll build the backend logic for these in upcoming PRs