### PR TITLE
Write/Delete from mapping table on post publish and deletion

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -40,6 +40,7 @@ import type { DeleteDispatcher } from 'activitypub/object-dispatchers/delete.dis
 import { get } from 'es-toolkit/compat';
 import type { EventSerializer } from 'events/event';
 import type { createIncomingPubSubMessageHandler } from 'events/pubsub-http';
+import type { GhostPostService } from 'ghost/ghost-post.service';
 import { Hono, type Context as HonoContext, type Next } from 'hono';
 import { cors } from 'hono/cors';
 import { AccountController } from 'http/api/account.controller';
@@ -208,6 +209,8 @@ container.resolve<FeedUpdateService>('feedUpdateService').init();
 container.resolve<NotificationEventService>('notificationEventService').init();
 
 container.resolve<GhostExploreService>('ghostExploreService').init();
+
+container.resolve<GhostPostService>('ghostPostService').init();
 
 container
     .resolve<PostInteractionCountsService>('postInteractionCountsService')

--- a/src/ghost/ghost-post.service.integration.test.ts
+++ b/src/ghost/ghost-post.service.integration.test.ts
@@ -85,6 +85,7 @@ describe('GhostPostService', () => {
         ghostPostService = new GhostPostService(
             db,
             postService,
+            postRepository,
             logger,
             events,
         );
@@ -118,7 +119,7 @@ describe('GhostPostService', () => {
             };
 
             // Creating initial post
-            const initialResult = await postService.handleIncomingGhostPost(
+            const initialResult = await ghostPostService.createGhostPost(
                 account,
                 {
                     title: 'Original Test Article',
@@ -173,9 +174,9 @@ describe('GhostPostService', () => {
                 authors: [],
             };
 
-            const handleIncomingGhostPostSpy = vi.spyOn(
-                postService,
-                'handleIncomingGhostPost',
+            const createGhostPostSpy = vi.spyOn(
+                ghostPostService,
+                'createGhostPost',
             );
 
             await ghostPostService.updateArticleFromGhostPost(
@@ -183,10 +184,7 @@ describe('GhostPostService', () => {
                 ghostPost,
             );
 
-            expect(handleIncomingGhostPostSpy).toHaveBeenCalledWith(
-                account,
-                ghostPost,
-            );
+            expect(createGhostPostSpy).toHaveBeenCalledWith(account, ghostPost);
 
             const apId = account.getApIdForPost({
                 uuid: ghostPost.uuid,
@@ -199,7 +197,7 @@ describe('GhostPostService', () => {
         });
 
         it('should delete post when ghost post has missing content', async () => {
-            const initialResult = await postService.handleIncomingGhostPost(
+            const initialResult = await ghostPostService.createGhostPost(
                 account,
                 {
                     title: 'Test Article',
@@ -252,7 +250,7 @@ describe('GhostPostService', () => {
         });
 
         it('should delete post when ghost post is private', async () => {
-            const initialResult = await postService.handleIncomingGhostPost(
+            const initialResult = await ghostPostService.createGhostPost(
                 account,
                 {
                     title: 'Test Article',
@@ -319,7 +317,7 @@ describe('GhostPostService', () => {
             };
 
             // First create the initial post
-            const initialResult = await postService.handleIncomingGhostPost(
+            const initialResult = await ghostPostService.createGhostPost(
                 account,
                 ghostPost,
             );
@@ -474,7 +472,7 @@ describe('GhostPostService', () => {
         it('should delete an existing post successfully', async () => {
             const uuid = 'ee218320-b2e6-11ef-8a80-0242ac120009';
 
-            const initialResult = await postService.handleIncomingGhostPost(
+            const initialResult = await ghostPostService.createGhostPost(
                 account,
                 {
                     title: 'Test Article to Delete',

--- a/src/ghost/ghost-post.service.ts
+++ b/src/ghost/ghost-post.service.ts
@@ -13,16 +13,15 @@ import {
 import type { Knex } from 'knex';
 import { PostDeletedEvent } from 'post/post-deleted.event';
 import {
+    type CreatePostError,
     type GhostPost,
     Post,
     PostType,
     type PostUpdateParams,
 } from 'post/post.entity';
-import type {
-    DeletePostError,
-    GhostPostError,
-    PostService,
-} from 'post/post.service';
+import type { DeletePostError, PostService } from 'post/post.service';
+
+export type GhostPostError = CreatePostError | 'post-already-exists';
 
 export class GhostPostService {
     constructor(

--- a/src/ghost/ghost-post.service.unit.test.ts
+++ b/src/ghost/ghost-post.service.unit.test.ts
@@ -1,0 +1,170 @@
+import type { Logger } from '@logtape/logtape';
+import type { Account } from 'account/account.entity';
+import type { AsyncEvents } from 'core/events';
+import { getError, getValue, isError, ok } from 'core/result';
+import type { Knex } from 'knex';
+import { Post } from 'post/post.entity';
+import type { KnexPostRepository } from 'post/post.repository.knex';
+import type { PostService } from 'post/post.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GhostPostService } from './ghost-post.service';
+
+describe('GhostPostService', () => {
+    let ghostPostService: GhostPostService;
+    let mockDb: Knex;
+    let mockPostService: PostService;
+    let mockPostRepository: KnexPostRepository;
+    let mockLogger: Logger;
+    let mockEvents: AsyncEvents;
+    let mockAccount: Account;
+    let mockPost: Post;
+    let mockQueryBuilder: {
+        insert: ReturnType<typeof vi.fn>;
+        select: ReturnType<typeof vi.fn>;
+        where: ReturnType<typeof vi.fn>;
+        first: ReturnType<typeof vi.fn>;
+    };
+
+    beforeEach(() => {
+        mockLogger = {
+            error: vi.fn(),
+        } as unknown as Logger;
+
+        mockEvents = {} as unknown as AsyncEvents;
+
+        mockAccount = {
+            uuid: 'account-uuid-123',
+        } as unknown as Account;
+
+        mockPost = {
+            id: 1,
+            apId: new URL('https://example.com/posts/test-post'),
+            uuid: 'post-uuid-456',
+        } as unknown as Post;
+
+        mockPostRepository = {
+            save: vi.fn().mockResolvedValue(undefined),
+        } as unknown as KnexPostRepository;
+
+        mockPostService = {
+            deleteByApId: vi.fn().mockResolvedValue(ok(true)),
+        } as unknown as PostService;
+
+        vi.spyOn(Post, 'createArticleFromGhostPost').mockResolvedValue(
+            ok(mockPost),
+        );
+
+        mockQueryBuilder = {
+            insert: vi.fn(),
+            select: vi.fn(),
+            where: vi.fn(),
+            first: vi.fn(),
+        };
+
+        mockQueryBuilder.select.mockReturnValue(mockQueryBuilder);
+        mockQueryBuilder.where.mockReturnValue(mockQueryBuilder);
+
+        mockDb = vi.fn().mockReturnValue(mockQueryBuilder) as unknown as Knex;
+
+        ghostPostService = new GhostPostService(
+            mockDb,
+            mockPostService,
+            mockPostRepository,
+            mockLogger,
+            mockEvents,
+        );
+    });
+
+    describe('createGhostPost', () => {
+        it('should handle database insert failure with error and cleanup', async () => {
+            mockQueryBuilder.first.mockResolvedValue(null); // No existing post by default
+            const ghostPostData = {
+                title: 'Test Ghost Post',
+                uuid: 'test-uuid-123',
+                html: '<p>Test content</p>',
+                excerpt: 'Test excerpt',
+                custom_excerpt: null,
+                feature_image: null,
+                published_at: new Date().toISOString(),
+                url: 'https://example.com/test-post',
+                visibility: 'public' as const,
+                authors: [],
+            };
+
+            const insertError = new Error('Database connection failed');
+            mockQueryBuilder.insert.mockRejectedValue(insertError);
+
+            const result = await ghostPostService.createGhostPost(
+                mockAccount,
+                ghostPostData,
+            );
+
+            expect(isError(result)).toBe(true);
+            if (!isError(result)) {
+                throw new Error('Expected error result');
+            }
+            expect(getError(result)).toBe('failed-to-create-post');
+
+            expect(Post.createArticleFromGhostPost).toHaveBeenCalledWith(
+                mockAccount,
+                ghostPostData,
+            );
+
+            expect(mockPostRepository.save).toHaveBeenCalledWith(mockPost);
+
+            expect(mockDb).toHaveBeenCalledWith('ghost_ap_post_mappings');
+            expect(mockQueryBuilder.insert).toHaveBeenCalledWith({
+                ghost_uuid: ghostPostData.uuid,
+                ap_id: mockPost.apId.href,
+            });
+
+            expect(mockLogger.error).toHaveBeenCalledWith(
+                'Failed to create ghost post mapping for apId: {apId}, error: {error}',
+                {
+                    apId: mockPost.apId.href,
+                    error: insertError,
+                },
+            );
+
+            expect(mockPostService.deleteByApId).toHaveBeenCalledWith(
+                mockPost.apId,
+                mockAccount,
+            );
+        });
+
+        it('should succeed when mapping insert works correctly', async () => {
+            const ghostPostData = {
+                title: 'Test Ghost Post Success',
+                uuid: 'test-uuid-success-456',
+                html: '<p>Success content</p>',
+                excerpt: 'Success excerpt',
+                custom_excerpt: null,
+                feature_image: null,
+                published_at: new Date().toISOString(),
+                url: 'https://example.com/success-post',
+                visibility: 'public' as const,
+                authors: [],
+            };
+
+            mockQueryBuilder.insert.mockResolvedValue([1]);
+            const result = await ghostPostService.createGhostPost(
+                mockAccount,
+                ghostPostData,
+            );
+
+            expect(isError(result)).toBe(false);
+            if (isError(result)) {
+                throw new Error('Expected success result');
+            }
+            expect(getValue(result)).toBe(mockPost);
+            expect(mockQueryBuilder.insert).toHaveBeenCalledWith({
+                ghost_uuid: ghostPostData.uuid,
+                ap_id: mockPost.apId.href,
+            });
+
+            expect(mockLogger.error).not.toHaveBeenCalled();
+
+            expect(mockPostService.deleteByApId).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/http/api/webhook.controller.ts
+++ b/src/http/api/webhook.controller.ts
@@ -93,6 +93,10 @@ export class WebhookController {
                     return BadRequest(
                         'Webhook already processed for this post',
                     );
+                case 'failed-to-create-post':
+                    return new Response('Failed to create post', {
+                        status: 500,
+                    });
                 default:
                     return exhaustiveCheck(error);
             }

--- a/src/http/api/webhook.controller.ts
+++ b/src/http/api/webhook.controller.ts
@@ -73,7 +73,7 @@ export class WebhookController {
 
         const account = ctx.get('account');
 
-        const postResult = await this.postService.handleIncomingGhostPost(
+        const postResult = await this.ghostPostService.createGhostPost(
             account,
             data,
         );

--- a/src/post/post.service.integration.test.ts
+++ b/src/post/post.service.integration.test.ts
@@ -141,34 +141,6 @@ describe('PostService', () => {
         await db.destroy();
     });
 
-    describe('handleIncomingGhostPost', () => {
-        it('should create a post successfully', async () => {
-            const [account] = await fixtureManager.createInternalAccount();
-
-            const result = await postService.handleIncomingGhostPost(account, {
-                title: 'Test Post',
-                uuid: 'ee218320-b2e6-11ef-8a80-0242ac120002',
-                html: 'This is a test post',
-                excerpt: 'This is a test post',
-                custom_excerpt: null,
-                feature_image: null,
-                published_at: new Date().toISOString(),
-                url: 'https://example.com/test-post',
-                visibility: 'public',
-                authors: [],
-            });
-
-            if (isError(result)) {
-                throw new Error('Result should not be an error');
-            }
-
-            const post = getValue(result);
-            expect(post).toBeInstanceOf(Post);
-            expect(post.author.id).toBe(account.id);
-            expect(post.uuid).toBe('ee218320-b2e6-11ef-8a80-0242ac120002');
-        });
-    });
-
     describe('createNote', () => {
         it('should create a note successfully', async () => {
             const content = 'This is a test note';

--- a/src/post/post.service.integration.test.ts
+++ b/src/post/post.service.integration.test.ts
@@ -167,43 +167,6 @@ describe('PostService', () => {
             expect(post.author.id).toBe(account.id);
             expect(post.uuid).toBe('ee218320-b2e6-11ef-8a80-0242ac120002');
         });
-
-        it('should return an error if the post already exists', async () => {
-            const [account] = await fixtureManager.createInternalAccount();
-
-            await postService.handleIncomingGhostPost(account, {
-                title: 'Test Post',
-                uuid: 'ee218320-b2e6-11ef-8a80-0242ac120002',
-                html: 'This is a test post',
-                excerpt: 'This is a test post',
-                custom_excerpt: null,
-                feature_image: null,
-                published_at: new Date().toISOString(),
-                url: 'https://example.com/test-post',
-                visibility: 'public',
-                authors: [],
-            });
-
-            const result = await postService.handleIncomingGhostPost(account, {
-                title: 'Test Post',
-                uuid: 'ee218320-b2e6-11ef-8a80-0242ac120002',
-                html: 'This is a test post',
-                excerpt: 'This is a test post',
-                custom_excerpt: null,
-                feature_image: null,
-                published_at: new Date().toISOString(),
-                url: 'https://example.com/test-post',
-                visibility: 'public',
-                authors: [],
-            });
-
-            if (!isError(result)) {
-                throw new Error('Result should be an error');
-            }
-
-            const error = getError(result);
-            expect(error).toBe('post-already-exists');
-        });
     });
 
     describe('createNote', () => {

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -440,7 +440,7 @@ export class PostService {
     async handleIncomingGhostPost(
         account: Account,
         ghostPost: GhostPost,
-    ): Promise<Result<Post, GhostPostError>> {
+    ): Promise<Result<Post, CreatePostError>> {
         const postResult = await Post.createArticleFromGhostPost(
             account,
             ghostPost,
@@ -451,12 +451,6 @@ export class PostService {
         }
 
         const post = getValue(postResult);
-
-        const existingPost = await this.postRepository.getByApId(post.apId);
-
-        if (existingPost) {
-            return error('post-already-exists');
-        }
 
         await this.postRepository.save(post);
 

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -28,8 +28,6 @@ import type { VerificationError } from 'storage/adapters/storage-adapter';
 import type { ImageStorageService } from 'storage/image-storage.service';
 import { ContentPreparer } from './content';
 import {
-    type CreatePostError,
-    type GhostPost,
     type ImageAttachment,
     type Mention,
     Post,
@@ -429,26 +427,6 @@ export class PostService {
         }
 
         post.addRepost(account);
-
-        await this.postRepository.save(post);
-
-        return ok(post);
-    }
-
-    async handleIncomingGhostPost(
-        account: Account,
-        ghostPost: GhostPost,
-    ): Promise<Result<Post, CreatePostError>> {
-        const postResult = await Post.createArticleFromGhostPost(
-            account,
-            ghostPost,
-        );
-
-        if (isError(postResult)) {
-            return postResult;
-        }
-
-        const post = getValue(postResult);
 
         await this.postRepository.save(post);
 

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -54,8 +54,6 @@ export type RepostError =
     | 'already-reposted'
     | InteractionError;
 
-export type GhostPostError = CreatePostError | 'post-already-exists';
-
 export type DeletePostError = GetByApIdError | 'not-author';
 
 export type UpdatePostError = 'post-not-found' | 'not-author';


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2294 https://linear.app/ghost/issue/PROD-2297

- Added createGhostPost logic to GhostPostService
- While creating the post we check if the post already exists. Create a new post if it doesn't exist and add it to the mapping table
- Deletes the ghost post mapping when a PostDeletedEvent is received