### PR TITLE
Fixed "ghost_pro" flag assignment

### DIFF
--- a/src/http/api/site.controller.ts
+++ b/src/http/api/site.controller.ts
@@ -19,6 +19,7 @@ export class SiteController {
 
         try {
             const isGhostPro = this.isRequestViaGhostPro(ctx);
+            ctx.get('logger').info('isGhostPro: {isGhostPro}', { isGhostPro });
             const site = await this.siteService.initialiseSiteForHost(
                 host,
                 isGhostPro,
@@ -42,10 +43,14 @@ export class SiteController {
 
     private isRequestViaGhostPro(ctx: AppContext): boolean {
         const requestIps = this.getRequestIpAddresses(ctx);
+        ctx.get('logger').info('requestIps: {requestIps}', { requestIps });
         if (!requestIps || requestIps.length === 0) {
             return false;
         }
 
+        ctx.get('logger').info('ghostProIpAddresses: {ghostProIpAddresses}', {
+            ghostProIpAddresses: this.ghostProIpAddresses,
+        });
         const ghostProIps = this.ghostProIpAddresses;
         if (!ghostProIps || ghostProIps.length === 0) {
             return false;

--- a/src/http/api/site.controller.ts
+++ b/src/http/api/site.controller.ts
@@ -19,7 +19,6 @@ export class SiteController {
 
         try {
             const isGhostPro = this.isRequestViaGhostPro(ctx);
-            ctx.get('logger').info('isGhostPro: {isGhostPro}', { isGhostPro });
             const site = await this.siteService.initialiseSiteForHost(
                 host,
                 isGhostPro,
@@ -43,14 +42,10 @@ export class SiteController {
 
     private isRequestViaGhostPro(ctx: AppContext): boolean {
         const requestIps = this.getRequestIpAddresses(ctx);
-        ctx.get('logger').info('requestIps: {requestIps}', { requestIps });
         if (!requestIps || requestIps.length === 0) {
             return false;
         }
 
-        ctx.get('logger').info('ghostProIpAddresses: {ghostProIpAddresses}', {
-            ghostProIpAddresses: this.ghostProIpAddresses,
-        });
         const ghostProIps = this.ghostProIpAddresses;
         if (!ghostProIps || ghostProIps.length === 0) {
             return false;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2284

- context: as we open up the Ghost (Pro) AP infra to self-hosters, we want to be able to monitor usage
- the previous logic for computing isGhostPro? was flawed: it was looking at the **first** ip address in the `x-forwarded-for` header and matching it against a list of Ghost (Pro) IP addresses. Instead, we want to be matching against the last proxy that forwarded the request to GCP
- new logic: match **any** of the ip addresses in the `x-forwarded-for` header against a list of Ghost (Pro) IP addresses, i.e. evaluate whether the request was made **via** Ghost (Pro)