### PR TITLE
Fixed duplicate error reports in Sentry

### DIFF
--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -757,7 +757,9 @@ export async function inboxErrorHandler(
     ctx: Context<ContextData>,
     error: unknown,
 ) {
-    Sentry.captureException(error);
+    if (process.env.USE_MQ !== 'true') {
+        Sentry.captureException(error);
+    }
     ctx.data.logger.error('Error handling incoming activity: {error}', {
         error,
     });

--- a/src/mq/gcloud-pubsub-push/error-utils.ts
+++ b/src/mq/gcloud-pubsub-push/error-utils.ts
@@ -1,3 +1,5 @@
+import { FetchError } from '@fedify/fedify';
+
 export interface ErrorAnalysis {
     /**
      * Whether this error should be retried or not
@@ -137,6 +139,60 @@ function analyzeFedifyDeliveryError(error: Error): ErrorAnalysis {
     };
 }
 
+function isFetchError(error: Error): error is FetchError {
+    return error instanceof FetchError;
+}
+
+function analyzeFetchError(error: FetchError): ErrorAnalysis {
+    // Extract status code from the Fedify delivery error
+    const statusCode = Number.parseInt(
+        error.message.match(/HTTP (\d{3})/)?.[1] || '500',
+        10,
+    );
+
+    const standardStatusCodes = new Set([
+        // 1xx Informational
+        100, 101, 102, 103, 104,
+        // 2xx Success
+        200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
+        // 3xx Redirection
+        300, 301, 302, 303, 304, 305, 306, 307, 308,
+        // 4xx Client Error
+        400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413,
+        414, 415, 416, 417, 421, 422, 423, 424, 425, 426, 428, 429, 431, 451,
+        // 5xx Server Error
+        500, 501, 502, 503, 504, 505, 506, 507, 508, 511,
+    ]);
+
+    // Non-standard status codes are not retryable and not reportable
+    if (!standardStatusCodes.has(statusCode)) {
+        return {
+            isRetryable: false,
+            isReportable: false,
+        };
+    }
+
+    const permanentFailureStatusCodes = [
+        400, // Bad Request
+        401, // Unauthorized
+        403, // Forbidden
+        404, // Not Found
+        405, // Method Not Allowed
+        410, // Gone
+        422, // Unprocessable Entity
+        501, // Not Implemented
+    ];
+
+    const isRetryable = !permanentFailureStatusCodes.includes(statusCode);
+
+    return {
+        isRetryable,
+        // Fedify delivery errors are from remote servers, we don't report
+        // them to error tracking
+        isReportable: false,
+    };
+}
+
 /**
  * Analyze an error to determine its characteristics and handling strategy
  *
@@ -166,6 +222,10 @@ export function analyzeError(error: Error): ErrorAnalysis {
 
     if (isFedifyDeliveryError(error)) {
         return analyzeFedifyDeliveryError(error);
+    }
+
+    if (isFetchError(error)) {
+        return analyzeFetchError(error);
     }
 
     return {

--- a/src/mq/gcloud-pubsub-push/error-utils.unit.test.ts
+++ b/src/mq/gcloud-pubsub-push/error-utils.unit.test.ts
@@ -1,3 +1,4 @@
+import { FetchError } from '@fedify/fedify';
 import { describe, expect, it } from 'vitest';
 
 import { analyzeError } from './error-utils';
@@ -329,6 +330,200 @@ describe('analyzeError', () => {
             // Should be treated as generic error (retryable and reportable)
             expect(result.isRetryable).toBe(true);
             expect(result.isReportable).toBe(true);
+        });
+    });
+
+    describe('FetchError handling', () => {
+        it('should handle FetchError with HTTP 503 as retryable', () => {
+            const error = new FetchError(
+                'https://mastodon.nz/users/BobLefridge',
+                'HTTP 503: https://mastodon.nz/users/BobLefridge',
+            );
+
+            const result = analyzeError(error);
+
+            expect(result.isRetryable).toBe(true);
+            expect(result.isReportable).toBe(false);
+        });
+
+        it('should handle FetchError with HTTP 404 as non-retryable', () => {
+            const error = new FetchError(
+                'https://example.com/users/notfound',
+                'HTTP 404: https://example.com/users/notfound',
+            );
+
+            const result = analyzeError(error);
+
+            expect(result.isRetryable).toBe(false);
+            expect(result.isReportable).toBe(false);
+        });
+
+        it('should handle FetchError with HTTP 400 as non-retryable', () => {
+            const error = new FetchError(
+                'https://example.com/api',
+                'HTTP 400: Bad Request',
+            );
+
+            const result = analyzeError(error);
+
+            expect(result.isRetryable).toBe(false);
+            expect(result.isReportable).toBe(false);
+        });
+
+        it('should handle FetchError with HTTP 401 as non-retryable', () => {
+            const error = new FetchError(
+                'https://example.com/api',
+                'HTTP 401: Unauthorized',
+            );
+
+            const result = analyzeError(error);
+
+            expect(result.isRetryable).toBe(false);
+            expect(result.isReportable).toBe(false);
+        });
+
+        it('should handle FetchError with HTTP 403 as non-retryable', () => {
+            const error = new FetchError(
+                'https://example.com/api',
+                'HTTP 403: Forbidden',
+            );
+
+            const result = analyzeError(error);
+
+            expect(result.isRetryable).toBe(false);
+            expect(result.isReportable).toBe(false);
+        });
+
+        it('should handle FetchError with HTTP 410 as non-retryable', () => {
+            const error = new FetchError(
+                'https://example.com/api',
+                'HTTP 410: Gone',
+            );
+
+            const result = analyzeError(error);
+
+            expect(result.isRetryable).toBe(false);
+            expect(result.isReportable).toBe(false);
+        });
+
+        it('should handle FetchError with HTTP 422 as non-retryable', () => {
+            const error = new FetchError(
+                'https://example.com/api',
+                'HTTP 422: Unprocessable Entity',
+            );
+
+            const result = analyzeError(error);
+
+            expect(result.isRetryable).toBe(false);
+            expect(result.isReportable).toBe(false);
+        });
+
+        it('should handle FetchError with HTTP 429 as retryable', () => {
+            const error = new FetchError(
+                'https://example.com/api',
+                'HTTP 429: Too Many Requests',
+            );
+
+            const result = analyzeError(error);
+
+            expect(result.isRetryable).toBe(true);
+            expect(result.isReportable).toBe(false);
+        });
+
+        it('should handle FetchError with HTTP 500 as retryable', () => {
+            const error = new FetchError(
+                'https://example.com/api',
+                'HTTP 500: Internal Server Error',
+            );
+
+            const result = analyzeError(error);
+
+            expect(result.isRetryable).toBe(true);
+            expect(result.isReportable).toBe(false);
+        });
+
+        it('should handle FetchError with HTTP 502 as retryable', () => {
+            const error = new FetchError(
+                'https://example.com/api',
+                'HTTP 502: Bad Gateway',
+            );
+
+            const result = analyzeError(error);
+
+            expect(result.isRetryable).toBe(true);
+            expect(result.isReportable).toBe(false);
+        });
+
+        it('should handle FetchError with HTTP 504 as retryable', () => {
+            const error = new FetchError(
+                'https://example.com/api',
+                'HTTP 504: Gateway Timeout',
+            );
+
+            const result = analyzeError(error);
+
+            expect(result.isRetryable).toBe(true);
+            expect(result.isReportable).toBe(false);
+        });
+
+        it('should handle FetchError with non-standard HTTP 520 as non-retryable', () => {
+            const error = new FetchError(
+                'https://example.com/api',
+                'HTTP 520: Web Server Returns an Unknown Error',
+            );
+
+            const result = analyzeError(error);
+
+            expect(result.isRetryable).toBe(false);
+            expect(result.isReportable).toBe(false);
+        });
+
+        it('should handle FetchError with non-standard HTTP 522 as non-retryable', () => {
+            const error = new FetchError(
+                'https://example.com/api',
+                'HTTP 522: Connection Timed Out',
+            );
+
+            const result = analyzeError(error);
+
+            expect(result.isRetryable).toBe(false);
+            expect(result.isReportable).toBe(false);
+        });
+
+        it('should handle FetchError without HTTP status code as retryable', () => {
+            const error = new FetchError(
+                'https://example.com/api',
+                'Network error occurred',
+            );
+
+            const result = analyzeError(error);
+
+            expect(result.isRetryable).toBe(true);
+            expect(result.isReportable).toBe(false);
+        });
+
+        it('should handle FetchError with malformed HTTP status as retryable', () => {
+            const error = new FetchError(
+                'https://example.com/api',
+                'HTTP abc: Invalid status',
+            );
+
+            const result = analyzeError(error);
+
+            expect(result.isRetryable).toBe(true);
+            expect(result.isReportable).toBe(false);
+        });
+
+        it('should handle FetchError with HTTP 501 as non-retryable', () => {
+            const error = new FetchError(
+                'https://example.com/api',
+                'HTTP 501: Not Implemented',
+            );
+
+            const result = analyzeError(error);
+
+            expect(result.isRetryable).toBe(false);
+            expect(result.isReportable).toBe(false);
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2285

Errors when processing Inbox activitites are surfaced via the inbox error handler, as well as the message queue error handler when running with a queue. This means that for each error in inbox handlers we are reporting to Sentry twice.