### PR TITLE
Fixed `cover_image` retrieval on initial site creation

### DIFF
--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -124,6 +124,8 @@ describe('AccountService', () => {
             name: 'Test Site Title',
             bio: 'Test Site Description',
             avatar_url: 'https://www.example.com/avatars/internal-account.png',
+            banner_image_url:
+                'https://www.example.com/banners/internal-account.png',
         };
         externalAccountData = {
             username: 'external-account',

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -189,7 +189,7 @@ export class AccountService {
             bio: internalAccountData.bio || null,
             url: new URL(`https://${site.host}`),
             avatarUrl: parseURL(internalAccountData.avatar_url),
-            bannerImageUrl: null,
+            bannerImageUrl: parseURL(internalAccountData.banner_image_url),
             customFields: null,
             apPublicKey: keyPair.publicKey,
             apPrivateKey: keyPair.privateKey,

--- a/src/account/types.ts
+++ b/src/account/types.ts
@@ -12,6 +12,7 @@ export interface InternalAccountData {
     name?: string;
     bio: string | null;
     avatar_url: string | null;
+    banner_image_url: string | null;
 }
 
 /**

--- a/src/feed/feed.service.integration.test.ts
+++ b/src/feed/feed.service.integration.test.ts
@@ -143,6 +143,7 @@ describe('FeedService', () => {
                         title: `Site ${host} title`,
                         description: `Site ${host} description`,
                         icon: `https://${host}/favicon.ico`,
+                        cover_image: `https://${host}/cover.png`,
                     },
                 };
             },

--- a/src/helpers/ghost.ts
+++ b/src/helpers/ghost.ts
@@ -5,6 +5,7 @@ export type SiteSettings = {
         description: string | null;
         icon: string | null;
         title: string;
+        cover_image: string | null;
     };
 };
 
@@ -19,6 +20,7 @@ export async function getSiteSettings(host: string): Promise<SiteSettings> {
             description: settings?.site?.description || null,
             title: settings?.site?.title || normalizedHost,
             icon: settings?.site?.icon || null,
+            cover_image: settings?.site?.cover_image || null,
         },
     };
 }

--- a/src/helpers/ghost.unit.test.ts
+++ b/src/helpers/ghost.unit.test.ts
@@ -15,6 +15,7 @@ describe('getSiteSettings', () => {
                 description: 'foo',
                 title: 'bar',
                 icon: 'https://example.com/baz.png',
+                cover_image: 'https://example.com/qux.png',
             },
         };
 
@@ -45,6 +46,7 @@ describe('getSiteSettings', () => {
                 description: null,
                 title: 'bar',
                 icon: 'https://example.com/baz.png',
+                cover_image: null,
             },
         });
     });
@@ -63,6 +65,7 @@ describe('getSiteSettings', () => {
                 description: 'foo',
                 title: 'bar',
                 icon: null,
+                cover_image: null,
             },
         });
     });
@@ -73,6 +76,7 @@ describe('getSiteSettings', () => {
                 site: {
                     description: 'foo',
                     icon: 'https://example.com/baz.png',
+                    cover_image: 'https://example.com/qux.png',
                 },
             }),
         } as ResponsePromise);
@@ -84,6 +88,30 @@ describe('getSiteSettings', () => {
                 description: 'foo',
                 title: 'example.com',
                 icon: 'https://example.com/baz.png',
+                cover_image: 'https://example.com/qux.png',
+            },
+        });
+    });
+
+    it('sets the site cover image to null if missing', async () => {
+        vi.mocked(ky.get).mockReturnValue({
+            json: async () => ({
+                site: {
+                    description: 'foo',
+                    title: 'bar',
+                    icon: 'https://example.com/baz.png',
+                },
+            }),
+        } as ResponsePromise);
+
+        const result = await getSiteSettings(host);
+
+        expect(result).toEqual({
+            site: {
+                description: 'foo',
+                title: 'bar',
+                icon: 'https://example.com/baz.png',
+                cover_image: null,
             },
         });
     });

--- a/src/http/api/__snapshots__/views/AccountView.viewByApId.internal-no-context.json
+++ b/src/http/api/__snapshots__/views/AccountView.viewByApId.internal-no-context.json
@@ -1,7 +1,7 @@
 {
   "apId": "https://billy-elliot.dance/.ghost/activitypub/users/index",
   "avatarUrl": "https://billy-elliot.dance/avatar/c4863565-3533-43fa-9991-19c5160a4da2.jpg",
-  "bannerImageUrl": "",
+  "bannerImageUrl": "https://billy-elliot.dance/cover/cd93c035-7326-4043-aed1-9150fe91b59.jpg",
   "bio": "Balbus clibanus bestia suppellex acies armarium.",
   "blockedByMe": false,
   "customFields": {},

--- a/src/http/api/__snapshots__/views/AccountView.viewById.no-context.json
+++ b/src/http/api/__snapshots__/views/AccountView.viewById.no-context.json
@@ -1,7 +1,7 @@
 {
   "apId": "https://eggs.food/.ghost/activitypub/users/index",
   "avatarUrl": "https://eggs.food/avatar/c4863565-3533-43fa-9991-19c5160a4da2.jpg",
-  "bannerImageUrl": "",
+  "bannerImageUrl": "https://eggs.food/cover/cd93c035-7326-4043-aed1-9150fe91b59.jpg",
   "bio": "Balbus clibanus bestia suppellex acies armarium.",
   "blockedByMe": false,
   "customFields": {},

--- a/src/http/api/views/account.posts.view.integration.test.ts
+++ b/src/http/api/views/account.posts.view.integration.test.ts
@@ -60,6 +60,7 @@ describe('AccountPostsView', () => {
             name: 'Test Site Title',
             bio: 'Test Site Description',
             avatar_url: 'https://example.com/avatar.jpg',
+            banner_image_url: 'https://example.com/banner.jpg',
         };
 
         const logger = {

--- a/src/http/api/views/account.view.integration.test.ts
+++ b/src/http/api/views/account.view.integration.test.ts
@@ -65,6 +65,7 @@ describe('AccountView', () => {
                     description: 'Test site',
                     title: 'Test site',
                     icon: 'Test site',
+                    cover_image: 'Test site',
                 },
             }),
         });

--- a/src/post/post.repository.knex.integration.test.ts
+++ b/src/post/post.repository.knex.integration.test.ts
@@ -74,6 +74,7 @@ describe('KnexPostRepository', () => {
                         title: 'Test Site',
                         description: 'A fake site used for testing',
                         icon: 'https://testing.com/favicon.ico',
+                        cover_image: 'https://testing.com/cover.png',
                     },
                 };
             },

--- a/src/site/site.service.integration.test.ts
+++ b/src/site/site.service.integration.test.ts
@@ -59,6 +59,7 @@ describe('SiteService', () => {
                         icon: '',
                         title: 'Default Title',
                         description: 'Default Description',
+                        cover_image: 'https://testing.com/cover.png',
                     },
                 };
             },

--- a/src/site/site.service.ts
+++ b/src/site/site.service.ts
@@ -96,6 +96,7 @@ export class SiteService {
                 name: settings?.site?.title,
                 bio: settings?.site?.description || null,
                 avatar_url: settings?.site?.icon || null,
+                banner_image_url: settings?.site?.cover_image || null,
             };
 
             await this.accountService.createInternalAccount(

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -58,6 +58,7 @@ export class FixtureManager {
                     name: faker.person.fullName(),
                     bio: null,
                     avatar_url: null,
+                    banner_image_url: null,
                 });
 
             const accountByApId = await this.accountRepository.getByApId(
@@ -253,6 +254,7 @@ export function createFixtureManager(
                 description: 'Balbus clibanus bestia suppellex acies armarium.',
                 title: 'Umerus casso venia bestia stultus colligo sonitus cohors.',
                 icon: `https://${host}/avatar/c4863565-3533-43fa-9991-19c5160a4da2.jpg`,
+                cover_image: `https://${host}/cover/cd93c035-7326-4043-aed1-9150fe91b59.jpg`,
             },
         }),
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2345

When QA'ing the creation of a site we spotted that the cover image for the site was not being imported for the initial profile creation. This changeset fixes this