### PR TITLE
Added table for ghost uuid to ap post ap_id mapping

### DIFF
--- a/migrate/migrations/000061_add-ghost-ap-post-mappings-table.down.sql
+++ b/migrate/migrations/000061_add-ghost-ap-post-mappings-table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS ghost_ap_post_mappings;

--- a/migrate/migrations/000061_add-ghost-ap-post-mappings-table.up.sql
+++ b/migrate/migrations/000061_add-ghost-ap-post-mappings-table.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE ghost_ap_post_mappings (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    created_at TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+
+    -- The uuid of the ghost post
+    ghost_uuid CHAR(36) NOT NULL UNIQUE,
+
+    -- The ap id of the ap post
+    ap_id VARCHAR(1024) NOT NULL,
+    ap_id_hash BINARY(32) GENERATED ALWAYS AS (UNHEX(SHA2(ap_id, 256))) STORED UNIQUE
+);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2293

- This table will be used to store mapping between ghost post's uuid and AP post ap_id
- Added `ap_id_hash` for faster lookups
- Unique index on `ghost_uuid` and `ap_id_hash`