### PR TITLE
Added logging for the request IP

### DIFF
--- a/src/http/api/site.controller.ts
+++ b/src/http/api/site.controller.ts
@@ -21,6 +21,13 @@ export class SiteController {
         try {
             const requestIp = this.getRequestIp(ctx);
             const isGhostPro = this.isGhostProIp(requestIp);
+            ctx.get('logger').info(
+                'Request IP: {requestIp} (Ghost (Pro): {isGhostPro})',
+                {
+                    requestIp,
+                    isGhostPro,
+                },
+            );
             const site = await this.siteService.initialiseSiteForHost(
                 host,
                 isGhostPro,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2284

- we have recently added a flag to differentiate Ghost Pro sites, based on the request IP
- currently, it seems we're missing a Ghost (Pro) IP address in our config, and this logging will help us debug the issue