### PR TITLE
Upgrade biome to `v2.1.1`

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -7,16 +7,14 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "ignore": ["package.json", "**/__snapshots__/**"]
+    "includes": ["**", "!**/package.json", "!**/__snapshots__/**"]
   },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
     "indentWidth": 4
   },
-  "organizeImports": {
-    "enabled": true
-  },
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {
@@ -28,7 +26,7 @@
         "noNonNullAssertion": "off"
       },
       "suspicious": {
-        "noConsoleLog": "off"
+        "noConsole": { "level": "off", "options": { "allow": ["log"] } }
       }
     }
   },

--- a/features/step_definitions/5xx_steps.js
+++ b/features/step_definitions/5xx_steps.js
@@ -2,8 +2,11 @@ import assert from 'node:assert';
 import { createHmac } from 'node:crypto';
 
 import { Given, Then, When } from '@cucumber/cucumber';
-import { createActor } from '../support/fixtures.js';
-import { createWebhookPost, getWebhookSecret } from '../support/fixtures.js';
+import {
+    createActor,
+    createWebhookPost,
+    getWebhookSecret,
+} from '../support/fixtures.js';
 
 Given('we are sent invalid @context values to the inbox', async function () {
     const actor = await createActor('Alice');

--- a/features/step_definitions/activitypub_steps.js
+++ b/features/step_definitions/activitypub_steps.js
@@ -6,8 +6,7 @@ import {
     createActor,
     createObject,
 } from '../support/fixtures.js';
-import { fetchActivityPub } from '../support/request.js';
-import { waitForRequest } from '../support/request.js';
+import { fetchActivityPub, waitForRequest } from '../support/request.js';
 import { parseActivityString, parseActorString } from '../support/steps.js';
 
 async function activityCreatedBy(activityDef, name, actorName) {

--- a/features/step_definitions/post_steps.js
+++ b/features/step_definitions/post_steps.js
@@ -60,7 +60,7 @@ Then(
 
 Then(
     'post {string} in the {string} response is {string}',
-    async function (postNumber, type, activityOrObjectName) {
+    async function (postNumber, _type, activityOrObjectName) {
         const responseJson = await this.response.clone().json();
         const activity = this.activities[activityOrObjectName];
         const object = this.objects[activityOrObjectName];

--- a/features/step_definitions/reply_steps.js
+++ b/features/step_definitions/reply_steps.js
@@ -1,6 +1,5 @@
-import { Given, Then, When } from '@cucumber/cucumber';
-
 import assert from 'node:assert';
+import { Given, Then, When } from '@cucumber/cucumber';
 import { waitForItemInFeed } from '../support/feed.js';
 import { createActivity, createObject } from '../support/fixtures.js';
 import { waitForItemInNotifications } from '../support/notifications.js';

--- a/features/step_definitions/repost_steps.js
+++ b/features/step_definitions/repost_steps.js
@@ -5,8 +5,7 @@ import { waitForAPObjectInFeed } from '../support/feed.js';
 import { createActivity } from '../support/fixtures.js';
 import { waitForAPObjectInInbox } from '../support/inbox.js';
 import { waitForItemInNotifications } from '../support/notifications.js';
-import { fetchActivityPub } from '../support/request.js';
-import { waitForRequest } from '../support/request.js';
+import { fetchActivityPub, waitForRequest } from '../support/request.js';
 
 When('we repost the object {string}', async function (name) {
     const id = this.objects[name].id;

--- a/features/step_definitions/request_steps.js
+++ b/features/step_definitions/request_steps.js
@@ -8,7 +8,7 @@ import { getCurrentDirectory } from '../support/path.js';
 import { fetchActivityPub } from '../support/request.js';
 
 When(
-    /an authenticated (\"(delete|get|post|put)\"\s)?request is made to "(.*)"$/,
+    /an authenticated ("(delete|get|post|put)"\s)?request is made to "(.*)"$/,
     async function (method, path) {
         const requestMethod = method || 'get';
         let requestPath = path;
@@ -43,7 +43,7 @@ When(
 );
 
 When(
-    /^an authenticated (\"(post|put)\"\s)?request is made to "(.*)" with the data:$/,
+    /^an authenticated ("(post|put)"\s)?request is made to "(.*)" with the data:$/,
     async function (method, path, data) {
         this.response = await fetchActivityPub(`https://self.test${path}`, {
             method: method,
@@ -57,7 +57,7 @@ When(
 );
 
 When(
-    /^an authenticated (\"(post|put)\"\s)?request is made to "(.*)" with an image$/,
+    /^an authenticated ("(post|put)"\s)?request is made to "(.*)" with an image$/,
     async function (method, path) {
         const image = await readFile(
             resolve(getCurrentDirectory(), '../fixtures/dog.jpg'),

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "src"
   ],
   "devDependencies": {
-    "@biomejs/biome": "1.9.4",
+    "@biomejs/biome": "2.1.3",
     "@cucumber/cucumber": "11.3.0",
     "@faker-js/faker": "9.9.0",
     "@fedify/cli": "1.7.8",

--- a/src/account/account.repository.knex.integration.test.ts
+++ b/src/account/account.repository.knex.integration.test.ts
@@ -1,8 +1,7 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-
 import assert from 'node:assert';
+import { exportJwk } from '@fedify/fedify';
 import type { Knex } from 'knex';
-
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AccountEntity } from '@/account/account.entity';
 import { KnexAccountRepository } from '@/account/account.repository.knex';
 import { AccountCreatedEvent } from '@/account/events';
@@ -14,8 +13,7 @@ import {
     createInternalAccountDraftData,
 } from '@/test/account-entity-test-helpers';
 import { createTestDb } from '@/test/db';
-import { type FixtureManager, createFixtureManager } from '@/test/fixtures';
-import { exportJwk } from '@fedify/fedify';
+import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
 
 describe('KnexAccountRepository', () => {
     let client: Knex;

--- a/src/account/account.repository.knex.ts
+++ b/src/account/account.repository.knex.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from 'node:crypto';
+import { exportJwk } from '@fedify/fedify';
+import type { Knex } from 'knex';
 import {
     type Account,
     type AccountDraft,
@@ -15,8 +17,6 @@ import {
 import type { AsyncEvents } from '@/core/events';
 import { parseURL } from '@/core/url';
 import type { Site } from '@/site/site.service';
-import { exportJwk } from '@fedify/fedify';
-import type { Knex } from 'knex';
 
 interface AccountRow {
     id: number;

--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -1,5 +1,5 @@
-import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
-import { type Actor, type Note, isActor, lookupObject } from '@fedify/fedify';
+import { type Actor, isActor, lookupObject, type Note } from '@fedify/fedify';
+import type { Knex } from 'knex';
 import {
     afterEach,
     beforeAll,
@@ -22,13 +22,13 @@ import type {
     InternalAccountData,
     Site,
 } from '@/account/types';
+import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import { AP_BASE_PATH } from '@/constants';
 import { AsyncEvents } from '@/core/events';
 import { getError, getValue, isError } from '@/core/result';
 import { generateTestCryptoKeyPair } from '@/test/crypto-key-pair';
 import { createTestDb } from '@/test/db';
-import { type FixtureManager, createFixtureManager } from '@/test/fixtures';
-import type { Knex } from 'knex';
+import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
 
 vi.mock('@fedify/fedify', async () => {
     // generateCryptoKeyPair is a slow operation so we generate a key pair
@@ -1189,7 +1189,7 @@ describe('AccountService', () => {
     describe('recordDeliveryFailure', () => {
         it('should create a new backoff for first failure', async () => {
             const [account] = await fixtureManager.createInternalAccount();
-            const inboxUrl = account.apInbox!;
+            const _inboxUrl = account.apInbox!;
 
             await service.recordDeliveryFailure(
                 account.apInbox!,

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import {
     type Actor,
     exportJwk,
@@ -6,8 +7,6 @@ import {
     lookupObject,
 } from '@fedify/fedify';
 import type { Knex } from 'knex';
-
-import { randomUUID } from 'node:crypto';
 import { type Account, AccountEntity } from '@/account/account.entity';
 import type { KnexAccountRepository } from '@/account/account.repository.knex';
 import { AccountFollowedEvent } from '@/account/events/account-followed.event';
@@ -20,7 +19,7 @@ import type {
 import { mapActorToExternalAccountData } from '@/account/utils';
 import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import type { AsyncEvents } from '@/core/events';
-import { type Result, error, getValue, isError, ok } from '@/core/result';
+import { error, getValue, isError, ok, type Result } from '@/core/result';
 import { parseURL } from '@/core/url';
 
 interface GetFollowingAccountsOptions {
@@ -132,7 +131,7 @@ export class AccountService {
             }
 
             actor = potentialActor;
-        } catch (err) {
+        } catch (_err) {
             return error('network-failure');
         }
 
@@ -148,7 +147,7 @@ export class AccountService {
 
         try {
             data = await mapActorToExternalAccountData(actor);
-        } catch (err) {
+        } catch (_err) {
             return error('invalid-data');
         }
 

--- a/src/account/account.service.unit.test.ts
+++ b/src/account/account.service.unit.test.ts
@@ -1,11 +1,10 @@
+import type { Knex } from 'knex';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-
 import type { AccountEntity } from '@/account/account.entity';
 import type { KnexAccountRepository } from '@/account/account.repository.knex';
 import { AccountService } from '@/account/account.service';
 import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import type { AsyncEvents } from '@/core/events';
-import type { Knex } from 'knex';
 
 describe('AccountService', () => {
     let knex: Knex;

--- a/src/account/events/index.ts
+++ b/src/account/events/index.ts
@@ -1,4 +1,5 @@
 export { AccountBlockedEvent } from '@/account/events/account-blocked.event';
+export { AccountCreatedEvent } from '@/account/events/account-created.event';
 export { AccountFollowedEvent } from '@/account/events/account-followed.event';
 export { AccountUnblockedEvent } from '@/account/events/account-unblocked.event';
 export { AccountUnfollowedEvent } from '@/account/events/account-unfollowed.event';
@@ -6,4 +7,3 @@ export { AccountUpdatedEvent } from '@/account/events/account-updated.event';
 export { DomainBlockedEvent } from '@/account/events/domain-blocked.event';
 export { DomainUnblockedEvent } from '@/account/events/domain-unblocked.event';
 export { NotificationsReadEvent } from '@/account/events/notifications-read-event';
-export { AccountCreatedEvent } from '@/account/events/account-created.event';

--- a/src/account/utils.ts
+++ b/src/account/utils.ts
@@ -1,5 +1,5 @@
-import type { ExternalAccountData } from '@/account/types';
 import { type Actor, PropertyValue } from '@fedify/fedify';
+import type { ExternalAccountData } from '@/account/types';
 
 interface PublicKey {
     id: string;

--- a/src/account/utils.unit.test.ts
+++ b/src/account/utils.unit.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
-
 import { type Actor, PropertyValue } from '@fedify/fedify';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
     getAccountHandle,

--- a/src/activity-handlers/create.handler.ts
+++ b/src/activity-handlers/create.handler.ts
@@ -1,16 +1,10 @@
-import type { AccountService } from '@/account/account.service';
+import type { Context, Create } from '@fedify/fedify';
 import type { ContextData } from '@/app';
 import { exhaustiveCheck, getError, isError } from '@/core/result';
 import type { PostService } from '@/post/post.service';
-import type { SiteService } from '@/site/site.service';
-import type { Context, Create } from '@fedify/fedify';
 
 export class CreateHandler {
-    constructor(
-        private readonly postService: PostService,
-        private readonly accountService: AccountService,
-        private readonly siteService: SiteService,
-    ) {}
+    constructor(private readonly postService: PostService) {}
 
     async handle(ctx: Context<ContextData>, create: Create) {
         ctx.data.logger.info('Handling Create');

--- a/src/activity-handlers/delete.handler.ts
+++ b/src/activity-handlers/delete.handler.ts
@@ -1,17 +1,15 @@
+import type { Actor, Context, Delete } from '@fedify/fedify';
 import type { Account } from '@/account/account.entity';
 import type { AccountService } from '@/account/account.service';
 import type { ContextData } from '@/app';
 import { exhaustiveCheck, getError, isError } from '@/core/result';
 import { getRelatedActivities } from '@/db';
-import type { KnexPostRepository } from '@/post/post.repository.knex';
 import type { PostService } from '@/post/post.service';
-import type { Actor, Context, Delete } from '@fedify/fedify';
 
 export class DeleteHandler {
     constructor(
         private readonly postService: PostService,
         private readonly accountService: AccountService,
-        private readonly postRepository: KnexPostRepository,
     ) {}
 
     async handle(ctx: Context<ContextData>, deleteActivity: Delete) {

--- a/src/activity-handlers/follow.handler.ts
+++ b/src/activity-handlers/follow.handler.ts
@@ -1,7 +1,3 @@
-import type { AccountService } from '@/account/account.service';
-import type { ContextData } from '@/app';
-import { getValue, isError } from '@/core/result';
-import type { ModerationService } from '@/moderation/moderation.service';
 import {
     Accept,
     type Actor,
@@ -10,6 +6,10 @@ import {
     Reject,
 } from '@fedify/fedify';
 import { v4 as uuidv4 } from 'uuid';
+import type { AccountService } from '@/account/account.service';
+import type { ContextData } from '@/app';
+import { getValue, isError } from '@/core/result';
+import type { ModerationService } from '@/moderation/moderation.service';
 
 export class FollowHandler {
     constructor(

--- a/src/activity-handlers/update.handler.ts
+++ b/src/activity-handlers/update.handler.ts
@@ -1,8 +1,8 @@
+import { type Actor, type Context, isActor, type Update } from '@fedify/fedify';
 import type { AccountService } from '@/account/account.service';
 import { mapActorToExternalAccountData } from '@/account/utils';
 import type { ContextData } from '@/app';
 import { exhaustiveCheck, getError, isError } from '@/core/result';
-import { type Actor, type Context, type Update, isActor } from '@fedify/fedify';
 
 export class UpdateHandler {
     constructor(private readonly accountService: AccountService) {}

--- a/src/activitypub/activity.unit.test.ts
+++ b/src/activitypub/activity.unit.test.ts
@@ -1,10 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
-
 import type { Activity, Actor } from '@fedify/fedify';
-
-import type { FedifyRequestContext } from '@/app';
-
+import { describe, expect, it, vi } from 'vitest';
 import { FedifyActivitySender } from '@/activitypub/activity';
+import type { FedifyRequestContext } from '@/app';
 
 describe('FedifyActivitySender', () => {
     describe('sendActivityToActorFollowers', () => {

--- a/src/activitypub/actor.unit.test.ts
+++ b/src/activitypub/actor.unit.test.ts
@@ -1,10 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
-
 import type { Actor } from '@fedify/fedify';
-
-import type { FedifyRequestContext } from '@/app';
-
+import { describe, expect, it, vi } from 'vitest';
 import { FedifyActorResolver } from '@/activitypub/actor';
+import type { FedifyRequestContext } from '@/app';
 
 describe('FedifyActorResolver', () => {
     describe('resolveActorByHandle', () => {

--- a/src/activitypub/fedify-context.factory.test.ts
+++ b/src/activitypub/fedify-context.factory.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from 'vitest';
 import { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import type { FedifyContext } from '@/app';
-import { describe, expect, it } from 'vitest';
 
 describe('FedifyContextFactory', () => {
     it('Gives back the fedify context when called in the register callback', async () => {

--- a/src/activitypub/fediverse-bridge.ts
+++ b/src/activitypub/fediverse-bridge.ts
@@ -1,16 +1,4 @@
 import type EventEmitter from 'node:events';
-import type { Account } from '@/account/account.entity';
-import type { AccountService } from '@/account/account.service';
-import { AccountBlockedEvent, AccountUpdatedEvent } from '@/account/events';
-import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
-import {
-    buildCreateActivityAndObjectFromPost,
-    buildUpdateActivityAndObjectFromPost,
-} from '@/helpers/activitypub/activity';
-import { PostCreatedEvent } from '@/post/post-created.event';
-import { PostDeletedEvent } from '@/post/post-deleted.event';
-import { PostUpdatedEvent } from '@/post/post-updated.event';
-import { PostType } from '@/post/post.entity';
 import {
     type Activity,
     Delete,
@@ -20,6 +8,18 @@ import {
     Update,
 } from '@fedify/fedify';
 import { v4 as uuidv4 } from 'uuid';
+import type { Account } from '@/account/account.entity';
+import type { AccountService } from '@/account/account.service';
+import { AccountBlockedEvent, AccountUpdatedEvent } from '@/account/events';
+import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
+import {
+    buildCreateActivityAndObjectFromPost,
+    buildUpdateActivityAndObjectFromPost,
+} from '@/helpers/activitypub/activity';
+import { PostType } from '@/post/post.entity';
+import { PostCreatedEvent } from '@/post/post-created.event';
+import { PostDeletedEvent } from '@/post/post-deleted.event';
+import { PostUpdatedEvent } from '@/post/post-updated.event';
 
 export class FediverseBridge {
     constructor(

--- a/src/activitypub/fediverse-bridge.unit.test.ts
+++ b/src/activitypub/fediverse-bridge.unit.test.ts
@@ -1,7 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
 import EventEmitter from 'node:events';
 import { type Object as FedifyObject, Follow, Reject } from '@fedify/fedify';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AccountEntity } from '@/account/account.entity';
 import type { AccountService } from '@/account/account.service';
@@ -10,10 +9,10 @@ import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory'
 import { FediverseBridge } from '@/activitypub/fediverse-bridge';
 import type { UriBuilder } from '@/activitypub/uri';
 import type { FedifyContext } from '@/app';
+import { Post, PostType } from '@/post/post.entity';
 import { PostCreatedEvent } from '@/post/post-created.event';
 import { PostDeletedEvent } from '@/post/post-deleted.event';
 import { PostUpdatedEvent } from '@/post/post-updated.event';
-import { Post, PostType } from '@/post/post.entity';
 
 const nextTick = () => new Promise((resolve) => process.nextTick(resolve));
 

--- a/src/activitypub/followers.service.integration.test.ts
+++ b/src/activitypub/followers.service.integration.test.ts
@@ -1,3 +1,5 @@
+import type { Knex } from 'knex';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { KnexAccountRepository } from '@/account/account.repository.knex';
 import { AccountService } from '@/account/account.service';
 import { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
@@ -5,9 +7,7 @@ import { FollowersService } from '@/activitypub/followers.service';
 import { AsyncEvents } from '@/core/events';
 import { generateTestCryptoKeyPair } from '@/test/crypto-key-pair';
 import { createTestDb } from '@/test/db';
-import { type FixtureManager, createFixtureManager } from '@/test/fixtures';
-import type { Knex } from 'knex';
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
 
 describe('FollowersService', () => {
     let client: Knex;
@@ -36,7 +36,7 @@ describe('FollowersService', () => {
         });
         it('Can get all followers, handling missing data', async () => {
             // Create accounts on different domains to avoid conflicts
-            const [account, accountSite] =
+            const [account, _accountSite] =
                 await fixtureManager.createInternalAccount();
             const [follower1] = await fixtureManager.createInternalAccount();
             const [follower2] = await fixtureManager.createInternalAccount();

--- a/src/activitypub/followers.service.ts
+++ b/src/activitypub/followers.service.ts
@@ -1,7 +1,7 @@
-import type { Account } from '@/account/account.entity';
-import { parseURL } from '@/core/url';
 import type { Recipient } from '@fedify/fedify';
 import type { Knex } from 'knex';
+import type { Account } from '@/account/account.entity';
+import { parseURL } from '@/core/url';
 
 export class FollowersService {
     constructor(private readonly client: Knex) {}

--- a/src/activitypub/index.ts
+++ b/src/activitypub/index.ts
@@ -1,4 +1,4 @@
-export * from '@/activitypub/actor';
 export * from '@/activitypub/activity';
+export * from '@/activitypub/actor';
 export * from '@/activitypub/object';
 export * from '@/activitypub/uri';

--- a/src/activitypub/object-dispatchers/delete.dispatcher.ts
+++ b/src/activitypub/object-dispatchers/delete.dispatcher.ts
@@ -1,5 +1,5 @@
-import type { ContextData } from '@/app';
 import { Delete, type RequestContext } from '@fedify/fedify';
+import type { ContextData } from '@/app';
 
 export class DeleteDispatcher {
     async dispatch(

--- a/src/activitypub/object-dispatchers/delete.dispatcher.unit.test.ts
+++ b/src/activitypub/object-dispatchers/delete.dispatcher.unit.test.ts
@@ -1,7 +1,7 @@
-import { DeleteDispatcher } from '@/activitypub/object-dispatchers/delete.dispatcher';
-import type { ContextData } from '@/app';
 import { Delete, type RequestContext } from '@fedify/fedify';
 import { describe, expect, it } from 'vitest';
+import { DeleteDispatcher } from '@/activitypub/object-dispatchers/delete.dispatcher';
+import type { ContextData } from '@/app';
 
 describe('DeleteDispatcher', () => {
     describe('dispatch', () => {

--- a/src/activitypub/object.unit.test.ts
+++ b/src/activitypub/object.unit.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
-
 import type { Article, KvStore } from '@fedify/fedify';
+import { describe, expect, it, vi } from 'vitest';
 
 import { FedifyKvStoreObjectStore } from '@/activitypub/object';
 

--- a/src/activitypub/uri.unit.test.ts
+++ b/src/activitypub/uri.unit.test.ts
@@ -1,10 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
-
 import { Article } from '@fedify/fedify';
-
-import type { FedifyRequestContext } from '@/app';
-
+import { describe, expect, it, vi } from 'vitest';
 import { FedifyUriBuilder } from '@/activitypub/uri';
+import type { FedifyRequestContext } from '@/app';
 
 type ArticleValues = {
     id: string;

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,40 @@
 import 'reflect-metadata';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { createHmac } from 'node:crypto';
+import {
+    Accept,
+    Announce,
+    Article,
+    type Context,
+    Create,
+    Delete,
+    type Federation,
+    Follow,
+    type KvStore,
+    Like,
+    Note,
+    Reject,
+    type RequestContext,
+    Undo,
+    Update,
+} from '@fedify/fedify';
+import { federation } from '@fedify/fedify/x/hono';
+import { serve } from '@hono/node-server';
+import {
+    configure,
+    getAnsiColorFormatter,
+    getConsoleSink,
+    isLogLevel,
+    type Logger,
+    type LogLevel,
+    type LogRecord,
+    withContext,
+} from '@logtape/logtape';
+import * as Sentry from '@sentry/node';
+import { get } from 'es-toolkit/compat';
+import { Hono, type Context as HonoContext, type Next } from 'hono';
+import { cors } from 'hono/cors';
+import { behindProxy } from 'x-forwarded-fetch';
 import type { Account } from '@/account/account.entity';
 import type { KnexAccountRepository } from '@/account/account.repository.knex';
 import { dispatchRejectActivity } from '@/activity-dispatchers/reject.dispatcher';
@@ -53,54 +87,20 @@ import type { SiteController } from '@/http/api/site.controller';
 import { WebFingerController } from '@/http/api/webfinger.controller';
 import type { WebhookController } from '@/http/api/webhook.controller';
 import {
-    GhostRole,
     createRoleMiddleware,
+    GhostRole,
     requireRole,
 } from '@/http/middleware/role-guard';
 import { RouteRegistry } from '@/http/routing/route-registry';
 import { setupInstrumentation, spanWrapper } from '@/instrumentation';
 import {
-    type GCloudPubSubPushMessageQueue,
     createPushMessageHandler,
+    type GCloudPubSubPushMessageQueue,
 } from '@/mq/gcloud-pubsub-push/mq';
 import type { NotificationEventService } from '@/notification/notification-event.service';
-import { PostInteractionCountsUpdateRequestedEvent } from '@/post/post-interaction-counts-update-requested.event';
 import type { PostInteractionCountsService } from '@/post/post-interaction-counts.service';
+import { PostInteractionCountsUpdateRequestedEvent } from '@/post/post-interaction-counts-update-requested.event';
 import type { Site, SiteService } from '@/site/site.service';
-import {
-    Accept,
-    Announce,
-    Article,
-    type Context,
-    Create,
-    Delete,
-    type Federation,
-    Follow,
-    type KvStore,
-    Like,
-    Note,
-    Reject,
-    type RequestContext,
-    Undo,
-    Update,
-} from '@fedify/fedify';
-import { federation } from '@fedify/fedify/x/hono';
-import { serve } from '@hono/node-server';
-import {
-    type LogLevel,
-    type LogRecord,
-    type Logger,
-    configure,
-    getAnsiColorFormatter,
-    getConsoleSink,
-    isLogLevel,
-    withContext,
-} from '@logtape/logtape';
-import * as Sentry from '@sentry/node';
-import { get } from 'es-toolkit/compat';
-import { Hono, type Context as HonoContext, type Next } from 'hono';
-import { cors } from 'hono/cors';
-import { behindProxy } from 'x-forwarded-fetch';
 
 await setupInstrumentation();
 
@@ -517,7 +517,7 @@ const app = new Hono<{ Variables: HonoContextVariables }>();
  */
 export type AppContext = HonoContext<{ Variables: HonoContextVariables }>;
 
-app.get('/ping', (ctx) => {
+app.get('/ping', (_ctx) => {
     return new Response('', {
         status: 200,
     });
@@ -748,7 +748,7 @@ app.use(async (ctx, next) => {
         ctx.set('account', account);
 
         await next();
-    } catch (err) {
+    } catch (_err) {
         ctx.get('logger').error('No account found for {host}', {
             host: site.host,
         });

--- a/src/configuration/registrations.ts
+++ b/src/configuration/registrations.ts
@@ -1,3 +1,14 @@
+import { createFederation, type KvStore } from '@fedify/fedify';
+import type { PubSub } from '@google-cloud/pubsub';
+import { getLogger, type Logger } from '@logtape/logtape';
+import {
+    type AwilixContainer,
+    aliasTo,
+    asClass,
+    asFunction,
+    asValue,
+} from 'awilix';
+import type { Knex } from 'knex';
 import { KnexAccountRepository } from '@/account/account.repository.knex';
 import { AccountService } from '@/account/account.service';
 import { CreateHandler } from '@/activity-handlers/create.handler';
@@ -28,8 +39,8 @@ import { EventSerializer } from '@/events/event';
 import { PubSubEvents } from '@/events/pubsub';
 import { createIncomingPubSubMessageHandler } from '@/events/pubsub-http';
 import { GhostExploreService } from '@/explore/ghost-explore.service';
-import { FeedUpdateService } from '@/feed/feed-update.service';
 import { FeedService } from '@/feed/feed.service';
+import { FeedUpdateService } from '@/feed/feed-update.service';
 import { FlagService } from '@/flag/flag.service';
 import { GhostPostService } from '@/ghost/ghost-post.service';
 import { getSiteSettings } from '@/helpers/ghost';
@@ -54,28 +65,17 @@ import { WebhookController } from '@/http/api/webhook.controller';
 import { KnexKvStore } from '@/knex.kvstore';
 import { ModerationService } from '@/moderation/moderation.service';
 import { GCloudPubSubPushMessageQueue } from '@/mq/gcloud-pubsub-push/mq';
-import { NotificationEventService } from '@/notification/notification-event.service';
 import { NotificationService } from '@/notification/notification.service';
-import { PostInteractionCountsService } from '@/post/post-interaction-counts.service';
+import { NotificationEventService } from '@/notification/notification-event.service';
 import { KnexPostRepository } from '@/post/post.repository.knex';
 import { PostService } from '@/post/post.service';
+import { PostInteractionCountsService } from '@/post/post-interaction-counts.service';
 import { getFullTopic, initPubSubClient } from '@/pubsub';
 import { SiteService } from '@/site/site.service';
 import { GCPStorageAdapter } from '@/storage/adapters/gcp-storage-adapter';
 import { LocalStorageAdapter } from '@/storage/adapters/local-storage-adapter';
 import { ImageProcessor } from '@/storage/image-processor';
 import { ImageStorageService } from '@/storage/image-storage.service';
-import { type KvStore, createFederation } from '@fedify/fedify';
-import type { PubSub } from '@google-cloud/pubsub';
-import { type Logger, getLogger } from '@logtape/logtape';
-import {
-    type AwilixContainer,
-    aliasTo,
-    asClass,
-    asFunction,
-    asValue,
-} from 'awilix';
-import type { Knex } from 'knex';
 
 export function registerDependencies(
     container: AwilixContainer,

--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -1,7 +1,7 @@
 export function parseURL(input: unknown): URL | null {
     try {
         return new URL(input as string | URL);
-    } catch (err) {
+    } catch (_err) {
         return null;
     }
 }

--- a/src/db.integration.test.ts
+++ b/src/db.integration.test.ts
@@ -1,6 +1,6 @@
-import { createTestDb } from '@/test/db';
 import type { Knex } from 'knex';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createTestDb } from '@/test/db';
 
 const TEST_TABLE = 'test_timestamps';
 

--- a/src/db.unit.test.ts
+++ b/src/db.unit.test.ts
@@ -1,5 +1,5 @@
-import { knex } from '@/db';
 import { describe, expect, it } from 'vitest';
+import { knex } from '@/db';
 
 describe('Knex Configuration', () => {
     it('should use UTC timezone in connection config', () => {

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -1,3 +1,23 @@
+import {
+    Accept,
+    Announce,
+    Article,
+    type Context,
+    Create,
+    Follow,
+    Group,
+    Image,
+    importJwk,
+    Like,
+    Note,
+    Person,
+    type Protocol,
+    type RequestContext,
+    Undo,
+    Update,
+    verifyObject,
+} from '@fedify/fedify';
+import * as Sentry from '@sentry/node';
 import type { KnexAccountRepository } from '@/account/account.repository.knex';
 import type { AccountService } from '@/account/account.service';
 import type { FollowersService } from '@/activitypub/followers.service';
@@ -13,26 +33,6 @@ import { OutboxType, type Post } from '@/post/post.entity';
 import type { KnexPostRepository } from '@/post/post.repository.knex';
 import type { PostService } from '@/post/post.service';
 import type { SiteService } from '@/site/site.service';
-import {
-    Accept,
-    Announce,
-    Article,
-    type Context,
-    Create,
-    Follow,
-    Group,
-    Image,
-    Like,
-    Note,
-    Person,
-    type Protocol,
-    type RequestContext,
-    Undo,
-    Update,
-    importJwk,
-    verifyObject,
-} from '@fedify/fedify';
-import * as Sentry from '@sentry/node';
 
 export const actorDispatcher = (
     siteService: SiteService,
@@ -110,7 +110,7 @@ export const keypairDispatcher = (
                     ),
                 },
             ];
-        } catch (err) {
+        } catch (_err) {
             ctx.data.logger.warn(`Could not parse keypair for ${identifier}`);
             return [];
         }
@@ -772,7 +772,7 @@ export function createFollowersDispatcher(
 ) {
     return async function dispatchFollowers(
         ctx: Context<ContextData>,
-        handle: string,
+        _handle: string,
     ) {
         const site = await siteService.getSiteByHost(ctx.host);
         if (!site) {
@@ -795,7 +795,7 @@ export function createFollowingDispatcher(
 ) {
     return async function dispatchFollowing(
         ctx: RequestContext<ContextData>,
-        handle: string,
+        _handle: string,
         cursor: string | null,
     ) {
         ctx.data.logger.info('Following Dispatcher');
@@ -854,7 +854,7 @@ export function createFollowersCounter(
 ) {
     return async function countFollowers(
         ctx: RequestContext<ContextData>,
-        handle: string,
+        _handle: string,
     ) {
         const site = await siteService.getSiteByHost(ctx.host);
         if (!site) {
@@ -876,7 +876,7 @@ export function createFollowingCounter(
 ) {
     return async function countFollowing(
         ctx: RequestContext<ContextData>,
-        handle: string,
+        _handle: string,
     ) {
         const site = await siteService.getSiteByHost(ctx.host);
         if (!site) {
@@ -903,7 +903,7 @@ export function createOutboxDispatcher(
 ) {
     return async function outboxDispatcher(
         ctx: RequestContext<ContextData>,
-        handle: string,
+        _handle: string,
         cursor: string | null,
     ) {
         ctx.data.logger.info('Outbox Dispatcher');
@@ -973,9 +973,9 @@ export function outboxFirstCursor() {
 }
 
 export async function likedDispatcher(
-    ctx: RequestContext<ContextData>,
-    handle: string,
-    cursor: string | null,
+    _ctx: RequestContext<ContextData>,
+    _handle: string,
+    _cursor: string | null,
 ) {
     return {
         items: [],
@@ -984,8 +984,8 @@ export async function likedDispatcher(
 }
 
 export async function likedCounter(
-    ctx: RequestContext<ContextData>,
-    handle: string,
+    _ctx: RequestContext<ContextData>,
+    _handle: string,
 ) {
     return 0;
 }
@@ -1102,7 +1102,7 @@ export async function undoDispatcher(
     return Undo.fromJsonLd(exists);
 }
 
-export async function nodeInfoDispatcher(ctx: RequestContext<ContextData>) {
+export async function nodeInfoDispatcher(_ctx: RequestContext<ContextData>) {
     return {
         software: {
             name: 'ghost',

--- a/src/dispatchers.unit.test.ts
+++ b/src/dispatchers.unit.test.ts
@@ -1,9 +1,3 @@
-import {
-    createOutboxCounter,
-    createOutboxDispatcher,
-    likedDispatcher,
-    nodeInfoDispatcher,
-} from '@/dispatchers';
 import type {
     Announce,
     Article,
@@ -11,11 +5,18 @@ import type {
     Note,
     RequestContext,
 } from '@fedify/fedify';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AccountEntity } from '@/account/account.entity';
 import type { AccountService } from '@/account/account.service';
 import type { ContextData } from '@/app';
 import { ACTOR_DEFAULT_HANDLE } from '@/constants';
+import {
+    createOutboxCounter,
+    createOutboxDispatcher,
+    likedDispatcher,
+    nodeInfoDispatcher,
+} from '@/dispatchers';
 import {
     buildAnnounceActivityForPost,
     buildCreateActivityAndObjectFromPost,
@@ -23,7 +24,6 @@ import {
 import { OutboxType, Post, PostType } from '@/post/post.entity';
 import type { PostService } from '@/post/post.service';
 import type { Site, SiteService } from '@/site/site.service';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/app', () => ({
     fedify: {

--- a/src/events/pubsub-http.ts
+++ b/src/events/pubsub-http.ts
@@ -5,13 +5,12 @@ import { z } from 'zod';
 
 import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import type { ContextData } from '@/app';
-import { createFedifyCtxForHost } from '@/helpers/fedify';
-
 import {
     PUBSUB_MESSAGE_ATTR_EVENT_HOST,
     PUBSUB_MESSAGE_ATTR_EVENT_NAME,
     type PubSubEvents,
 } from '@/events/pubsub';
+import { createFedifyCtxForHost } from '@/helpers/fedify';
 
 const IncomingMessagePayloadSchema = z.object({
     message: z.object({
@@ -45,7 +44,7 @@ export function createIncomingPubSubMessageHandler(
                     `[${PUBSUB_MESSAGE_ATTR_EVENT_HOST}] missing from payload`,
                 );
             }
-        } catch (error) {
+        } catch (_error) {
             return new Response(null, { status: 400 });
         }
 

--- a/src/events/pubsub-http.unit.test.ts
+++ b/src/events/pubsub-http.unit.test.ts
@@ -1,9 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
 import type { Federation, KvStore } from '@fedify/fedify';
 import type { Logger } from '@logtape/logtape';
 import * as Sentry from '@sentry/node';
 import type { Context } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import type { ContextData } from '@/app';
@@ -56,7 +55,7 @@ describe('handleIncomingPubSubMessage', () => {
         } as unknown as PubSubEvents;
         const fedify = {} as unknown as Federation<ContextData>;
         const fedifyContextFactory = {
-            registerContext: vi.fn().mockImplementation(async (ctx, fn) => {
+            registerContext: vi.fn().mockImplementation(async (_ctx, fn) => {
                 return await fn();
             }),
         } as unknown as FedifyContextFactory;

--- a/src/events/pubsub.integration.test.ts
+++ b/src/events/pubsub.integration.test.ts
@@ -1,4 +1,12 @@
 import {
+    type Message,
+    PubSub,
+    type Subscription,
+    type Topic,
+} from '@google-cloud/pubsub';
+import type { Logger } from '@logtape/logtape';
+import * as Sentry from '@sentry/node';
+import {
     afterAll,
     afterEach,
     beforeAll,
@@ -8,15 +16,6 @@ import {
     it,
     vi,
 } from 'vitest';
-
-import {
-    type Message,
-    PubSub,
-    type Subscription,
-    type Topic,
-} from '@google-cloud/pubsub';
-import type { Logger } from '@logtape/logtape';
-import * as Sentry from '@sentry/node';
 
 import { EventSerializer } from '@/events/event';
 import {

--- a/src/explore/ghost-explore.service.integration.test.ts
+++ b/src/explore/ghost-explore.service.integration.test.ts
@@ -1,12 +1,3 @@
-import { KnexAccountRepository } from '@/account/account.repository.knex';
-import type { AccountService } from '@/account/account.service';
-import { AccountCreatedEvent } from '@/account/events';
-import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
-import { AsyncEvents } from '@/core/events';
-import { error, ok } from '@/core/result';
-import { GhostExploreService } from '@/explore/ghost-explore.service';
-import { createTestDb } from '@/test/db';
-import { type FixtureManager, createFixtureManager } from '@/test/fixtures';
 import type { Logger } from '@logtape/logtape';
 import type { Knex } from 'knex';
 import {
@@ -18,6 +9,15 @@ import {
     it,
     vi,
 } from 'vitest';
+import { KnexAccountRepository } from '@/account/account.repository.knex';
+import type { AccountService } from '@/account/account.service';
+import { AccountCreatedEvent } from '@/account/events';
+import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
+import { AsyncEvents } from '@/core/events';
+import { error, ok } from '@/core/result';
+import { GhostExploreService } from '@/explore/ghost-explore.service';
+import { createTestDb } from '@/test/db';
+import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
 
 async function createGhostExploreAccount(
     db: Knex,

--- a/src/explore/ghost-explore.service.ts
+++ b/src/explore/ghost-explore.service.ts
@@ -1,12 +1,12 @@
+import { Follow } from '@fedify/fedify';
+import type { Logger } from '@logtape/logtape';
+import { uuid4 } from '@sentry/core';
 import type { KnexAccountRepository } from '@/account/account.repository.knex';
 import type { AccountService } from '@/account/account.service';
 import { AccountCreatedEvent } from '@/account/events';
 import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import type { AsyncEvents } from '@/core/events';
 import { getValue, isError } from '@/core/result';
-import { Follow } from '@fedify/fedify';
-import type { Logger } from '@logtape/logtape';
-import { uuid4 } from '@sentry/core';
 
 export class GhostExploreService {
     constructor(

--- a/src/feed/feed-update.service.ts
+++ b/src/feed/feed-update.service.ts
@@ -6,11 +6,11 @@ import {
     DomainBlockedEvent,
 } from '@/account/events';
 import type { FeedService } from '@/feed/feed.service';
+import { isFollowersOnlyPost, isPublicPost } from '@/post/post.entity';
 import { PostCreatedEvent } from '@/post/post-created.event';
 import { PostDeletedEvent } from '@/post/post-deleted.event';
 import { PostDerepostedEvent } from '@/post/post-dereposted.event';
 import { PostRepostedEvent } from '@/post/post-reposted.event';
-import { isFollowersOnlyPost, isPublicPost } from '@/post/post.entity';
 
 export class FeedUpdateService {
     constructor(

--- a/src/feed/feed-update.service.unit.test.ts
+++ b/src/feed/feed-update.service.unit.test.ts
@@ -1,6 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
 import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AccountEntity } from '@/account/account.entity';
 import {
@@ -8,13 +7,13 @@ import {
     AccountUnfollowedEvent,
     DomainBlockedEvent,
 } from '@/account/events';
-import { FeedUpdateService } from '@/feed/feed-update.service';
 import type { FeedService } from '@/feed/feed.service';
+import { FeedUpdateService } from '@/feed/feed-update.service';
+import { Audience, Post, PostType } from '@/post/post.entity';
 import { PostCreatedEvent } from '@/post/post-created.event';
 import { PostDeletedEvent } from '@/post/post-deleted.event';
 import { PostDerepostedEvent } from '@/post/post-dereposted.event';
 import { PostRepostedEvent } from '@/post/post-reposted.event';
-import { Audience, Post, PostType } from '@/post/post.entity';
 import { createInternalAccountDraftData } from '@/test/account-entity-test-helpers';
 
 describe('FeedUpdateService', () => {

--- a/src/feed/feed.service.integration.test.ts
+++ b/src/feed/feed.service.integration.test.ts
@@ -1,5 +1,6 @@
+import type { Logger } from '@logtape/logtape';
+import type { Knex } from 'knex';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-
 import type { Account } from '@/account/account.entity';
 import { KnexAccountRepository } from '@/account/account.repository.knex';
 import { AccountService } from '@/account/account.service';
@@ -8,10 +9,10 @@ import { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import { AsyncEvents } from '@/core/events';
 import { FeedService } from '@/feed/feed.service';
 import { ModerationService } from '@/moderation/moderation.service';
-import { Post } from '@/post/post.entity';
 import {
     Audience,
     type FollowersOnlyPost,
+    Post,
     type PostData,
     PostType,
     type PublicPost,
@@ -20,8 +21,6 @@ import { KnexPostRepository } from '@/post/post.repository.knex';
 import { SiteService } from '@/site/site.service';
 import { generateTestCryptoKeyPair } from '@/test/crypto-key-pair';
 import { createTestDb } from '@/test/db';
-import type { Logger } from '@logtape/logtape';
-import type { Knex } from 'knex';
 
 describe('FeedService', () => {
     let events: AsyncEvents;

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -1,3 +1,5 @@
+import { chunk } from 'es-toolkit';
+import type { Knex } from 'knex';
 import { sanitizeHtml } from '@/helpers/html';
 import type { ModerationService } from '@/moderation/moderation.service';
 import {
@@ -6,8 +8,6 @@ import {
     PostType,
     type PublicPost,
 } from '@/post/post.entity';
-import { chunk } from 'es-toolkit';
-import type { Knex } from 'knex';
 
 export type FeedType = 'Inbox' | 'Feed';
 

--- a/src/feed/feed.service.unit.test.ts
+++ b/src/feed/feed.service.unit.test.ts
@@ -1,10 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
-
 import type { Knex } from 'knex';
-
-import type { ModerationService } from '@/moderation/moderation.service';
-
+import { describe, expect, it, vi } from 'vitest';
 import { FeedService } from '@/feed/feed.service';
+import type { ModerationService } from '@/moderation/moderation.service';
 
 describe('FeedService', () => {
     describe('removeBlockedAccountPostsFromFeed', () => {

--- a/src/flag/flag.service.unit.test.ts
+++ b/src/flag/flag.service.unit.test.ts
@@ -1,5 +1,5 @@
-import { FlagService } from '@/flag/flag.service';
 import { describe, expect, it } from 'vitest';
+import { FlagService } from '@/flag/flag.service';
 
 describe('FlagService', () => {
     it('should be able to register flags', () => {

--- a/src/ghost/ghost-post.service.integration.test.ts
+++ b/src/ghost/ghost-post.service.integration.test.ts
@@ -1,3 +1,6 @@
+import type { Logger } from '@logtape/logtape';
+import type { Knex } from 'knex';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Account } from '@/account/account.entity';
 import { KnexAccountRepository } from '@/account/account.repository.knex';
 import { AccountService } from '@/account/account.service';
@@ -11,10 +14,7 @@ import { KnexPostRepository } from '@/post/post.repository.knex';
 import { PostService } from '@/post/post.service';
 import type { ImageStorageService } from '@/storage/image-storage.service';
 import { createTestDb } from '@/test/db';
-import { type FixtureManager, createFixtureManager } from '@/test/fixtures';
-import type { Logger } from '@logtape/logtape';
-import type { Knex } from 'knex';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
 
 describe('GhostPostService', () => {
     let db: Knex;

--- a/src/ghost/ghost-post.service.ts
+++ b/src/ghost/ghost-post.service.ts
@@ -1,15 +1,16 @@
 import type EventEmitter from 'node:events';
+import type { Logger } from '@logtape/logtape';
+import type { Knex } from 'knex';
 import type { Account } from '@/account/account.entity';
 import {
-    type Result,
     error,
     exhaustiveCheck,
     getError,
     getValue,
     isError,
     ok,
+    type Result,
 } from '@/core/result';
-import { PostDeletedEvent } from '@/post/post-deleted.event';
 import {
     type CreatePostError,
     type GhostPost,
@@ -18,8 +19,7 @@ import {
 } from '@/post/post.entity';
 import type { KnexPostRepository } from '@/post/post.repository.knex';
 import type { DeletePostError, PostService } from '@/post/post.service';
-import type { Logger } from '@logtape/logtape';
-import type { Knex } from 'knex';
+import { PostDeletedEvent } from '@/post/post-deleted.event';
 
 export type GhostPostError =
     | CreatePostError

--- a/src/ghost/ghost-post.service.unit.test.ts
+++ b/src/ghost/ghost-post.service.unit.test.ts
@@ -1,3 +1,6 @@
+import type { Logger } from '@logtape/logtape';
+import type { Knex } from 'knex';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Account } from '@/account/account.entity';
 import type { AsyncEvents } from '@/core/events';
 import { error, getError, getValue, isError, ok } from '@/core/result';
@@ -5,9 +8,6 @@ import { GhostPostService } from '@/ghost/ghost-post.service';
 import { Post } from '@/post/post.entity';
 import type { KnexPostRepository } from '@/post/post.repository.knex';
 import type { PostService } from '@/post/post.service';
-import type { Logger } from '@logtape/logtape';
-import type { Knex } from 'knex';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('GhostPostService', () => {
     let ghostPostService: GhostPostService;

--- a/src/helpers/activitypub/activity.ts
+++ b/src/helpers/activitypub/activity.ts
@@ -1,7 +1,4 @@
 import { createHash, randomUUID } from 'node:crypto';
-import type { Account } from '@/account/account.entity';
-import type { FedifyContext } from '@/app';
-import { type Post, PostType } from '@/post/post.entity';
 import {
     Announce,
     Article,
@@ -13,6 +10,9 @@ import {
     Update,
 } from '@fedify/fedify';
 import { Temporal } from '@js-temporal/polyfill';
+import type { Account } from '@/account/account.entity';
+import type { FedifyContext } from '@/app';
+import { type Post, PostType } from '@/post/post.entity';
 
 async function getFedifyObjectForPost(
     post: Post,

--- a/src/helpers/activitypub/activity.unit.test.ts
+++ b/src/helpers/activitypub/activity.unit.test.ts
@@ -1,12 +1,3 @@
-import { AccountEntity } from '@/account/account.entity';
-import type { UriBuilder } from '@/activitypub/uri';
-import type { FedifyContext } from '@/app';
-import {
-    buildAnnounceActivityForPost,
-    buildCreateActivityAndObjectFromPost,
-    buildUpdateActivityAndObjectFromPost,
-} from '@/helpers/activitypub/activity';
-import { Post, PostType } from '@/post/post.entity';
 import {
     Announce,
     Article,
@@ -16,6 +7,15 @@ import {
     Update,
 } from '@fedify/fedify';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AccountEntity } from '@/account/account.entity';
+import type { UriBuilder } from '@/activitypub/uri';
+import type { FedifyContext } from '@/app';
+import {
+    buildAnnounceActivityForPost,
+    buildCreateActivityAndObjectFromPost,
+    buildUpdateActivityAndObjectFromPost,
+} from '@/helpers/activitypub/activity';
+import { Post, PostType } from '@/post/post.entity';
 
 vi.mock('node:crypto', async (importOriginal) => {
     const actual = await importOriginal<typeof import('node:crypto')>();

--- a/src/helpers/activitypub/actor.ts
+++ b/src/helpers/activitypub/actor.ts
@@ -1,7 +1,8 @@
+import { type Actor, PropertyValue } from '@fedify/fedify';
 import type { AccountService } from '@/account/account.service';
 import { HANDLE_REGEX } from '@/constants';
 import type { Site } from '@/site/site.service';
-import { type Actor, PropertyValue } from '@fedify/fedify';
+
 interface Attachment {
     name: string;
     value: string;

--- a/src/helpers/activitypub/actor.unit.test.ts
+++ b/src/helpers/activitypub/actor.unit.test.ts
@@ -1,5 +1,5 @@
+import { type Actor, PropertyValue } from '@fedify/fedify';
 import { describe, expect, it, vi } from 'vitest';
-
 import type { AccountService } from '@/account/account.service';
 import type { Account, Site } from '@/account/types';
 import {
@@ -10,7 +10,6 @@ import {
     isFollowedByDefaultSiteAccount,
     isHandle,
 } from '@/helpers/activitypub/actor';
-import { type Actor, PropertyValue } from '@fedify/fedify';
 
 describe('getAttachments', () => {
     it('should return an array of attachments for the actor', async () => {

--- a/src/helpers/fedify.ts
+++ b/src/helpers/fedify.ts
@@ -11,7 +11,7 @@ export function createFedifyCtxForHost(
 
     try {
         hostUrl = new URL(`https://${host}`);
-    } catch (error) {
+    } catch (_error) {
         throw new Error(`Invalid host URL: https://${host}`);
     }
 

--- a/src/helpers/ghost.unit.test.ts
+++ b/src/helpers/ghost.unit.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
-
 import ky, { type ResponsePromise } from 'ky';
+import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('ky');
 

--- a/src/helpers/html.unit.test.ts
+++ b/src/helpers/html.unit.test.ts
@@ -1,6 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
 import doSanitizeHtml from 'sanitize-html';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { sanitizeHtml } from '@/helpers/html';
 

--- a/src/helpers/uri.ts
+++ b/src/helpers/uri.ts
@@ -3,7 +3,7 @@ export function isUri(value: string): boolean {
         new URL(value);
 
         return true;
-    } catch (err) {
+    } catch (_err) {
         return false;
     }
 }
@@ -17,7 +17,7 @@ export function toURL(value: unknown): URL | undefined {
     }
     try {
         return new URL(value);
-    } catch (err) {
+    } catch (_err) {
         return undefined;
     }
 }

--- a/src/http/api/account.controller.ts
+++ b/src/http/api/account.controller.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import type { KnexAccountRepository } from '@/account/account.repository.knex';
 import type { AccountService } from '@/account/account.service';
 import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
@@ -17,7 +18,6 @@ import type { AccountView } from '@/http/api/views/account.view';
 import { RequireRoles, Route } from '@/http/decorators/route.decorator';
 import { GhostRole } from '@/http/middleware/role-guard';
 import { lookupActorProfile } from '@/lookup-helpers';
-import { z } from 'zod';
 
 /**
  * Default number of posts to return in a profile

--- a/src/http/api/feed.controller.ts
+++ b/src/http/api/feed.controller.ts
@@ -1,6 +1,5 @@
 import * as Sentry from '@sentry/node';
 
-import type { AccountService } from '@/account/account.service';
 import { getAccountHandle } from '@/account/utils';
 import type { AppContext } from '@/app';
 import type { FeedService, FeedType } from '@/feed/feed.service';
@@ -25,7 +24,6 @@ const MAX_FEED_POSTS_LIMIT = 100;
 export class FeedController {
     constructor(
         private readonly feedService: FeedService,
-        private readonly accountService: AccountService,
         private readonly postInteractionCountsService: PostInteractionCountsService,
     ) {}
 

--- a/src/http/api/feed.unit.test.ts
+++ b/src/http/api/feed.unit.test.ts
@@ -1,14 +1,12 @@
+import * as Sentry from '@sentry/node';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import * as Sentry from '@sentry/node';
-
 import { AccountEntity } from '@/account/account.entity';
-import type { AccountService } from '@/account/account.service';
 import type { AppContext } from '@/app';
 import type { FeedService } from '@/feed/feed.service';
 import { FeedController } from '@/http/api/feed.controller';
-import type { PostInteractionCountsService } from '@/post/post-interaction-counts.service';
 import { PostType } from '@/post/post.entity';
+import type { PostInteractionCountsService } from '@/post/post-interaction-counts.service';
 import type { Site } from '@/site/site.service';
 import { createInternalAccountDraftData } from '@/test/account-entity-test-helpers';
 
@@ -20,7 +18,6 @@ vi.mock('@sentry/node', () => {
 
 describe('Feed API', () => {
     let feedService: FeedService;
-    let accountService: AccountService;
     let postInteractionCountsService: PostInteractionCountsService;
     let feedController: FeedController;
     let site: Site;
@@ -151,16 +148,6 @@ describe('Feed API', () => {
             ...draft,
         });
 
-        accountService = {
-            getDefaultAccountForSite: async (_site: Site) => {
-                if (_site === site) {
-                    return account;
-                }
-
-                return null;
-            },
-        } as unknown as AccountService;
-
         postInteractionCountsService = {
             requestUpdate: vi.fn().mockResolvedValue(undefined),
         } as unknown as PostInteractionCountsService;
@@ -169,7 +156,6 @@ describe('Feed API', () => {
 
         feedController = new FeedController(
             feedService,
-            accountService,
             postInteractionCountsService,
         );
 

--- a/src/http/api/follow.controller.ts
+++ b/src/http/api/follow.controller.ts
@@ -1,4 +1,4 @@
-import { type Federation, Follow, Undo, isActor } from '@fedify/fedify';
+import { type Federation, Follow, isActor, Undo } from '@fedify/fedify';
 import { v4 as uuidv4 } from 'uuid';
 
 import type { AccountService } from '@/account/account.service';

--- a/src/http/api/helpers/post.ts
+++ b/src/http/api/helpers/post.ts
@@ -1,8 +1,7 @@
 import type { Account } from '@/account/account.entity';
 import { getAccountHandle } from '@/account/utils';
-import type { Post } from '@/post/post.entity';
-
 import type { AuthorDTO, PostDTO } from '@/http/api/types';
+import type { Post } from '@/post/post.entity';
 
 function accountToAuthorDTO(
     account: Account,

--- a/src/http/api/like.controller.ts
+++ b/src/http/api/like.controller.ts
@@ -1,5 +1,11 @@
 import { createHash } from 'node:crypto';
-
+import {
+    type Actor,
+    type Federation,
+    Like,
+    PUBLIC_COLLECTION,
+    Undo,
+} from '@fedify/fedify';
 import type { AppContext, ContextData } from '@/app';
 import { ACTOR_DEFAULT_HANDLE } from '@/constants';
 import { exhaustiveCheck, getError, getValue, isError } from '@/core/result';
@@ -10,13 +16,6 @@ import { GhostRole } from '@/http/middleware/role-guard';
 import { lookupActor, lookupObject } from '@/lookup-helpers';
 import type { KnexPostRepository } from '@/post/post.repository.knex';
 import type { PostService } from '@/post/post.service';
-import {
-    type Actor,
-    type Federation,
-    Like,
-    PUBLIC_COLLECTION,
-    Undo,
-} from '@fedify/fedify';
 
 export class LikeController {
     constructor(

--- a/src/http/api/media.controller.ts
+++ b/src/http/api/media.controller.ts
@@ -1,9 +1,9 @@
+import type { Context } from 'hono';
 import type { AccountService } from '@/account/account.service';
 import { exhaustiveCheck, getError, getValue, isError } from '@/core/result';
 import { RequireRoles, Route } from '@/http/decorators/route.decorator';
 import { GhostRole } from '@/http/middleware/role-guard';
 import type { ImageStorageService } from '@/storage/image-storage.service';
-import type { Context } from 'hono';
 
 /**
  * Controller for media-related operations

--- a/src/http/api/media.controller.unit.test.ts
+++ b/src/http/api/media.controller.unit.test.ts
@@ -1,10 +1,10 @@
+import type { Context } from 'hono';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import type { AccountService } from '@/account/account.service';
 import { error, ok } from '@/core/result';
-import type { ImageStorageService } from '@/storage/image-storage.service';
-import type { Context } from 'hono';
 
 import { MediaController } from '@/http/api/media.controller';
-import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ImageStorageService } from '@/storage/image-storage.service';
 
 describe('Image Upload API', () => {
     let accountService: AccountService;

--- a/src/http/api/post.controller.ts
+++ b/src/http/api/post.controller.ts
@@ -1,4 +1,17 @@
 import { createHash } from 'node:crypto';
+import {
+    type Actor,
+    Announce,
+    Create,
+    type Federation,
+    Image,
+    Mention,
+    Note,
+    PUBLIC_COLLECTION,
+    Undo,
+} from '@fedify/fedify';
+import { Temporal } from '@js-temporal/polyfill';
+import { z } from 'zod';
 import type { KnexAccountRepository } from '@/account/account.repository.knex';
 import type { AccountService } from '@/account/account.service';
 import type { AppContext, ContextData } from '@/app';
@@ -21,19 +34,6 @@ import { lookupActor, lookupObject } from '@/lookup-helpers';
 import type { ImageAttachment } from '@/post/post.entity';
 import type { KnexPostRepository } from '@/post/post.repository.knex';
 import type { PostService } from '@/post/post.service';
-import {
-    type Actor,
-    Announce,
-    Create,
-    type Federation,
-    Image,
-    Mention,
-    Note,
-    PUBLIC_COLLECTION,
-    Undo,
-} from '@fedify/fedify';
-import { Temporal } from '@js-temporal/polyfill';
-import { z } from 'zod';
 
 /**
  * Controller for post-related operations
@@ -219,7 +219,7 @@ export class PostController {
 
         try {
             data = NoteSchema.parse((await ctx.req.json()) as unknown);
-        } catch (err) {
+        } catch (_err) {
             return new Response(
                 JSON.stringify({ error: 'Invalid request format' }),
                 { status: 400 },
@@ -313,7 +313,7 @@ export class PostController {
 
         try {
             data = ReplyActionSchema.parse((await ctx.req.json()) as unknown);
-        } catch (err) {
+        } catch (_err) {
             return new Response(
                 JSON.stringify({ error: 'Invalid request format' }),
                 { status: 400 },

--- a/src/http/api/post.controller.unit.test.ts
+++ b/src/http/api/post.controller.unit.test.ts
@@ -1,5 +1,5 @@
+import type { Federation } from '@fedify/fedify';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-
 import { AccountEntity } from '@/account/account.entity';
 import type { KnexAccountRepository } from '@/account/account.repository.knex';
 import type { AccountService } from '@/account/account.service';
@@ -17,7 +17,6 @@ import type { KnexPostRepository } from '@/post/post.repository.knex';
 import type { PostService } from '@/post/post.service';
 import type { Site } from '@/site/site.service';
 import { createInternalAccountDraftData } from '@/test/account-entity-test-helpers';
-import type { Federation } from '@fedify/fedify';
 
 describe('Post API', () => {
     let site: Site;

--- a/src/http/api/search.controller.ts
+++ b/src/http/api/search.controller.ts
@@ -1,3 +1,4 @@
+import { pick } from 'es-toolkit';
 import type { AppContext } from '@/app';
 import { isHandle } from '@/helpers/activitypub/actor';
 import { isUri } from '@/helpers/uri';
@@ -5,7 +6,6 @@ import type { AccountDTO } from '@/http/api/types';
 import type { AccountView } from '@/http/api/views/account.view';
 import { RequireRoles, Route } from '@/http/decorators/route.decorator';
 import { GhostRole } from '@/http/middleware/role-guard';
-import { pick } from 'es-toolkit';
 
 type AccountSearchResult = Pick<
     AccountDTO,

--- a/src/http/api/views/account.follows.view.integration.test.ts
+++ b/src/http/api/views/account.follows.view.integration.test.ts
@@ -1,3 +1,6 @@
+import { getDocumentLoader } from '@fedify/fedify';
+import nock from 'nock';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Account } from '@/account/account.entity';
 import { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import type { FedifyContext } from '@/app';
@@ -5,10 +8,7 @@ import { ok } from '@/core/result';
 import { AccountFollowsView } from '@/http/api/views/account.follows.view';
 import { ModerationService } from '@/moderation/moderation.service';
 import { createTestDb } from '@/test/db';
-import { type FixtureManager, createFixtureManager } from '@/test/fixtures';
-import { getDocumentLoader } from '@fedify/fedify';
-import nock from 'nock';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
 
 describe('AccountFollowsView', () => {
     let accountFollowsView: AccountFollowsView;

--- a/src/http/api/views/account.follows.view.ts
+++ b/src/http/api/views/account.follows.view.ts
@@ -1,9 +1,3 @@
-import type { Account } from '@/account/account.entity';
-import { getAccountHandle } from '@/account/utils';
-import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
-import { type Result, error, getValue, isError, ok } from '@/core/result';
-import type { MinimalAccountDTO } from '@/http/api/types';
-import type { ModerationService } from '@/moderation/moderation.service';
 import {
     type Actor,
     CollectionPage,
@@ -12,6 +6,12 @@ import {
     lookupObject,
 } from '@fedify/fedify';
 import type { Knex } from 'knex';
+import type { Account } from '@/account/account.entity';
+import { getAccountHandle } from '@/account/utils';
+import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
+import { error, getValue, isError, ok, type Result } from '@/core/result';
+import type { MinimalAccountDTO } from '@/http/api/types';
+import type { ModerationService } from '@/moderation/moderation.service';
 
 /**
  * Maximum number of follow accounts to return
@@ -172,7 +172,7 @@ export class AccountFollowsView {
             if (!(page instanceof CollectionPage) || !page?.itemIds) {
                 return error('error-getting-follows');
             }
-        } catch (err) {
+        } catch (_err) {
             return error('error-getting-follows');
         }
 
@@ -282,7 +282,7 @@ export class AccountFollowsView {
 
                 page = getValue(pageResult);
             }
-        } catch (err) {
+        } catch (_err) {
             return error('error-getting-follows');
         }
 
@@ -415,7 +415,7 @@ export class AccountFollowsView {
                         domainBlockedByMe,
                     });
                 }
-            } catch (err) {
+            } catch (_err) {
                 ctx.data.logger.error('Error while iterating over follow list');
                 // Skip this item if processing fails
                 // This ensures that a single invalid or unreachable follow doesn't block the API from returning valid follows

--- a/src/http/api/views/account.posts.view.integration.test.ts
+++ b/src/http/api/views/account.posts.view.integration.test.ts
@@ -1,3 +1,6 @@
+import type { Logger } from '@logtape/logtape';
+import type { Knex } from 'knex';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Account } from '@/account/account.entity';
 import { KnexAccountRepository } from '@/account/account.repository.knex';
 import { AccountService } from '@/account/account.service';
@@ -9,28 +12,25 @@ import type {
 import { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import { AsyncEvents } from '@/core/events';
 import { getError, getValue, isError } from '@/core/result';
-import { AccountPostsView } from '@/http/api/views/account.posts.view';
 import type { AccountPosts } from '@/http/api/views/account.posts.view';
+import { AccountPostsView } from '@/http/api/views/account.posts.view';
 import { Audience, Post, PostType } from '@/post/post.entity';
 import { KnexPostRepository } from '@/post/post.repository.knex';
 import { generateTestCryptoKeyPair } from '@/test/crypto-key-pair';
 import { createTestDb } from '@/test/db';
-import { type FixtureManager, createFixtureManager } from '@/test/fixtures';
-import type { Logger } from '@logtape/logtape';
-import type { Knex } from 'knex';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
 
 describe('AccountPostsView', () => {
     let viewer: AccountPostsView;
-    let accountService: AccountService;
+    let _accountService: AccountService;
     let accountRepository: KnexAccountRepository;
     let events: AsyncEvents;
-    let site: Site;
-    let internalAccountData: InternalAccountData;
+    let _site: Site;
+    let _internalAccountData: InternalAccountData;
     let db: Knex;
-    let defaultAccount: AccountType;
+    let _defaultAccount: AccountType;
     let siteDefaultAccount: Account | null;
-    let account: AccountType;
+    let _account: AccountType;
     let accountEntity: Account | null;
     let postRepository: KnexPostRepository;
     let fixtureManager: FixtureManager;
@@ -50,12 +50,12 @@ describe('AccountPostsView', () => {
         };
         const [id] = await db('sites').insert(siteData);
 
-        site = {
+        _site = {
             id,
             ...siteData,
         };
 
-        internalAccountData = {
+        _internalAccountData = {
             username: 'index',
             name: 'Test Site Title',
             bio: 'Test Site Description',
@@ -72,7 +72,7 @@ describe('AccountPostsView', () => {
         postRepository = new KnexPostRepository(db, events, logger);
         const fedifyContextFactory = new FedifyContextFactory();
 
-        accountService = new AccountService(
+        _accountService = new AccountService(
             db,
             events,
             accountRepository,
@@ -85,12 +85,12 @@ describe('AccountPostsView', () => {
         const [accountEntityTemp] =
             await fixtureManager.createInternalAccount();
         accountEntity = accountEntityTemp;
-        account = await db('accounts').where({ id: accountEntity.id }).first();
+        _account = await db('accounts').where({ id: accountEntity.id }).first();
 
         const [siteDefaultAccountTemp] =
             await fixtureManager.createInternalAccount();
         siteDefaultAccount = siteDefaultAccountTemp;
-        defaultAccount = await db('accounts')
+        _defaultAccount = await db('accounts')
             .where({ id: siteDefaultAccount.id })
             .first();
     });
@@ -282,7 +282,7 @@ describe('AccountPostsView', () => {
 
         it('does not return replies', async () => {
             const post = await fixtureManager.createPost(account);
-            const reply = await fixtureManager.createReply(account, post);
+            const _reply = await fixtureManager.createReply(account, post);
             const result = await viewer.getPostsFromOutbox(
                 account,
                 contextAccount.id,
@@ -368,7 +368,7 @@ describe('AccountPostsView', () => {
         it('returns an error if the account is not internal', async () => {
             const externalAccount =
                 await fixtureManager.createExternalAccount();
-            const post = await fixtureManager.createPost(externalAccount);
+            const _post = await fixtureManager.createPost(externalAccount);
             const result = await viewer.getPostsFromOutbox(
                 externalAccount,
                 contextAccount.id,
@@ -399,9 +399,9 @@ describe('AccountPostsView', () => {
                 );
 
                 // Create posts
-                const followedAuthorPost =
+                const _followedAuthorPost =
                     await fixtureManager.createPost(followedAuthor);
-                const unfollowedAuthorPost =
+                const _unfollowedAuthorPost =
                     await fixtureManager.createPost(unfollowedAuthor);
 
                 // Get posts from followed author's outbox
@@ -507,7 +507,8 @@ describe('AccountPostsView', () => {
                     await fixtureManager.createInternalAccount();
 
                 // Create own post
-                const ownPost = await fixtureManager.createPost(viewingAccount);
+                const _ownPost =
+                    await fixtureManager.createPost(viewingAccount);
 
                 // Get own posts
                 const result = await viewer.getPostsFromOutbox(

--- a/src/http/api/views/account.posts.view.ts
+++ b/src/http/api/views/account.posts.view.ts
@@ -1,11 +1,3 @@
-import type { Account } from '@/account/account.entity';
-import { getAccountHandle } from '@/account/utils';
-import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
-import { type Result, error, getValue, isError, ok } from '@/core/result';
-import { sanitizeHtml } from '@/helpers/html';
-import type { PostDTO } from '@/http/api/types';
-import { ContentPreparer } from '@/post/content';
-import { type Mention, OutboxType, PostType } from '@/post/post.entity';
 import {
     Activity,
     CollectionPage,
@@ -13,6 +5,14 @@ import {
     lookupObject,
 } from '@fedify/fedify';
 import type { Knex } from 'knex';
+import type { Account } from '@/account/account.entity';
+import { getAccountHandle } from '@/account/utils';
+import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
+import { error, getValue, isError, ok, type Result } from '@/core/result';
+import { sanitizeHtml } from '@/helpers/html';
+import type { PostDTO } from '@/http/api/types';
+import { ContentPreparer } from '@/post/content';
+import { type Mention, OutboxType, PostType } from '@/post/post.entity';
 
 export type GetPostsError =
     | 'invalid-next-parameter'
@@ -335,7 +335,7 @@ export class AccountPostsView {
                     page = await outbox.getFirst();
                 }
             }
-        } catch (err) {
+        } catch (_err) {
             return error('error-getting-outbox');
         }
 
@@ -543,7 +543,7 @@ export class AccountPostsView {
                 }
 
                 result.results.push(this.mapActivityToPostDTO(activity));
-            } catch (err) {
+            } catch (_err) {
                 // If we can't map a post to an activity, skip it
                 // This ensures that a single invalid or unreachable post doesn't block the API from returning valid posts
             }
@@ -851,7 +851,7 @@ export class AccountPostsView {
                     username: actor.preferredUsername,
                     url: actor.url,
                 } as Account;
-            } catch (err) {
+            } catch (_err) {
                 return error('network-failure');
             }
         }

--- a/src/http/api/views/account.posts.view.unit.test.ts
+++ b/src/http/api/views/account.posts.view.unit.test.ts
@@ -1,10 +1,9 @@
-import type { Account } from '@/account/account.entity';
-import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
-import { PostType } from '@/post/post.entity';
 import type { Knex } from 'knex';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-
+import type { Account } from '@/account/account.entity';
+import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import { AccountPostsView } from '@/http/api/views/account.posts.view';
+import { PostType } from '@/post/post.entity';
 
 // Mock the fedify modules
 vi.mock('@fedify/fedify', () => ({

--- a/src/http/api/views/account.view.integration.test.ts
+++ b/src/http/api/views/account.view.integration.test.ts
@@ -1,12 +1,12 @@
-import type { ContextData } from '@/app';
 import type { Context } from '@fedify/fedify';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-
+import type { Logger } from '@logtape/logtape';
 import type { Knex } from 'knex';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { KnexAccountRepository } from '@/account/account.repository.knex';
 import { AccountService } from '@/account/account.service';
 import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
+import type { ContextData } from '@/app';
 import { AsyncEvents } from '@/core/events';
 import { error, ok } from '@/core/result';
 import type { AccountDTO } from '@/http/api/types';
@@ -16,8 +16,7 @@ import { Audience, Post, PostType } from '@/post/post.entity';
 import { KnexPostRepository } from '@/post/post.repository.knex';
 import { SiteService } from '@/site/site.service';
 import { createTestDb } from '@/test/db';
-import { type FixtureManager, createFixtureManager } from '@/test/fixtures';
-import type { Logger } from '@logtape/logtape';
+import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
 
 vi.mock('@/lookup-helpers', () => ({
     lookupActorProfile: vi.fn(),
@@ -26,7 +25,7 @@ vi.mock('@/lookup-helpers', () => ({
 
 describe('AccountView', () => {
     let db: Knex;
-    let siteService: SiteService;
+    let _siteService: SiteService;
     let accountService: AccountService;
     let postRepository: KnexPostRepository;
     let accountView: AccountView;
@@ -59,7 +58,7 @@ describe('AccountView', () => {
             fedifyContextFactory,
         );
 
-        siteService = new SiteService(db, accountService, {
+        _siteService = new SiteService(db, accountService, {
             getSiteSettings: async () => ({
                 site: {
                     description: 'Test site',

--- a/src/http/api/views/account.view.ts
+++ b/src/http/api/views/account.view.ts
@@ -1,3 +1,5 @@
+import { type Actor, type Collection, isActor } from '@fedify/fedify';
+import type { Knex } from 'knex';
 import type { Account } from '@/account/account.entity';
 import { getAccountHandle } from '@/account/utils';
 import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
@@ -6,8 +8,6 @@ import { getAttachments, getHandle } from '@/helpers/activitypub/actor';
 import { sanitizeHtml } from '@/helpers/html';
 import type { AccountDTO } from '@/http/api/types';
 import { lookupActorProfile, lookupObject } from '@/lookup-helpers';
-import { type Actor, type Collection, isActor } from '@fedify/fedify';
-import type { Knex } from 'knex';
 
 /**
  * Additional context that can be passed to the view
@@ -366,7 +366,7 @@ export class AccountView {
             const collection = await getCollection.bind(actor)();
 
             return collection?.totalItems ?? 0;
-        } catch (error) {
+        } catch (_error) {
             return 0;
         }
     }

--- a/src/http/api/views/blocks.view.integration.test.ts
+++ b/src/http/api/views/blocks.view.integration.test.ts
@@ -1,8 +1,8 @@
-import { BlocksView } from '@/http/api/views/blocks.view';
-import { createTestDb } from '@/test/db';
-import { type FixtureManager, createFixtureManager } from '@/test/fixtures';
 import type { Knex } from 'knex';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { BlocksView } from '@/http/api/views/blocks.view';
+import { createTestDb } from '@/test/db';
+import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
 
 describe('BlocksView', () => {
     let db: Knex;

--- a/src/http/api/views/blocks.view.ts
+++ b/src/http/api/views/blocks.view.ts
@@ -1,6 +1,6 @@
+import type { Knex } from 'knex';
 import { getAccountHandle } from '@/account/utils';
 import type { BlockedDomainDTO, MinimalAccountDTO } from '@/http/api/types';
-import type { Knex } from 'knex';
 
 export class BlocksView {
     constructor(private readonly db: Knex) {}

--- a/src/http/api/views/reply.chain.view.integration.test.ts
+++ b/src/http/api/views/reply.chain.view.integration.test.ts
@@ -1,10 +1,10 @@
+import type { Knex } from 'knex';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { unsafeUnwrap } from '@/core/result';
 import { ReplyChainView } from '@/http/api/views/reply.chain.view';
 import type { Post } from '@/post/post.entity';
 import { createTestDb } from '@/test/db';
-import { type FixtureManager, createFixtureManager } from '@/test/fixtures';
-import type { Knex } from 'knex';
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
 
 /**
  * This will setup the database with a bunch of posts centered around a single post.
@@ -141,8 +141,7 @@ describe('ReplyChainView', () => {
         });
 
         it('should be able to return the next page of children', async () => {
-            const { ancestors, post, replies, chains } =
-                await setupPosts(fixtureManager);
+            const { post, replies } = await setupPosts(fixtureManager);
 
             const replyChainView = new ReplyChainView(db);
 
@@ -304,7 +303,7 @@ describe('ReplyChainView', () => {
         });
 
         it('should correctly set next cursor when there are more children', async () => {
-            const { post, replies } = await setupPosts(fixtureManager);
+            const { post } = await setupPosts(fixtureManager);
 
             const replyChainView = new ReplyChainView(db);
 
@@ -392,7 +391,7 @@ describe('ReplyChainView', () => {
         });
 
         it('should handle posts in the middle of a chain', async () => {
-            const { replies, chains } = await setupPosts(fixtureManager);
+            const { chains } = await setupPosts(fixtureManager);
 
             const replyChainView = new ReplyChainView(db);
 

--- a/src/http/api/views/reply.chain.view.ts
+++ b/src/http/api/views/reply.chain.view.ts
@@ -1,9 +1,9 @@
-import { getAccountHandle } from '@/account/utils';
-import { type Result, error, ok } from '@/core/result';
-import type { PostDTO } from '@/http/api/types';
-import { PostType } from '@/post/post.entity';
 import type { Knex } from 'knex';
 import z from 'zod';
+import { getAccountHandle } from '@/account/utils';
+import { error, ok, type Result } from '@/core/result';
+import type { PostDTO } from '@/http/api/types';
+import { PostType } from '@/post/post.entity';
 
 export type ReplyChain = {
     ancestors: {

--- a/src/http/api/webfinger.controller.ts
+++ b/src/http/api/webfinger.controller.ts
@@ -54,7 +54,7 @@ export class WebFingerController {
 
         try {
             account = await this.accountRepository.getBySite(site);
-        } catch (error) {
+        } catch (_error) {
             return new Response(null, {
                 status: 404,
             });

--- a/src/http/api/webfinger.unit.test.ts
+++ b/src/http/api/webfinger.unit.test.ts
@@ -1,10 +1,9 @@
+import type { Context } from 'hono';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-
 import type { Account } from '@/account/account.entity';
 import type { KnexAccountRepository } from '@/account/account.repository.knex';
 import { WebFingerController } from '@/http/api/webfinger.controller';
 import type { Site, SiteService } from '@/site/site.service';
-import type { Context } from 'hono';
 
 describe('handleWebFinger', () => {
     let siteService: SiteService;

--- a/src/http/api/webhook.controller.ts
+++ b/src/http/api/webhook.controller.ts
@@ -7,7 +7,6 @@ import { exhaustiveCheck, getError, getValue, isError } from '@/core/result';
 import type { GhostPostService } from '@/ghost/ghost-post.service';
 import { postToDTO } from '@/http/api/helpers/post';
 import { BadRequest, Forbidden } from '@/http/api/helpers/response';
-import type { PostService } from '@/post/post.service';
 
 const PostInputSchema = z.object({
     uuid: z.string().uuid(),
@@ -56,7 +55,6 @@ const PostUnpublishedWebhookSchema = z.object({
 
 export class WebhookController {
     constructor(
-        private readonly postService: PostService,
         private readonly ghostPostService: GhostPostService,
         private readonly logger: Logger,
     ) {}

--- a/src/http/middleware/role-guard.ts
+++ b/src/http/middleware/role-guard.ts
@@ -37,7 +37,7 @@ async function getKey(
         await jwksCache.set(['cachedJwks', jwksURL.hostname], key);
 
         return key;
-    } catch (err) {
+    } catch (_err) {
         if (retries === 0) {
             return null;
         }
@@ -124,7 +124,7 @@ export function createRoleMiddleware(jwksCache: KvStore) {
             } else {
                 ctx.set('role', GhostRole.Anonymous);
             }
-        } catch (err) {
+        } catch (_err) {
             ctx.set('role', GhostRole.Anonymous);
         }
 

--- a/src/http/routing/route-registry.ts
+++ b/src/http/routing/route-registry.ts
@@ -1,4 +1,7 @@
 import 'reflect-metadata';
+import * as Sentry from '@sentry/node';
+import type { AwilixContainer } from 'awilix';
+import type { Hono, MiddlewareHandler, Next } from 'hono';
 import type { AppContext, HonoContextVariables } from '@/app';
 import {
     ROLES_METADATA_KEY,
@@ -6,9 +9,6 @@ import {
 } from '@/http/decorators/route.decorator';
 import type { GhostRole } from '@/http/middleware/role-guard';
 import { requireRole } from '@/http/middleware/role-guard';
-import * as Sentry from '@sentry/node';
-import type { AwilixContainer } from 'awilix';
-import type { Hono, MiddlewareHandler, Next } from 'hono';
 
 interface RouteRegistration {
     method: 'GET' | 'POST' | 'PUT' | 'DELETE';

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,11 +1,11 @@
 import { IncomingMessage } from 'node:http';
-import { extractQueryInfoFromError } from '@/db';
 import { DiagConsoleLogger, DiagLogLevel, diag } from '@opentelemetry/api';
 import {
     BatchSpanProcessor,
     SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import * as Sentry from '@sentry/node';
+import { extractQueryInfoFromError } from '@/db';
 
 export async function setupInstrumentation() {
     if (process.env.NODE_ENV === 'production') {
@@ -101,13 +101,13 @@ export async function setupInstrumentation() {
                                             'http.url': req.url,
                                             'http.target': url.pathname,
                                         });
-                                    } catch (e) {
+                                    } catch (_e) {
                                         // Ignore URL parsing errors
                                     }
                                 }
                             }
                         },
-                        applyCustomAttributesOnSpan: (span) => {},
+                        applyCustomAttributesOnSpan: (_span) => {},
                     },
                 }),
             ],

--- a/src/knex.kvstore.integration.test.ts
+++ b/src/knex.kvstore.integration.test.ts
@@ -1,10 +1,9 @@
-import { beforeAll, describe, expect, it } from 'vitest';
-
-import { KnexKvStore } from '@/knex.kvstore';
-import { createTestDb } from '@/test/db';
 import { Temporal } from '@js-temporal/polyfill';
 import { getLogger } from '@logtape/logtape';
 import type { Knex } from 'knex';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { KnexKvStore } from '@/knex.kvstore';
+import { createTestDb } from '@/test/db';
 
 describe('KnexKvStore', () => {
     let client: Knex;

--- a/src/knex.kvstore.ts
+++ b/src/knex.kvstore.ts
@@ -36,7 +36,7 @@ export class KnexKvStore implements KvStore {
         if (!row) {
             return null;
         }
-        if (Object.hasOwnProperty.call(row.value, '@@BOOLEAN@@')) {
+        if (Object.hasOwn(row.value, '@@BOOLEAN@@')) {
             return row.value['@@BOOLEAN@@'];
         }
         return row.value;

--- a/src/lookup-helpers.ts
+++ b/src/lookup-helpers.ts
@@ -1,15 +1,15 @@
-import type { ContextData } from '@/app';
-import { type Result, error, ok } from '@/core/result';
 import {
-    Object as APObject,
     type Actor,
+    Object as APObject,
     type Article,
     type Collection,
     type Context,
-    type Note,
     isActor,
     lookupWebFinger,
+    type Note,
 } from '@fedify/fedify';
+import type { ContextData } from '@/app';
+import { error, ok, type Result } from '@/core/result';
 
 export type LookupError = 'no-links-found' | 'no-self-link' | 'lookup-error';
 
@@ -56,7 +56,7 @@ export async function lookupObject(
     let documentLoader = null;
     try {
         documentLoader = await ctx.getDocumentLoader({ identifier: 'index' });
-    } catch (err) {
+    } catch (_err) {
         ctx.data.logger.warn(
             'Could not get authenticated document loader for lookupObject',
         );

--- a/src/lookup-helpers.unit.test.ts
+++ b/src/lookup-helpers.unit.test.ts
@@ -1,8 +1,8 @@
+import { type Context, lookupWebFinger } from '@fedify/fedify';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ContextData } from '@/app';
 import { error, ok } from '@/core/result';
 import { lookupActorProfile } from '@/lookup-helpers';
-import { type Context, lookupWebFinger } from '@fedify/fedify';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@fedify/fedify', () => ({
     lookupWebFinger: vi.fn(),

--- a/src/moderation/moderation.service.integration.test.ts
+++ b/src/moderation/moderation.service.integration.test.ts
@@ -1,9 +1,8 @@
+import type { Knex } from 'knex';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
-
 import { ModerationService } from '@/moderation/moderation.service';
 import { createTestDb } from '@/test/db';
-import { type FixtureManager, createFixtureManager } from '@/test/fixtures';
-import type { Knex } from 'knex';
+import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
 
 describe('ModerationService', () => {
     let client: Knex;

--- a/src/moderation/moderation.service.ts
+++ b/src/moderation/moderation.service.ts
@@ -1,5 +1,5 @@
-import type { Post } from '@/post/post.entity';
 import type { Knex } from 'knex';
+import type { Post } from '@/post/post.entity';
 
 export class ModerationService {
     constructor(private readonly db: Knex) {}

--- a/src/mq/gcloud-pubsub-push/error-utils.ts
+++ b/src/mq/gcloud-pubsub-push/error-utils.ts
@@ -32,7 +32,7 @@ function isDnsResolutionError(error: Error, depth = 0): boolean {
     return false;
 }
 
-function analyzeDnsResolutionError(error: Error): ErrorAnalysis {
+function analyzeDnsResolutionError(_error: Error): ErrorAnalysis {
     // DNS resolution errors are not retryable and not reportable
     return {
         isRetryable: false,
@@ -83,7 +83,7 @@ function isUpstreamSSLError(error: Error, depth = 0): boolean {
     return false;
 }
 
-function analyzeUpstreamSSLError(error: Error): ErrorAnalysis {
+function analyzeUpstreamSSLError(_error: Error): ErrorAnalysis {
     // Upstream certificate errors are not retryable and not reportable
     return {
         isRetryable: false,
@@ -126,7 +126,7 @@ function isNetworkConnectivityError(error: Error, depth = 0): boolean {
     return false;
 }
 
-function analyzeNetworkConnectivityError(error: Error): ErrorAnalysis {
+function analyzeNetworkConnectivityError(_error: Error): ErrorAnalysis {
     // Network connectivity errors are retryable but not reportable
     return {
         isRetryable: true,

--- a/src/mq/gcloud-pubsub-push/mq.unit.test.ts
+++ b/src/mq/gcloud-pubsub-push/mq.unit.test.ts
@@ -1,12 +1,12 @@
 import type { PubSub, Topic } from '@google-cloud/pubsub';
 import type { Logger } from '@logtape/logtape';
 import type { Context } from 'hono';
-import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 
 import type { AccountService } from '@/account/account.service';
 import {
-    GCloudPubSubPushMessageQueue,
     createPushMessageHandler,
+    GCloudPubSubPushMessageQueue,
 } from '@/mq/gcloud-pubsub-push/mq';
 
 vi.mock('@google-cloud/pubsub', () => ({

--- a/src/notification/notification-event.service.unit.test.ts
+++ b/src/notification/notification-event.service.unit.test.ts
@@ -1,6 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
 import { EventEmitter } from 'node:events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Account as AccountEntity } from '@/account/account.entity';
 import {
@@ -9,13 +8,13 @@ import {
     DomainBlockedEvent,
     NotificationsReadEvent,
 } from '@/account/events';
-import { NotificationEventService } from '@/notification/notification-event.service';
 import type { NotificationService } from '@/notification/notification.service';
+import { NotificationEventService } from '@/notification/notification-event.service';
+import type { Post } from '@/post/post.entity';
 import { PostCreatedEvent } from '@/post/post-created.event';
 import { PostDeletedEvent } from '@/post/post-deleted.event';
 import { PostLikedEvent } from '@/post/post-liked.event';
 import { PostRepostedEvent } from '@/post/post-reposted.event';
-import type { Post } from '@/post/post.entity';
 
 describe('NotificationEventService', () => {
     let events: EventEmitter;

--- a/src/notification/notification.service.integration.test.ts
+++ b/src/notification/notification.service.integration.test.ts
@@ -1,16 +1,15 @@
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
-
 import type { Knex } from 'knex';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import { ModerationService } from '@/moderation/moderation.service';
 import {
     NotificationService,
     NotificationType,
 } from '@/notification/notification.service';
-import { Audience, PostType } from '@/post/post.entity';
 import type { Post } from '@/post/post.entity';
+import { Audience, PostType } from '@/post/post.entity';
 import { createTestDb } from '@/test/db';
-import { type FixtureManager, createFixtureManager } from '@/test/fixtures';
+import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
 
 describe('NotificationService', () => {
     let client: Knex;
@@ -821,7 +820,7 @@ describe('NotificationService', () => {
     describe('removeBlockedAccountNotifications', () => {
         it('should remove all notifications from a blocked account', async () => {
             // Create internal blocker account
-            const [account, site, userId] =
+            const [account, _site, userId] =
                 await fixtureManager.createInternalAccount(null, 'alice.com');
 
             // Create an external account that will be blocked
@@ -902,7 +901,7 @@ describe('NotificationService', () => {
     describe('removeBlockedDomainNotifications', () => {
         it('should remove all notifications from accounts from a blocked domain', async () => {
             // Create internal blocker account
-            const [account, site, userId] =
+            const [account, _site, userId] =
                 await fixtureManager.createInternalAccount(null, 'alice.com');
 
             // Create an external account that will have its domain blocked

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -1,8 +1,8 @@
-import { type Result, error, ok } from '@/core/result';
+import type { Knex } from 'knex';
+import { error, ok, type Result } from '@/core/result';
 import { sanitizeHtml } from '@/helpers/html';
 import type { ModerationService } from '@/moderation/moderation.service';
 import type { Post } from '@/post/post.entity';
-import type { Knex } from 'knex';
 
 export enum NotificationType {
     Like = 1,

--- a/src/post/content.ts
+++ b/src/post/content.ts
@@ -1,10 +1,10 @@
-import { HANDLE_REGEX } from '@/constants';
-import { isEqual } from '@/helpers/uri';
-import { type Mention, PostSummary } from '@/post/post.entity';
 import { htmlToText } from 'html-to-text';
 import linkifyHtml from 'linkify-html';
 import { parse } from 'node-html-parser';
 import urlRegex from 'url-regex';
+import { HANDLE_REGEX } from '@/constants';
+import { isEqual } from '@/helpers/uri';
+import { type Mention, PostSummary } from '@/post/post.entity';
 
 /**
  * Marker to indicate that the proceeding content is member content
@@ -76,18 +76,6 @@ export class ContentPreparer {
         },
     ) {
         return ContentPreparer.instance.prepare(content, options);
-    }
-
-    static regenerateExcerpt(html: string) {
-        return ContentPreparer.instance.regenerateExcerpt(html);
-    }
-
-    static parseMentions(content: string) {
-        return ContentPreparer.instance.parseMentions(content);
-    }
-
-    static updateMentions(content: string, mentions: Mention[]) {
-        return ContentPreparer.instance.updateMentions(content, mentions);
     }
 
     /**
@@ -199,6 +187,10 @@ export class ContentPreparer {
         return linkifyHtml(html, options);
     }
 
+    static regenerateExcerpt(html: string) {
+        return ContentPreparer.instance.regenerateExcerpt(html);
+    }
+
     /**
      * Re-generate excerpt from HTML content, based on a character limit
      *
@@ -228,10 +220,18 @@ export class ContentPreparer {
         return PostSummary.parse(`${text.substring(0, 500 - 3)}...`);
     }
 
+    static parseMentions(content: string) {
+        return ContentPreparer.instance.parseMentions(content);
+    }
+
     private parseMentions(content: string): Set<string> {
         const mentions =
             content.match(new RegExp(HANDLE_REGEX.source, 'g')) || [];
         return new Set(mentions);
+    }
+
+    static updateMentions(content: string, mentions: Mention[]) {
+        return ContentPreparer.instance.updateMentions(content, mentions);
     }
 
     /**
@@ -265,7 +265,7 @@ export class ContentPreparer {
             }
 
             return html.toString();
-        } catch (error) {
+        } catch (_error) {
             // If anything goes wrong during parsing or processing, return the original content
             return content;
         }

--- a/src/post/content.unit.test.ts
+++ b/src/post/content.unit.test.ts
@@ -1,10 +1,10 @@
+import { describe, expect, it } from 'vitest';
 import { AccountEntity } from '@/account/account.entity';
 import {
     ContentPreparer,
     MEMBER_CONTENT_MARKER,
     PAID_CONTENT_PREVIEW_HTML,
 } from '@/post/content';
-import { describe, expect, it } from 'vitest';
 
 describe('ContentPreparer', () => {
     const preparer = new ContentPreparer();

--- a/src/post/post-interaction-counts.service.ts
+++ b/src/post/post-interaction-counts.service.ts
@@ -2,12 +2,12 @@ import type { Logger } from '@logtape/logtape';
 
 import { getError, isError } from '@/core/result';
 import type { PubSubEvents } from '@/events/pubsub';
-import { PostInteractionCountsUpdateRequestedEvent } from '@/post/post-interaction-counts-update-requested.event';
 import type { KnexPostRepository } from '@/post/post.repository.knex';
 import {
     INTERACTION_COUNTS_NOT_FOUND,
     type PostService,
 } from '@/post/post.service';
+import { PostInteractionCountsUpdateRequestedEvent } from '@/post/post-interaction-counts-update-requested.event';
 
 export class PostInteractionCountsService {
     constructor(
@@ -116,7 +116,7 @@ export class PostInteractionCountsService {
             lastUpdate = publishedAt;
         }
 
-        const now = new Date().getTime();
+        const now = Date.now();
         const timeSinceLastUpdate = now - lastUpdate.getTime();
         const timeSincePublished = now - publishedAt.getTime();
 

--- a/src/post/post-interaction-counts.service.unit.test.ts
+++ b/src/post/post-interaction-counts.service.unit.test.ts
@@ -1,15 +1,15 @@
+import type { Logger } from '@logtape/logtape';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { error, ok } from '@/core/result';
 import type { PubSubEvents } from '@/events/pubsub';
-import { PostInteractionCountsUpdateRequestedEvent } from '@/post/post-interaction-counts-update-requested.event';
-import { PostInteractionCountsService } from '@/post/post-interaction-counts.service';
 import type { Post } from '@/post/post.entity';
 import type { KnexPostRepository } from '@/post/post.repository.knex';
 import {
     INTERACTION_COUNTS_NOT_FOUND,
     type PostService,
 } from '@/post/post.service';
-import type { Logger } from '@logtape/logtape';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PostInteractionCountsService } from '@/post/post-interaction-counts.service';
+import { PostInteractionCountsUpdateRequestedEvent } from '@/post/post-interaction-counts-update-requested.event';
 
 describe('PostInteractionCountsService', () => {
     let service: PostInteractionCountsService;

--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -1,11 +1,11 @@
 import { randomUUID } from 'node:crypto';
+import z from 'zod';
 import type { Account } from '@/account/account.entity';
 import { BaseEntity } from '@/core/base.entity';
-import { type Result, error, ok } from '@/core/result';
+import { error, ok, type Result } from '@/core/result';
 import { parseURL } from '@/core/url';
 import { sanitizeHtml } from '@/helpers/html';
 import { ContentPreparer, type PrepareContentOptions } from '@/post/content';
-import z from 'zod';
 
 /** @see PostSummary.parse to get a branded PostSummary */
 export type PostSummary = string & { readonly __brand: unique symbol };

--- a/src/post/post.entity.unit.test.ts
+++ b/src/post/post.entity.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { type Ok, getValue, isError } from '@/core/result';
+import { getValue, isError, type Ok } from '@/core/result';
 import {
     Audience,
     Post,

--- a/src/post/post.repository.knex.integration.test.ts
+++ b/src/post/post.repository.knex.integration.test.ts
@@ -1,19 +1,16 @@
 import assert from 'node:assert';
 import { randomUUID } from 'node:crypto';
+import type { Logger } from '@logtape/logtape';
+import type { Knex } from 'knex';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { KnexAccountRepository } from '@/account/account.repository.knex';
 import { AccountService } from '@/account/account.service';
 import { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import { AsyncEvents } from '@/core/events';
-import { type Ok, getValue } from '@/core/result';
-import { FeedUpdateService } from '@/feed/feed-update.service';
+import { getValue, type Ok } from '@/core/result';
 import { FeedService } from '@/feed/feed.service';
+import { FeedUpdateService } from '@/feed/feed-update.service';
 import { ModerationService } from '@/moderation/moderation.service';
-import { PostCreatedEvent } from '@/post/post-created.event';
-import { PostDeletedEvent } from '@/post/post-deleted.event';
-import { PostDerepostedEvent } from '@/post/post-dereposted.event';
-import { PostLikedEvent } from '@/post/post-liked.event';
-import { PostRepostedEvent } from '@/post/post-reposted.event';
-import { PostUpdatedEvent } from '@/post/post-updated.event';
 import {
     Audience,
     OutboxType,
@@ -23,13 +20,16 @@ import {
     PostType,
 } from '@/post/post.entity';
 import { KnexPostRepository } from '@/post/post.repository.knex';
+import { PostCreatedEvent } from '@/post/post-created.event';
+import { PostDeletedEvent } from '@/post/post-deleted.event';
+import { PostDerepostedEvent } from '@/post/post-dereposted.event';
+import { PostLikedEvent } from '@/post/post-liked.event';
+import { PostRepostedEvent } from '@/post/post-reposted.event';
+import { PostUpdatedEvent } from '@/post/post-updated.event';
 import { SiteService } from '@/site/site.service';
 import { generateTestCryptoKeyPair } from '@/test/crypto-key-pair';
 import { createTestDb } from '@/test/db';
-import { type FixtureManager, createFixtureManager } from '@/test/fixtures';
-import type { Logger } from '@logtape/logtape';
-import type { Knex } from 'knex';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
 
 describe('KnexPostRepository', () => {
     let events: AsyncEvents;
@@ -68,7 +68,7 @@ describe('KnexPostRepository', () => {
             generateTestCryptoKeyPair,
         );
         siteService = new SiteService(client, accountService, {
-            async getSiteSettings(host: string) {
+            async getSiteSettings(_host: string) {
                 return {
                     site: {
                         title: 'Test Site',

--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -1,15 +1,9 @@
-import type { Knex } from 'knex';
-
 import { randomUUID } from 'node:crypto';
+import type { Logger } from '@logtape/logtape';
+import type { Knex } from 'knex';
 import { AccountEntity } from '@/account/account.entity';
 import type { AsyncEvents } from '@/core/events';
 import { parseURL } from '@/core/url';
-import { PostCreatedEvent } from '@/post/post-created.event';
-import { PostDeletedEvent } from '@/post/post-deleted.event';
-import { PostDerepostedEvent } from '@/post/post-dereposted.event';
-import { PostLikedEvent } from '@/post/post-liked.event';
-import { PostRepostedEvent } from '@/post/post-reposted.event';
-import { PostUpdatedEvent } from '@/post/post-updated.event';
 import {
     type Audience,
     type CreatePostType,
@@ -20,7 +14,12 @@ import {
     PostSummary,
     PostTitle,
 } from '@/post/post.entity';
-import type { Logger } from '@logtape/logtape';
+import { PostCreatedEvent } from '@/post/post-created.event';
+import { PostDeletedEvent } from '@/post/post-deleted.event';
+import { PostDerepostedEvent } from '@/post/post-dereposted.event';
+import { PostLikedEvent } from '@/post/post-liked.event';
+import { PostRepostedEvent } from '@/post/post-reposted.event';
+import { PostUpdatedEvent } from '@/post/post-updated.event';
 
 interface PostRow {
     id: number;

--- a/src/post/post.service.integration.test.ts
+++ b/src/post/post.service.integration.test.ts
@@ -1,11 +1,24 @@
+import {
+    Collection,
+    Document,
+    Image,
+    Link,
+    lookupObject,
+    Mention,
+    Note,
+} from '@fedify/fedify';
+import { Temporal } from '@js-temporal/polyfill';
+import type { Logger } from '@logtape/logtape';
+import type { Knex } from 'knex';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Account } from '@/account/account.entity';
 import { KnexAccountRepository } from '@/account/account.repository.knex';
 import { AccountService } from '@/account/account.service';
 import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import { AsyncEvents } from '@/core/events';
 import {
-    type Error as Err,
     error as createError,
+    type Error as Err,
     error,
     getError,
     getValue,
@@ -24,20 +37,7 @@ import { KnexPostRepository } from '@/post/post.repository.knex';
 import { PostService } from '@/post/post.service';
 import type { ImageStorageService } from '@/storage/image-storage.service';
 import { createTestDb } from '@/test/db';
-import { type FixtureManager, createFixtureManager } from '@/test/fixtures';
-import {
-    Collection,
-    Document,
-    Image,
-    Link,
-    Mention,
-    Note,
-    lookupObject,
-} from '@fedify/fedify';
-import { Temporal } from '@js-temporal/polyfill';
-import type { Logger } from '@logtape/logtape';
-import type { Knex } from 'knex';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
 
 vi.mock('@fedify/fedify', async () => {
     const actual = await vi.importActual('@fedify/fedify');
@@ -98,7 +98,7 @@ describe('PostService', () => {
                 ...original,
                 lookupActorProfile: vi
                     .fn()
-                    .mockImplementation(async (ctx, handle) => {
+                    .mockImplementation(async (_ctx, handle) => {
                         // Extract username and domain from handle
                         const match = handle.match(/@?([^@]+)@(.+)/);
                         if (!match) return error('lookup-error');

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -1,14 +1,21 @@
+import {
+    Article,
+    Mention as FedifyMention,
+    lookupObject,
+    Note,
+} from '@fedify/fedify';
+import type { Logger } from '@logtape/logtape';
 import type { Account } from '@/account/account.entity';
 import type { AccountService } from '@/account/account.service';
 import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import {
-    type Result,
     error,
     exhaustiveCheck,
     getError,
     getValue,
     isError,
     ok,
+    type Result,
 } from '@/core/result';
 import { parseURL } from '@/core/url';
 import {
@@ -29,13 +36,6 @@ import {
 import type { KnexPostRepository, Outbox } from '@/post/post.repository.knex';
 import type { VerificationError } from '@/storage/adapters/storage-adapter';
 import type { ImageStorageService } from '@/storage/image-storage.service';
-import {
-    Article,
-    Mention as FedifyMention,
-    Note,
-    lookupObject,
-} from '@fedify/fedify';
-import type { Logger } from '@logtape/logtape';
 
 export type GetByApIdError = 'upstream-error' | 'not-a-post' | 'missing-author';
 

--- a/src/pubsub.integration.test.ts
+++ b/src/pubsub.integration.test.ts
@@ -1,6 +1,5 @@
-import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
-
 import { PubSub } from '@google-cloud/pubsub';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 
 import { getFullTopic, initPubSubClient } from '@/pubsub';
 

--- a/src/site/site.service.integration.test.ts
+++ b/src/site/site.service.integration.test.ts
@@ -1,5 +1,5 @@
+import type { Knex } from 'knex';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-
 import { KnexAccountRepository } from '@/account/account.repository.knex';
 import { AccountService } from '@/account/account.service';
 import { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
@@ -11,7 +11,6 @@ import {
 } from '@/site/site.service';
 import { generateTestCryptoKeyPair } from '@/test/crypto-key-pair';
 import { createTestDb } from '@/test/db';
-import type { Knex } from 'knex';
 
 vi.mock('@fedify/fedify', async () => {
     // generateCryptoKeyPair is a slow operation so we generate a key pair
@@ -31,7 +30,7 @@ describe('SiteService', () => {
     let service: SiteService;
     let accountService: AccountService;
     let ghostService: IGhostService;
-    let site: Site;
+    let _site: Site;
     let db: Knex;
 
     beforeAll(async () => {
@@ -57,7 +56,7 @@ describe('SiteService', () => {
             generateTestCryptoKeyPair,
         );
         ghostService = {
-            async getSiteSettings(host: string) {
+            async getSiteSettings(_host: string) {
                 return {
                     site: {
                         icon: '',

--- a/src/site/site.service.ts
+++ b/src/site/site.service.ts
@@ -1,8 +1,8 @@
 import crypto from 'node:crypto';
+import type { Knex } from 'knex';
 import type { AccountService } from '@/account/account.service';
 import type { InternalAccountData } from '@/account/types';
 import type { getSiteSettings } from '@/helpers/ghost';
-import type { Knex } from 'knex';
 
 export type Site = {
     id: number;

--- a/src/storage/adapters/gcp-storage-adapter.ts
+++ b/src/storage/adapters/gcp-storage-adapter.ts
@@ -1,11 +1,11 @@
-import { type Result, error, ok } from '@/core/result';
+import { type Bucket, Storage } from '@google-cloud/storage';
+import type { Logger } from '@logtape/logtape';
+import { error, ok, type Result } from '@/core/result';
 import type {
     StorageAdapter,
     StorageError,
     VerificationError,
 } from '@/storage/adapters/storage-adapter';
-import { type Bucket, Storage } from '@google-cloud/storage';
-import type { Logger } from '@logtape/logtape';
 
 export class GCPStorageAdapter implements StorageAdapter {
     private storage: Storage;
@@ -113,7 +113,7 @@ export class GCPStorageAdapter implements StorageAdapter {
             if (!exists) {
                 return error('file-not-found');
             }
-        } catch (err) {
+        } catch (_err) {
             return error('file-not-found');
         }
 

--- a/src/storage/adapters/gcp-storage-adapter.unit.test.ts
+++ b/src/storage/adapters/gcp-storage-adapter.unit.test.ts
@@ -1,8 +1,8 @@
-import { error, getValue, isError, ok } from '@/core/result';
-import { GCPStorageAdapter } from '@/storage/adapters/gcp-storage-adapter';
 import { type Bucket, Storage } from '@google-cloud/storage';
 import type { Logger } from '@logtape/logtape';
-import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { error, getValue, isError, ok } from '@/core/result';
+import { GCPStorageAdapter } from '@/storage/adapters/gcp-storage-adapter';
 
 const mockLogger = {
     info: vi.fn(),

--- a/src/storage/adapters/local-storage-adapter.integration.test.ts
+++ b/src/storage/adapters/local-storage-adapter.integration.test.ts
@@ -1,7 +1,6 @@
-import { describe, expect, it } from 'vitest';
-
-import { readFileSync, readdirSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
 import { getValue, isError } from '@/core/result';
 import { LocalStorageAdapter } from '@/storage/adapters/local-storage-adapter';
 

--- a/src/storage/adapters/local-storage-adapter.ts
+++ b/src/storage/adapters/local-storage-adapter.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'node:fs';
 import { dirname, join, normalize } from 'node:path';
-import { type Result, error, ok } from '@/core/result';
+import { error, ok, type Result } from '@/core/result';
 import type {
     StorageAdapter,
     StorageError,
@@ -48,7 +48,7 @@ export class LocalStorageAdapter implements StorageAdapter {
             const url = new URL(path, this.hostingUrl).toString();
 
             return ok(url);
-        } catch (err) {
+        } catch (_err) {
             return error('error-saving-file');
         }
     }

--- a/src/storage/image-processor.ts
+++ b/src/storage/image-processor.ts
@@ -1,6 +1,6 @@
-import { type Result, error, ok } from '@/core/result';
 import type { Logger } from '@logtape/logtape';
 import sharp from 'sharp';
+import { error, ok, type Result } from '@/core/result';
 
 export type ValidationError = 'file-too-large' | 'file-type-not-supported';
 

--- a/src/storage/image-processor.unit.test.ts
+++ b/src/storage/image-processor.unit.test.ts
@@ -1,8 +1,8 @@
-import { getError, isError } from '@/core/result';
-import { ImageProcessor } from '@/storage/image-processor';
 import type { Logger } from '@logtape/logtape';
 import sharp from 'sharp';
 import { describe, expect, it, vi } from 'vitest';
+import { getError, isError } from '@/core/result';
+import { ImageProcessor } from '@/storage/image-processor';
 
 const mockLogger = {
     info: vi.fn(),

--- a/src/storage/image-storage.service.integration.test.ts
+++ b/src/storage/image-storage.service.integration.test.ts
@@ -1,11 +1,11 @@
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
+import { File as NodeFile } from 'fetch-blob/file.js';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { getError, getValue, isError } from '@/core/result';
 import { GCPStorageAdapter } from '@/storage/adapters/gcp-storage-adapter';
 import { ImageProcessor } from '@/storage/image-processor';
 import { ImageStorageService } from '@/storage/image-storage.service';
-import { File as NodeFile } from 'fetch-blob/file.js';
-import { beforeAll, describe, expect, it } from 'vitest';
 
 const logger = {
     info: console.log,

--- a/src/storage/image-storage.service.ts
+++ b/src/storage/image-storage.service.ts
@@ -1,4 +1,5 @@
-import { type Result, getValue, isError, ok } from '@/core/result';
+import { v4 as uuidv4 } from 'uuid';
+import { getValue, isError, ok, type Result } from '@/core/result';
 import type {
     StorageAdapter,
     StorageError,
@@ -8,7 +9,6 @@ import type {
     ImageProcessor,
     ValidationError,
 } from '@/storage/image-processor';
-import { v4 as uuidv4 } from 'uuid';
 
 export class ImageStorageService {
     constructor(

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 import { faker } from '@faker-js/faker';
+import type { Logger } from '@logtape/logtape';
 import type { Knex } from 'knex';
-
 import type { Account } from '@/account/account.entity';
 import { KnexAccountRepository } from '@/account/account.repository.knex';
 import { AccountService } from '@/account/account.service';
@@ -12,7 +12,6 @@ import { type CreatePostType, Post, PostType } from '@/post/post.entity';
 import { KnexPostRepository } from '@/post/post.repository.knex';
 import { type Site, SiteService } from '@/site/site.service';
 import { generateTestCryptoKeyPair } from '@/test/crypto-key-pair';
-import type { Logger } from '@logtape/logtape';
 
 export class FixtureManager {
     constructor(

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,59 +49,59 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@biomejs/biome@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/biome/-/biome-1.9.4.tgz#89766281cbc3a0aae865a7ff13d6aaffea2842bf"
-  integrity sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==
+"@biomejs/biome@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/biome/-/biome-2.1.3.tgz#b426af6da72728d46f2de9267a140aba2c5d9d07"
+  integrity sha512-KE/tegvJIxTkl7gJbGWSgun7G6X/n2M6C35COT6ctYrAy7SiPyNvi6JtoQERVK/VRbttZfgGq96j2bFmhmnH4w==
   optionalDependencies:
-    "@biomejs/cli-darwin-arm64" "1.9.4"
-    "@biomejs/cli-darwin-x64" "1.9.4"
-    "@biomejs/cli-linux-arm64" "1.9.4"
-    "@biomejs/cli-linux-arm64-musl" "1.9.4"
-    "@biomejs/cli-linux-x64" "1.9.4"
-    "@biomejs/cli-linux-x64-musl" "1.9.4"
-    "@biomejs/cli-win32-arm64" "1.9.4"
-    "@biomejs/cli-win32-x64" "1.9.4"
+    "@biomejs/cli-darwin-arm64" "2.1.3"
+    "@biomejs/cli-darwin-x64" "2.1.3"
+    "@biomejs/cli-linux-arm64" "2.1.3"
+    "@biomejs/cli-linux-arm64-musl" "2.1.3"
+    "@biomejs/cli-linux-x64" "2.1.3"
+    "@biomejs/cli-linux-x64-musl" "2.1.3"
+    "@biomejs/cli-win32-arm64" "2.1.3"
+    "@biomejs/cli-win32-x64" "2.1.3"
 
-"@biomejs/cli-darwin-arm64@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz#dfa376d23a54a2d8f17133c92f23c1bf2e62509f"
-  integrity sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==
+"@biomejs/cli-darwin-arm64@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.1.3.tgz#fed55146221efd0b89b2398f629003a2e24feb43"
+  integrity sha512-LFLkSWRoSGS1wVUD/BE6Nlt2dSn0ulH3XImzg2O/36BoToJHKXjSxzPEMAqT9QvwVtk7/9AQhZpTneERU9qaXA==
 
-"@biomejs/cli-darwin-x64@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz#eafc2ce3849d385fc02238aad1ca4a73395a64d9"
-  integrity sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==
+"@biomejs/cli-darwin-x64@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.1.3.tgz#5cbffc6eb65a190ee6a0315245476b92abe531ce"
+  integrity sha512-Q/4OTw8P9No9QeowyxswcWdm0n2MsdCwWcc5NcKQQvzwPjwuPdf8dpPPf4r+x0RWKBtl1FLiAUtJvBlri6DnYw==
 
-"@biomejs/cli-linux-arm64-musl@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz#d780c3e01758fc90f3268357e3f19163d1f84fca"
-  integrity sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==
+"@biomejs/cli-linux-arm64-musl@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.1.3.tgz#6cffb8747c76c9a2b2a6bbd7a5e474e3148e21a4"
+  integrity sha512-KXouFSBnoxAWZYDQrnNRzZBbt5s9UJkIm40hdvSL9mBxSSoxRFQJbtg1hP3aa8A2SnXyQHxQfpiVeJlczZt76w==
 
-"@biomejs/cli-linux-arm64@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz#8ed1dd0e89419a4b66a47f95aefb8c46ae6041c9"
-  integrity sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==
+"@biomejs/cli-linux-arm64@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.1.3.tgz#30696c10321837987a925d547e13e60c828614e1"
+  integrity sha512-2hS6LgylRqMFmAZCOFwYrf77QMdUwJp49oe8PX/O8+P2yKZMSpyQTf3Eo5ewnsMFUEmYbPOskafdV1ds1MZMJA==
 
-"@biomejs/cli-linux-x64-musl@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz#f36982b966bd671a36671e1de4417963d7db15fb"
-  integrity sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==
+"@biomejs/cli-linux-x64-musl@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.1.3.tgz#924a394de57a73cf76bacd44b9780dd532b1718a"
+  integrity sha512-KaLAxnROouzIWtl6a0Y88r/4hW5oDUJTIqQorOTVQITaKQsKjZX4XCUmHIhdEk8zMnaiLZzRTAwk1yIAl+mIew==
 
-"@biomejs/cli-linux-x64@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz#a0a7f56680c76b8034ddc149dbf398bdd3a462e8"
-  integrity sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==
+"@biomejs/cli-linux-x64@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-x64/-/cli-linux-x64-2.1.3.tgz#8cac08e0af942c439cc4c0d7aa71ba12e3736382"
+  integrity sha512-NxlSCBhLvQtWGagEztfAZ4WcE1AkMTntZV65ZvR+J9jp06+EtOYEBPQndA70ZGhHbEDG57bR6uNvqkd1WrEYVA==
 
-"@biomejs/cli-win32-arm64@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz#e2ef4e0084e76b7e26f0fc887c5ef1265ea56200"
-  integrity sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==
+"@biomejs/cli-win32-arm64@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.1.3.tgz#483acf4c9b656c2408c1fd3731af588e99ac2dde"
+  integrity sha512-V9CUZCtWH4u0YwyCYbQ3W5F4ZGPWp2C2TYcsiWFNNyRfmOW1j/TY/jAurl33SaRjgZPO5UUhGyr9m6BN9t84NQ==
 
-"@biomejs/cli-win32-x64@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz#4c7afa90e3970213599b4095e62f87e5972b2340"
-  integrity sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==
+"@biomejs/cli-win32-x64@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-x64/-/cli-win32-x64-2.1.3.tgz#b7ac23a4636ebb8ae6036ee5c65b065a4072f4c4"
+  integrity sha512-dxy599q6lgp8ANPpR8sDMscwdp9oOumEsVXuVCVT9N2vAho8uYXlCz53JhxX6LtJOXaE73qzgkGQ7QqvFlMC0g==
 
 "@cfworker/json-schema@^4.1.1":
   version "4.1.1"


### PR DESCRIPTION
no ref

This is a major upgrade that required code changes due to the addition of extra rules / modification of existing rules in biome

As part of this I also had to set the ts target to `es2022` as the compiler started complaining about `Object.hasOwn` usage. Since we are targeting node `22` anyways, this should be fine (`es2022` should be fully supported in node `22`)