### PR TITLE
Added reads from mapping table

### DIFF
--- a/src/http/api/webhook.controller.ts
+++ b/src/http/api/webhook.controller.ts
@@ -171,6 +171,7 @@ export class WebhookController {
                 case 'upstream-error':
                 case 'not-a-post':
                 case 'missing-author':
+                case 'post-not-found':
                     return BadRequest('Failed to delete ghost post');
                 case 'not-author':
                     return Forbidden(


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2296/

- Added logic to read from the new `ghost_ap_post_mappings` table for updating and deleting posts
- The `ghost_ap_post_mappings` table has been backfilled with data on prod. Commit here: https://github.com/TryGhost/ActivityPub/commit/ba12b87504138343800c79550c697a14d4c97576
- Cleaned up some tests