### PR TITLE
Added fix for post repository setting negative `reply_count` during a race condition

### DIFF
--- a/src/post/post.repository.knex.ts
+++ b/src/post/post.repository.knex.ts
@@ -271,7 +271,9 @@ export class KnexPostRepository {
                     if (post.inReplyTo) {
                         await transaction('posts')
                             .update({
-                                reply_count: this.db.raw('reply_count - 1'),
+                                reply_count: this.db.raw(
+                                    'CASE WHEN reply_count > 0 THEN reply_count - 1 ELSE 0 END',
+                                ),
                             })
                             .where({ id: post.inReplyTo });
                     }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2238

The issue seems to be occurring as part of a race condition when the system is trying to handle multiple deletes for the same post. This change adds in some defensive SQL to ensure this value can not go below zero