### PR TITLE
Stopped sending activities to internal accounts

### DIFF
--- a/src/mq/gcloud-pubsub-push/mq.ts
+++ b/src/mq/gcloud-pubsub-push/mq.ts
@@ -155,10 +155,7 @@ export class GCloudPubSubPushMessageQueue implements MessageQueue {
                                 inboxUrl,
                             );
 
-                        if (
-                            !shouldDeliver &&
-                            message.baseUrl === 'https://fabien.ghost.io'
-                        ) {
+                        if (!shouldDeliver) {
                             this.logger.info(
                                 `Dropping message [FedifyID: ${message.id}] due to inbox URL being an internal account: ${inboxUrl.href}`,
                                 { fedifyId: message.id, mq_message: message },


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2324

Our domain layer handles all of the state updates for the the Create, Like, Announce, Delete & Undo activitites, which means we don't need to send them to the inboxes of internal accounts, as the state is already handled by the initial API request to create the activity.

We have tested this code in production gated to https://fabien.ghost.io