### PR TITLE
Restricted Like, Announce & Delete delivery

### DIFF
--- a/src/mq/gcloud-pubsub-push/mq.ts
+++ b/src/mq/gcloud-pubsub-push/mq.ts
@@ -128,10 +128,18 @@ export class GCloudPubSubPushMessageQueue implements MessageQueue {
                 return;
             }
 
-            // We don't want to deliver Create activities to internal accounts
-            if (
+            const activityTypeIsHandledByDomain =
                 message.activityType ===
-                    'https://www.w3.org/ns/activitystreams#Create' &&
+                    'https://www.w3.org/ns/activitystreams#Create' ||
+                message.activityType ===
+                    'https://www.w3.org/ns/activitystreams#Like' ||
+                message.activityType ===
+                    'https://www.w3.org/ns/activitystreams#Announce' ||
+                message.activityType ===
+                    'https://www.w3.org/ns/activitystreams#Delete';
+
+            if (
+                activityTypeIsHandledByDomain &&
                 process.env.FORCE_INTERNAL_ACTIVITY_DELIVERY !== 'true'
             ) {
                 // Don't bother doing a DB lookup if the pathname doesn't even match


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2324

We have checked that Create activities are not necessary to send and now want to look at other high delivery activities. This is still all gated to fabien.ghost.io whilst we're testing.