### PR TITLE
Restricted Create activity sending to external accounts

### DIFF
--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -752,6 +752,17 @@ export class AccountService {
         await this.accountRepository.save(updated);
     }
 
+    // TODO Move all methods below to a delivery service
+
+    async shouldDeliverActivity(inboxUrl: URL): Promise<boolean> {
+        const account = await this.accountRepository.getByInboxUrl(inboxUrl);
+        if (!account) {
+            return false;
+        }
+
+        return !account.isInternal;
+    }
+
     async recordDeliveryFailure(
         inboxUrl: URL,
         failureReason: string,

--- a/src/mq/gcloud-pubsub-push/mq.ts
+++ b/src/mq/gcloud-pubsub-push/mq.ts
@@ -131,7 +131,8 @@ export class GCloudPubSubPushMessageQueue implements MessageQueue {
             // We don't want to deliver Create activities to internal accounts
             if (
                 message.activityType ===
-                'https://www.w3.org/ns/activitystreams#Create'
+                    'https://www.w3.org/ns/activitystreams#Create' &&
+                process.env.FORCE_INTERNAL_ACTIVITY_DELIVERY !== 'true'
             ) {
                 // Don't bother doing a DB lookup if the pathname doesn't even match
                 if (inboxUrl.pathname.startsWith('/.ghost/activitypub')) {

--- a/src/mq/gcloud-pubsub-push/mq.ts
+++ b/src/mq/gcloud-pubsub-push/mq.ts
@@ -141,7 +141,10 @@ export class GCloudPubSubPushMessageQueue implements MessageQueue {
                                 inboxUrl,
                             );
 
-                        if (!shouldDeliver) {
+                        if (
+                            !shouldDeliver &&
+                            message.baseUrl === 'https://fabien.ghost.io'
+                        ) {
                             this.logger.info(
                                 `Dropping message [FedifyID: ${message.id}] due to inbox URL being an internal account: ${inboxUrl.href}`,
                                 { fedifyId: message.id, mq_message: message },


### PR DESCRIPTION
The Create activity handler is essentially a noop when handling
activities that we already know about. This means that sending
Create activities to internal accounts is superfluous.