### PR TITLE
Added hash / index for account inbox URL

### DIFF
--- a/migrate/migrations/000062_add-inbox-url-hash-to-accounts-table.down.sql
+++ b/migrate/migrations/000062_add-inbox-url-hash-to-accounts-table.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX idx_accounts_ap_inbox_url_hash ON accounts;
+
+ALTER TABLE accounts
+    DROP COLUMN ap_inbox_url_hash;

--- a/migrate/migrations/000062_add-inbox-url-hash-to-accounts-table.up.sql
+++ b/migrate/migrations/000062_add-inbox-url-hash-to-accounts-table.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE accounts
+    ADD COLUMN ap_inbox_url_hash BINARY(32)
+        GENERATED ALWAYS AS (UNHEX(SHA2(LOWER(ap_inbox_url), 256))) STORED;
+
+CREATE INDEX idx_accounts_ap_inbox_url_hash ON accounts(ap_inbox_url_hash);

--- a/src/account/account.repository.knex.ts
+++ b/src/account/account.repository.knex.ts
@@ -322,7 +322,10 @@ export class KnexAccountRepository {
 
     async getByInboxUrl(inboxUrl: URL): Promise<Account | null> {
         const accountRow = await this.db('accounts')
-            .where('accounts.ap_inbox_url', inboxUrl.href)
+            .whereRaw(
+                'accounts.ap_inbox_url_hash = UNHEX(SHA2(LOWER(?), 256))',
+                [inboxUrl.href],
+            )
             .leftJoin('users', 'users.account_id', 'accounts.id')
             .select(
                 'accounts.id',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2266

With the recently added changes around tracking delivery failures, we started reading from `accounts.inbox_url`, but this field was not designed to have lookups done on it so we have added an extra index / hash to improve performance