### PR TITLE
Set Ghost (Pro) flag when creating a new site

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - ACTIVITYPUB_COLLECTION_PAGE_SIZE=20
       - LOCAL_STORAGE_PATH=/opt/activitypub/content
       # - LOCAL_STORAGE_HOSTING_URL=https://<tailscale-url>/.ghost/activitypub/local-storage
+      # - GHOST_PRO_IP_ADDRESSES=100.83.192.90,192.168.65.1
     command: yarn build:watch
     depends_on:
       migrate:

--- a/src/configuration/registrations.ts
+++ b/src/configuration/registrations.ts
@@ -373,7 +373,20 @@ export function registerDependencies(
         asFunction(createFollowingCounter).singleton(),
     );
 
-    container.register('siteController', asClass(SiteController).singleton());
+    container.register(
+        'siteController',
+        asFunction((siteService: SiteService) => {
+            let ghostProIpAddresses: string[] | undefined;
+
+            if (process.env.GHOST_PRO_IP_ADDRESSES) {
+                ghostProIpAddresses = process.env.GHOST_PRO_IP_ADDRESSES.split(
+                    ',',
+                ).map((ip) => ip.trim());
+            }
+
+            return new SiteController(siteService, ghostProIpAddresses);
+        }).singleton(),
+    );
 
     container.register(
         'webhookController',

--- a/src/http/api/site.controller.unit.test.ts
+++ b/src/http/api/site.controller.unit.test.ts
@@ -1,0 +1,169 @@
+import { IncomingMessage } from 'node:http';
+import { Socket } from 'node:net';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AppContext } from '../../app';
+import type { Site, SiteService } from '../../site/site.service';
+import { SiteController } from './site.controller';
+
+describe('SiteController', () => {
+    let siteService: SiteService;
+    let siteController: SiteController;
+    let mockSite: Site;
+
+    beforeEach(() => {
+        mockSite = {
+            id: 1,
+            host: 'example.com',
+            webhook_secret: 'secret',
+        };
+
+        siteService = {
+            initialiseSiteForHost: vi.fn().mockResolvedValue(mockSite),
+        } as unknown as SiteService;
+    });
+
+    function getMockAppContext(
+        host: string | undefined,
+        headers: Record<string, string> = {},
+    ): AppContext {
+        return {
+            req: {
+                header: (name: string) => {
+                    if (name === 'host') return host;
+                    return headers[name] || undefined;
+                },
+                raw: {
+                    socket: {
+                        remoteAddress: headers['socket.remoteAddress'],
+                    },
+                },
+            },
+            get: vi.fn((key: string) => {
+                if (key === 'logger') {
+                    return { info: vi.fn() };
+                }
+                return undefined;
+            }),
+        } as unknown as AppContext;
+    }
+
+    describe('handleGetSiteData', () => {
+        it('returns 401 if no host header is provided', async () => {
+            siteController = new SiteController(siteService);
+            const ctx = getMockAppContext(undefined);
+            const response = await siteController.handleGetSiteData(ctx);
+
+            expect(response.status).toBe(401);
+            const body = await response.json();
+            expect(body).toEqual({ error: 'No Host header' });
+        });
+
+        it('returns site data as JSON', async () => {
+            siteController = new SiteController(siteService);
+            const ctx = getMockAppContext('example.com');
+            const response = await siteController.handleGetSiteData(ctx);
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get('Content-Type')).toBe(
+                'application/json',
+            );
+
+            const body = await response.json();
+            expect(body).toEqual(mockSite);
+        });
+
+        it('sets `ghost_pro` flag to false when request IP is not a Ghost (Pro) IP', async () => {
+            siteController = new SiteController(siteService, [
+                '10.0.0.1',
+                '10.0.0.2',
+            ]);
+            const ctx = getMockAppContext('example.com', {
+                'x-forwarded-for': '192.168.1.1',
+            });
+
+            await siteController.handleGetSiteData(ctx);
+
+            expect(siteService.initialiseSiteForHost).toHaveBeenCalledWith(
+                'example.com',
+                false,
+            );
+        });
+
+        it('sets `ghost_pro` flag to true when request IP is a Ghost (Pro) IP', async () => {
+            siteController = new SiteController(siteService, [
+                '10.0.0.1',
+                '10.0.0.2',
+            ]);
+            const ctx = getMockAppContext('example.com', {
+                'x-forwarded-for': '10.0.0.1',
+            });
+
+            await siteController.handleGetSiteData(ctx);
+
+            expect(siteService.initialiseSiteForHost).toHaveBeenCalledWith(
+                'example.com',
+                true,
+            );
+        });
+
+        it('handles a comma-separated list of IPs in x-forwarded-for header', async () => {
+            siteController = new SiteController(siteService, [
+                '10.0.0.1',
+                '10.0.0.2',
+            ]);
+            const ctx = getMockAppContext('example.com', {
+                'x-forwarded-for': '10.0.0.1, 192.168.1.1, 172.16.0.1',
+            });
+
+            await siteController.handleGetSiteData(ctx);
+
+            expect(siteService.initialiseSiteForHost).toHaveBeenCalledWith(
+                'example.com',
+                true,
+            );
+        });
+
+        it('uses the remote address when x-forwarded-for header is not present', async () => {
+            siteController = new SiteController(siteService, [
+                '10.0.0.1',
+                '10.0.0.2',
+            ]);
+            const ctx = getMockAppContext('example.com');
+
+            const mockSocket = new Socket();
+            Object.defineProperty(mockSocket, 'remoteAddress', {
+                value: '10.0.0.2',
+                writable: false,
+            });
+
+            const mockIncomingMessage = new IncomingMessage(mockSocket);
+            Object.defineProperty(ctx.req, 'raw', {
+                value: mockIncomingMessage,
+                writable: false,
+            });
+
+            await siteController.handleGetSiteData(ctx);
+
+            expect(siteService.initialiseSiteForHost).toHaveBeenCalledWith(
+                'example.com',
+                true,
+            );
+        });
+
+        it('sets `ghost_pro` flag to false when no IP headers are found', async () => {
+            siteController = new SiteController(siteService, [
+                '10.0.0.1',
+                '10.0.0.2',
+            ]);
+            const ctx = getMockAppContext('example.com');
+
+            await siteController.handleGetSiteData(ctx);
+
+            expect(siteService.initialiseSiteForHost).toHaveBeenCalledWith(
+                'example.com',
+                false,
+            );
+        });
+    });
+});

