### PR TITLE
Improved handling of ECONNRESET errors

### DIFF
--- a/src/mq/gcloud-pubsub-push/error-utils.ts
+++ b/src/mq/gcloud-pubsub-push/error-utils.ts
@@ -97,9 +97,9 @@ function isNetworkConnectivityError(error: Error, depth = 0): boolean {
     }
 
     if (
-        error.message.match(/EHOSTUNREACH/i) !== null ||
-        error.message.match(/ETIMEDOUT/i) !== null ||
-        error.message.match(/ECONNREFUSED/i) !== null ||
+        error.message.match(/connect EHOSTUNREACH/i) !== null ||
+        error.message.match(/connect ETIMEDOUT/i) !== null ||
+        error.message.match(/connect ECONNREFUSED/i) !== null ||
         error.message.match(/ECONNRESET/i) !== null ||
         error.message.match(/socket hang up/i) !== null ||
         error.message.match(/Connect Timeout Error/i) !== null ||

--- a/src/mq/gcloud-pubsub-push/error-utils.ts
+++ b/src/mq/gcloud-pubsub-push/error-utils.ts
@@ -100,7 +100,7 @@ function isNetworkConnectivityError(error: Error, depth = 0): boolean {
         error.message.match(/connect EHOSTUNREACH/i) !== null ||
         error.message.match(/connect ETIMEDOUT/i) !== null ||
         error.message.match(/connect ECONNREFUSED/i) !== null ||
-        error.message.match(/connect ECONNRESET/i) !== null ||
+        error.message.match(/ECONNRESET/i) !== null ||
         error.message.match(/socket hang up/i) !== null ||
         error.message.match(/Connect Timeout Error/i) !== null ||
         error.message.match(/other side closed/i) !== null

--- a/src/mq/gcloud-pubsub-push/error-utils.ts
+++ b/src/mq/gcloud-pubsub-push/error-utils.ts
@@ -100,7 +100,7 @@ function isNetworkConnectivityError(error: Error, depth = 0): boolean {
         error.message.match(/connect EHOSTUNREACH/i) !== null ||
         error.message.match(/connect ETIMEDOUT/i) !== null ||
         error.message.match(/connect ECONNREFUSED/i) !== null ||
-        error.message.match(/ECONNRESET/i) !== null ||
+        error.message.match(/(read|connect) ECONNRESET/i) !== null ||
         error.message.match(/socket hang up/i) !== null ||
         error.message.match(/Connect Timeout Error/i) !== null ||
         error.message.match(/other side closed/i) !== null

--- a/src/mq/gcloud-pubsub-push/error-utils.ts
+++ b/src/mq/gcloud-pubsub-push/error-utils.ts
@@ -97,9 +97,9 @@ function isNetworkConnectivityError(error: Error, depth = 0): boolean {
     }
 
     if (
-        error.message.match(/connect EHOSTUNREACH/i) !== null ||
-        error.message.match(/connect ETIMEDOUT/i) !== null ||
-        error.message.match(/connect ECONNREFUSED/i) !== null ||
+        error.message.match(/EHOSTUNREACH/i) !== null ||
+        error.message.match(/ETIMEDOUT/i) !== null ||
+        error.message.match(/ECONNREFUSED/i) !== null ||
         error.message.match(/ECONNRESET/i) !== null ||
         error.message.match(/socket hang up/i) !== null ||
         error.message.match(/Connect Timeout Error/i) !== null ||

--- a/src/mq/gcloud-pubsub-push/error-utils.unit.test.ts
+++ b/src/mq/gcloud-pubsub-push/error-utils.unit.test.ts
@@ -461,7 +461,16 @@ describe('analyzeError', () => {
             expect(result.isReportable).toBe(false);
         });
 
-        it('should handle ECONNRESET errors as non-retryable', () => {
+        it('should handle read ECONNRESET errors as non-retryable', () => {
+            const error = new Error('read ECONNRESET');
+
+            const result = analyzeError(error);
+
+            expect(result.isRetryable).toBe(true);
+            expect(result.isReportable).toBe(false);
+        });
+
+        it('should handle connect ECONNRESET errors as non-retryable', () => {
             const error = new Error('connect ECONNRESET');
 
             const result = analyzeError(error);


### PR DESCRIPTION
We have seen "read ECONNRESET" as well as "connect ECONNRESET" and we want to catch both of them as network connectivitiy errors