### PR TITLE
Ensured that ActivityPub endpoints can be cached

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -599,6 +599,7 @@ app.use(async (c, next) => {
 
         if (!isApiRequest) {
             if (c.req.method === 'GET' || c.req.method === 'HEAD') {
+                c.res.headers.set('Cache-Control', 'public, max-age=0');
                 c.res.headers.set(
                     'Surrogate-Control',
                     process.env.ACTIVITYPUB_SURROGATE_CACHE_CONTROL,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2331

Surrogates like Fastly will not cache requests if they are marked as private, regardless of the Surrogate-Control header.

Marking this as public ensures that the content can be cached by surrogates, and setting a max-age of 0 ensures that browsers don't cache it, giving us full control of purging at the surrogate level.