--- a/src/site/site.service.integration.test.ts
+++ b/src/site/site.service.integration.test.ts
@@ -107,4 +107,23 @@ describe('SiteService', () => {
 
         expect(retrievedSite).toMatchObject(site);
     });
+
+    it('Can initialise a site with the `ghost_pro` flag', async () => {
+        const site = await service.initialiseSiteForHost('hostname.tld', true);
+
+        expect(site.host).toBe('hostname.tld');
+        expect(site.webhook_secret).toBeDefined();
+        expect(site.id).toBeDefined();
+
+        const siteRows = await db('sites').select('*');
+
+        expect(siteRows).toHaveLength(1);
+
+        const siteRow = siteRows[0];
+
+        expect(siteRow.id).toBe(site.id);
+        expect(siteRow.webhook_secret).toBe(site.webhook_secret);
+        expect(siteRow.host).toBe(site.host);
+        expect(siteRow.ghost_pro).toBe(1);
+    });
 });

--- a/src/site/site.service.ts
+++ b/src/site/site.service.ts
@@ -21,7 +21,7 @@ export class SiteService {
         private ghostService: IGhostService,
     ) {}
 
-    private async createSite(host: string): Promise<Site> {
+    private async createSite(host: string, isGhostPro: boolean): Promise<Site> {
         const rows = await this.client
             .select('*')
             .from('sites')
@@ -36,6 +36,7 @@ export class SiteService {
             .insert({
                 host,
                 webhook_secret,
+                ghost_pro: isGhostPro,
             })
             .into('sites');
 
@@ -66,12 +67,15 @@ export class SiteService {
         };
     }
 
-    public async initialiseSiteForHost(host: string): Promise<Site> {
+    public async initialiseSiteForHost(
+        host: string,
+        isGhostPro = false,
+    ): Promise<Site> {
         const existingSite = await this.getSiteByHost(host);
 
         let site: Site;
         if (existingSite === null) {
-            site = await this.createSite(host);
+            site = await this.createSite(host, isGhostPro);
         } else {
             site = existingSite;
         }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2284

- context: as we open up the ActivityPub infra to self-hosters, we want to be able to monitor usage
- logic: when a site is created, we check for the request IP address. If the IP address matches one of the Ghost (Pro) IP address, we set the `"ghost_pro"` flag in the `"sites"` table to true