### PR TITLE
Removed old API endpoints

### DIFF
--- a/features/step_definitions/5xx_steps.js
+++ b/features/step_definitions/5xx_steps.js
@@ -106,7 +106,7 @@ Given('we are sent invalid type to the inbox', async function () {
 
 Given('we are sent a publish webhook', async function () {
     const endpoint =
-        'https://self.test/.ghost/activitypub/webhooks/post/published';
+        'https://self.test/.ghost/activitypub/v1/webhooks/post/published';
     const payload = createWebhookPost();
     const body = JSON.stringify(payload);
     const timestamp = Date.now();
@@ -129,7 +129,7 @@ When(
     'we are sent a second publish webhook for the same post',
     async function () {
         const endpoint =
-            'https://self.test/.ghost/activitypub/webhooks/post/published';
+            'https://self.test/.ghost/activitypub/v1/webhooks/post/published';
         const payload = this.firstPublishWebhook;
         const body = JSON.stringify(payload);
         const timestamp = Date.now();

--- a/features/step_definitions/index.js
+++ b/features/step_definitions/index.js
@@ -97,9 +97,9 @@ BeforeAll(async function setupSelfSite() {
 
 BeforeAll(async function setupLocalSites() {
     await Promise.all([
-        fetchActivityPub('https://alice.test/.ghost/activitypub/site'),
-        fetchActivityPub('https://bob.test/.ghost/activitypub/site'),
-        fetchActivityPub('https://carol.test/.ghost/activitypub/site'),
+        fetchActivityPub('https://alice.test/.ghost/activitypub/v1/site'),
+        fetchActivityPub('https://bob.test/.ghost/activitypub/v1/site'),
+        fetchActivityPub('https://carol.test/.ghost/activitypub/v1/site'),
     ]);
 });
 
@@ -107,10 +107,10 @@ Before(async function reset() {
     await resetWiremock();
     await resetDatabase();
     await Promise.all([
-        fetchActivityPub('https://self.test/.ghost/activitypub/site'),
-        fetchActivityPub('https://alice.test/.ghost/activitypub/site'),
-        fetchActivityPub('https://bob.test/.ghost/activitypub/site'),
-        fetchActivityPub('https://carol.test/.ghost/activitypub/site'),
+        fetchActivityPub('https://self.test/.ghost/activitypub/v1/site'),
+        fetchActivityPub('https://alice.test/.ghost/activitypub/v1/site'),
+        fetchActivityPub('https://bob.test/.ghost/activitypub/v1/site'),
+        fetchActivityPub('https://carol.test/.ghost/activitypub/v1/site'),
     ]);
 });
 

--- a/features/step_definitions/webhook_steps.js
+++ b/features/step_definitions/webhook_steps.js
@@ -8,7 +8,7 @@ import { fetchActivityPub } from '../support/request.js';
 
 const endpoints = {
     'post.published':
-        'https://self.test/.ghost/activitypub/webhooks/post/published',
+        'https://self.test/.ghost/activitypub/v1/webhooks/post/published',
 };
 
 Given('a {string} webhook', function (string) {

--- a/features/support/content.js
+++ b/features/support/content.js
@@ -4,7 +4,7 @@ import { fetchActivityPub } from './request.js';
 
 export async function publishArticle() {
     const endpoint =
-        'https://self.test/.ghost/activitypub/webhooks/post/published';
+        'https://self.test/.ghost/activitypub/v1/webhooks/post/published';
     const payload = createWebhookPost();
     const body = JSON.stringify(payload);
     const timestamp = Date.now();

--- a/features/support/content.js
+++ b/features/support/content.js
@@ -27,7 +27,7 @@ export async function publishArticle() {
 }
 
 export async function publishNote(content = 'This is a note') {
-    const endpoint = 'https://self.test/.ghost/activitypub/actions/note';
+    const endpoint = 'https://self.test/.ghost/activitypub/v1/actions/note';
     const payload = { content };
     const body = JSON.stringify(payload);
     const timestamp = Date.now();

--- a/features/support/feed.js
+++ b/features/support/feed.js
@@ -10,7 +10,7 @@ export async function waitForItemInFeed(
     const MAX_RETRIES = 5;
 
     const response = await fetchActivityPub(
-        'https://self.test/.ghost/activitypub/feed/notes',
+        'https://self.test/.ghost/activitypub/v1/feed/notes',
         {
             headers: {
                 Accept: 'application/ld+json',
@@ -50,7 +50,7 @@ export async function waitForAPObjectInFeed(
         retryCount: 0,
         delay: 0,
     },
-    feedUrl = 'https://self.test/.ghost/activitypub/feed/notes',
+    feedUrl = 'https://self.test/.ghost/activitypub/v1/feed/notes',
 ) {
     const MAX_RETRIES = 5;
 

--- a/features/support/inbox.js
+++ b/features/support/inbox.js
@@ -10,7 +10,7 @@ export async function waitForItemInInbox(
     const MAX_RETRIES = 5;
 
     const response = await fetchActivityPub(
-        'https://self.test/.ghost/activitypub/feed/reader',
+        'https://self.test/.ghost/activitypub/v1/feed/reader',
         {
             headers: {
                 Accept: 'application/ld+json',
@@ -54,7 +54,7 @@ export async function waitForAPObjectInInbox(
     const MAX_RETRIES = 5;
 
     const response = await fetchActivityPub(
-        'https://self.test/.ghost/activitypub/feed/reader',
+        'https://self.test/.ghost/activitypub/v1/feed/reader',
         {
             headers: {
                 Accept: 'application/ld+json',

--- a/features/support/notifications.js
+++ b/features/support/notifications.js
@@ -19,7 +19,7 @@ export async function waitForItemInNotifications(
     const MAX_RETRIES = 5;
 
     const response = await fetchActivityPub(
-        'https://self.test/.ghost/activitypub/notifications',
+        'https://self.test/.ghost/activitypub/v1/notifications',
         {
             headers: {
                 Accept: 'application/ld+json',
@@ -63,7 +63,7 @@ export async function waitForUnreadNotifications(
     const MAX_RETRIES = 5;
 
     const response = await fetchActivityPub(
-        'https://self.test/.ghost/activitypub/notifications/unread/count',
+        'https://self.test/.ghost/activitypub/v1/notifications/unread/count',
     );
 
     const responseJson = await response.clone().json();

--- a/src/app.ts
+++ b/src/app.ts
@@ -678,16 +678,6 @@ app.use(async (ctx, next) => {
 // This needs to go before the middleware which loads the site
 // Because the site doesn't always exist - this is how it's created
 app.get(
-    '/.ghost/activitypub/site',
-    requireRole(GhostRole.Owner),
-    spanWrapper((ctx: AppContext) => {
-        const siteController =
-            container.resolve<SiteController>('siteController');
-        return siteController.handleGetSiteData(ctx);
-    }),
-);
-
-app.get(
     '/.ghost/activitypub/v1/site',
     requireRole(GhostRole.Owner),
     spanWrapper((ctx: AppContext) => {
@@ -786,16 +776,6 @@ function validateWebhook() {
         return next();
     };
 }
-
-app.post(
-    '/.ghost/activitypub/webhooks/post/published',
-    validateWebhook(),
-    spanWrapper((ctx: AppContext) => {
-        const webhookController =
-            container.resolve<WebhookController>('webhookController');
-        return webhookController.handlePostPublished(ctx);
-    }),
-);
 
 app.post(
     '/.ghost/activitypub/v1/webhooks/post/published',

--- a/src/http/api/account.controller.ts
+++ b/src/http/api/account.controller.ts
@@ -50,7 +50,6 @@ export class AccountController {
     /**
      * Handle a request for an account
      */
-    @Route('GET', '/.ghost/activitypub/account/:handle')
     @Route('GET', '/.ghost/activitypub/v1/account/:handle')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetAccount(ctx: AppContext) {
@@ -97,7 +96,6 @@ export class AccountController {
     /**
      * Handle a request for a list of account follows
      */
-    @Route('GET', '/.ghost/activitypub/account/:handle/follows/:type')
     @Route('GET', '/.ghost/activitypub/v1/account/:handle/follows/:type')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetAccountFollows(ctx: AppContext) {
@@ -203,7 +201,6 @@ export class AccountController {
     /**
      * Handle a request for a list of posts by an account
      */
-    @Route('GET', '/.ghost/activitypub/posts/:handle')
     @Route('GET', '/.ghost/activitypub/v1/posts/:handle')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetAccountPosts(ctx: AppContext) {
@@ -313,7 +310,6 @@ export class AccountController {
     /**
      * Handle a request for a list of posts liked by an account
      */
-    @Route('GET', '/.ghost/activitypub/posts/:handle/liked')
     @Route('GET', '/.ghost/activitypub/v1/posts/:handle/liked')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetAccountLikedPosts(ctx: AppContext) {
@@ -347,7 +343,6 @@ export class AccountController {
     /**
      * Handle a request for an account update
      */
-    @Route('PUT', '/.ghost/activitypub/account')
     @Route('PUT', '/.ghost/activitypub/v1/account')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleUpdateAccount(ctx: AppContext) {

--- a/src/http/api/block.controller.ts
+++ b/src/http/api/block.controller.ts
@@ -13,7 +13,6 @@ export class BlockController {
         private readonly blocksView: BlocksView,
     ) {}
 
-    @Route('POST', '/.ghost/activitypub/actions/block/:id')
     @Route('POST', '/.ghost/activitypub/v1/actions/block/:id')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleBlock(ctx: AppContext) {
@@ -54,7 +53,6 @@ export class BlockController {
         });
     }
 
-    @Route('POST', '/.ghost/activitypub/actions/unblock/:id')
     @Route('POST', '/.ghost/activitypub/v1/actions/unblock/:id')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleUnblock(ctx: AppContext) {
@@ -95,7 +93,6 @@ export class BlockController {
         });
     }
 
-    @Route('POST', '/.ghost/activitypub/actions/block/domain/:domain')
     @Route('POST', '/.ghost/activitypub/v1/actions/block/domain/:domain')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleBlockDomain(ctx: AppContext) {
@@ -114,7 +111,6 @@ export class BlockController {
         });
     }
 
-    @Route('POST', '/.ghost/activitypub/actions/unblock/domain/:domain')
     @Route('POST', '/.ghost/activitypub/v1/actions/unblock/domain/:domain')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleUnblockDomain(ctx: AppContext) {
@@ -133,7 +129,6 @@ export class BlockController {
         });
     }
 
-    @Route('GET', '/.ghost/activitypub/blocks/accounts')
     @Route('GET', '/.ghost/activitypub/v1/blocks/accounts')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetBlockedAccounts(ctx: AppContext) {
@@ -153,7 +148,6 @@ export class BlockController {
         );
     }
 
-    @Route('GET', '/.ghost/activitypub/blocks/domains')
     @Route('GET', '/.ghost/activitypub/v1/blocks/domains')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetBlockedDomains(ctx: AppContext) {

--- a/src/http/api/feed.controller.ts
+++ b/src/http/api/feed.controller.ts
@@ -29,14 +29,12 @@ export class FeedController {
         private readonly postInteractionCountsService: PostInteractionCountsService,
     ) {}
 
-    @Route('GET', '/.ghost/activitypub/feed/notes')
     @Route('GET', '/.ghost/activitypub/v1/feed/notes')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async getNotesFeed(ctx: AppContext) {
         return this.handleGetFeed(ctx, 'Feed');
     }
 
-    @Route('GET', '/.ghost/activitypub/feed/reader')
     @Route('GET', '/.ghost/activitypub/v1/feed/reader')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async getReaderFeed(ctx: AppContext) {

--- a/src/http/api/follow.controller.ts
+++ b/src/http/api/follow.controller.ts
@@ -18,7 +18,6 @@ export class FollowController {
         private readonly fedify: Federation<ContextData>,
     ) {}
 
-    @Route('POST', '/.ghost/activitypub/actions/follow/:handle')
     @Route('POST', '/.ghost/activitypub/v1/actions/follow/:handle')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleFollow(ctx: AppContext) {
@@ -128,7 +127,6 @@ export class FollowController {
         });
     }
 
-    @Route('POST', '/.ghost/activitypub/actions/unfollow/:handle')
     @Route('POST', '/.ghost/activitypub/v1/actions/unfollow/:handle')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleUnfollow(ctx: AppContext) {

--- a/src/http/api/like.controller.ts
+++ b/src/http/api/like.controller.ts
@@ -25,7 +25,6 @@ export class LikeController {
         private readonly fedify: Federation<ContextData>,
     ) {}
 
-    @Route('POST', '/.ghost/activitypub/actions/like/:id')
     @Route('POST', '/.ghost/activitypub/v1/actions/like/:id')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleLike(ctx: AppContext) {
@@ -159,7 +158,6 @@ export class LikeController {
         });
     }
 
-    @Route('POST', '/.ghost/activitypub/actions/unlike/:id')
     @Route('POST', '/.ghost/activitypub/v1/actions/unlike/:id')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleUnlike(ctx: AppContext) {

--- a/src/http/api/media.controller.ts
+++ b/src/http/api/media.controller.ts
@@ -17,7 +17,6 @@ export class MediaController {
     /**
      * Handle image upload
      */
-    @Route('POST', '/.ghost/activitypub/upload/image')
     @Route('POST', '/.ghost/activitypub/v1/upload/image')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleImageUpload(ctx: Context) {

--- a/src/http/api/notification.controller.ts
+++ b/src/http/api/notification.controller.ts
@@ -29,7 +29,6 @@ export class NotificationController {
         private readonly notificationService: NotificationService,
     ) {}
 
-    @Route('GET', '/.ghost/activitypub/notifications')
     @Route('GET', '/.ghost/activitypub/v1/notifications')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetNotifications(ctx: AppContext) {
@@ -121,7 +120,6 @@ export class NotificationController {
         );
     }
 
-    @Route('GET', '/.ghost/activitypub/notifications/unread/count')
     @Route('GET', '/.ghost/activitypub/v1/notifications/unread/count')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetUnreadNotificationsCount(ctx: AppContext) {
@@ -155,7 +153,6 @@ export class NotificationController {
         );
     }
 
-    @Route('PUT', '/.ghost/activitypub/notifications/unread/reset')
     @Route('PUT', '/.ghost/activitypub/v1/notifications/unread/reset')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleResetUnreadNotificationsCount(ctx: AppContext) {

--- a/src/http/api/post.controller.ts
+++ b/src/http/api/post.controller.ts
@@ -45,7 +45,6 @@ export class PostController {
     /**
      * Handle a request to get a post
      */
-    @Route('GET', '/.ghost/activitypub/post/:post_ap_id')
     @Route('GET', '/.ghost/activitypub/v1/post/:post_ap_id')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetPost(ctx: AppContext) {
@@ -121,7 +120,6 @@ export class PostController {
     /**
      * Handle a request to delete a post
      */
-    @Route('DELETE', '/.ghost/activitypub/post/:id')
     @Route('DELETE', '/.ghost/activitypub/v1/post/:id')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleDeletePost(ctx: AppContext) {
@@ -198,7 +196,6 @@ export class PostController {
     /**
      * Handle a request to create a note
      */
-    @Route('POST', '/.ghost/activitypub/actions/note')
     @Route('POST', '/.ghost/activitypub/v1/actions/note')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleCreateNote(ctx: AppContext) {
@@ -289,7 +286,6 @@ export class PostController {
     /**
      * Handle a request to create a reply
      */
-    @Route('POST', '/.ghost/activitypub/actions/reply/:id')
     @Route('POST', '/.ghost/activitypub/v1/actions/reply/:id')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleCreateReply(ctx: AppContext) {
@@ -569,7 +565,6 @@ export class PostController {
     /**
      * Handle a request to repost
      */
-    @Route('POST', '/.ghost/activitypub/actions/repost/:id')
     @Route('POST', '/.ghost/activitypub/v1/actions/repost/:id')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleRepost(ctx: AppContext): Promise<Response> {
@@ -651,7 +646,6 @@ export class PostController {
     /**
      * Handle a request to derepost
      */
-    @Route('POST', '/.ghost/activitypub/actions/derepost/:id')
     @Route('POST', '/.ghost/activitypub/v1/actions/derepost/:id')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleDerepost(ctx: AppContext) {

--- a/src/http/api/reply-chain.controller.ts
+++ b/src/http/api/reply-chain.controller.ts
@@ -8,7 +8,6 @@ import type { ReplyChainView } from './views/reply.chain.view';
 export class ReplyChainController {
     constructor(private readonly replyChainView: ReplyChainView) {}
 
-    @Route('GET', '/.ghost/activitypub/replies/:post_ap_id')
     @Route('GET', '/.ghost/activitypub/v1/replies/:post_ap_id')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetReplies(ctx: AppContext) {

--- a/src/http/api/search.controller.ts
+++ b/src/http/api/search.controller.ts
@@ -44,7 +44,6 @@ export class SearchController {
      *
      * @param ctx App context instance
      */
-    @Route('GET', '/.ghost/activitypub/actions/search')
     @Route('GET', '/.ghost/activitypub/v1/actions/search')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleSearch(ctx: AppContext) {


### PR DESCRIPTION
We've migrated to the v1 API now and want to remove these as they should be used anywhere, and it makes it more explicit that filtering on v1 refers to the API exclusively