### PR TITLE
Fixed `SIGTERM` handling in dev / test environment

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -920,7 +920,12 @@ serve(
 
 process.on('SIGINT', () => process.exit(0));
 process.on('SIGTERM', () => {
+    if (['development', 'testing'].includes(process.env.NODE_ENV || '')) {
+        process.exit(0);
+    }
+
     globalLogging.info('Received SIGTERM, shutting down gracefully');
+
     setTimeout(() => {
         process.exit(0);
     }, 9000);


### PR DESCRIPTION
no ref

In dev / test environment we do not need to wait for the graceful shutdown as we want to be able to quickly restart the application when changes are made