### PR TITLE
Added origin filtering for Fedify idempotence keys

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - NODE_ENV=development
       - ALLOW_PRIVATE_ADDRESS=true
       - SKIP_SIGNATURE_VERIFICATION=true
+      - FILTER_ACTIVITY_IDEMPOTENCE_ORIGIN=true
       - USE_MQ=true
       - MQ_PUBSUB_PROJECT_ID=activitypub
       - MQ_PUBSUB_HOST=pubsub:8085
@@ -158,6 +159,7 @@ services:
       - ALLOW_PRIVATE_ADDRESS=true
       - NODE_TLS_REJECT_UNAUTHORIZED=0
       - USE_MQ=true
+      - FILTER_ACTIVITY_IDEMPOTENCE_ORIGIN=true
       - MQ_PUBSUB_PROJECT_ID=activitypub
       - MQ_PUBSUB_HOST=pubsub-testing:8085
       - MQ_PUBSUB_TOPIC_NAME=fedify-topic

--- a/src/configuration/registrations.ts
+++ b/src/configuration/registrations.ts
@@ -95,7 +95,10 @@ export function registerDependencies(
 
     container.register({
         fedifyKv: asFunction((db: Knex) => {
-            return KnexKvStore.create(db, 'key_value');
+            return KnexKvStore.create(db, 'key_value', {
+                filterActivityIdempotenceOrigin:
+                    process.env.FILTER_ACTIVITY_IDEMPOTENCE_ORIGIN === 'true',
+            });
         }).singleton(),
         globalDb: aliasTo('fedifyKv'),
     });


### PR DESCRIPTION
We have seen a few issues where processing the same activity multiple times leads to deadlocks and DB contention. Processing multiple times isn't necessary since we moved to the shared database, any inserts into feeds or notifications is handled the first time we handle the activity.

Fedify uses KvStore to track activity idempotence, storing keys in the format ["_fedify", "activityIdempotence", origin, activityUrl]. This includes the origin (receiving server URL) in the key, which prevents the same activity from being processed when received from different servers.

This change introduces an optional feature flag (FILTER_ACTIVITY_IDEMPOTENCE_ORIGIN) that removes the origin component from these keys. When enabled, activities are deduplicated based solely on their URL, allowing the same activity to be processed only once regardless of which inbox receives it.

This prepares for eventual upstream changes in Fedify while allowing immediate use of the functionality where needed.