### PR TITLE
Added graceful termination

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -916,3 +916,9 @@ serve(
 );
 
 process.on('SIGINT', () => process.exit(0));
+process.on('SIGTERM', () => {
+    globalLogging.info('Received SIGTERM, shutting down gracefully');
+    setTimeout(() => {
+        process.exit(0);
+    }, 9000);
+});


### PR DESCRIPTION
ref no-issue

- CloudRun sends a SIGTERM signal and allows 10 seconds for a container to exit successfully. Sleeping for 9 seconds gives it time to finish processing current requests.