### PR TITLE
Standardized handle format in blocked users list

### DIFF
--- a/src/http/api/views/blocks.view.integration.test.ts
+++ b/src/http/api/views/blocks.view.integration.test.ts
@@ -51,7 +51,7 @@ describe('BlocksView', () => {
                 id: blockedOne.apId.toString(),
                 apId: blockedOne.apId.toString(),
                 name: blockedOne.name,
-                handle: `${blockedOne.username}@${blockedOne.apId.host}`,
+                handle: `@${blockedOne.username}@${blockedOne.apId.host}`,
                 avatarUrl: blockedOne.avatarUrl
                     ? blockedOne.avatarUrl.toString()
                     : null,
@@ -64,7 +64,7 @@ describe('BlocksView', () => {
                 id: blockedTwo.apId.toString(),
                 apId: blockedTwo.apId.toString(),
                 name: blockedTwo.name,
-                handle: `${blockedTwo.username}@${blockedTwo.apId.host}`,
+                handle: `@${blockedTwo.username}@${blockedTwo.apId.host}`,
                 avatarUrl: blockedTwo.avatarUrl
                     ? blockedTwo.avatarUrl.toString()
                     : null,

--- a/src/http/api/views/blocks.view.ts
+++ b/src/http/api/views/blocks.view.ts
@@ -1,5 +1,5 @@
-import type { Knex } from 'knex';
 import { getAccountHandle } from 'account/utils';
+import type { Knex } from 'knex';
 import type { BlockedDomainDTO, MinimalAccountDTO } from '../types';
 
 export class BlocksView {

--- a/src/http/api/views/blocks.view.ts
+++ b/src/http/api/views/blocks.view.ts
@@ -1,4 +1,5 @@
 import type { Knex } from 'knex';
+import { getAccountHandle } from 'account/utils';
 import type { BlockedDomainDTO, MinimalAccountDTO } from '../types';
 
 export class BlocksView {
@@ -26,7 +27,7 @@ export class BlocksView {
             id: result.ap_id,
             apId: result.ap_id,
             name: result.name || '',
-            handle: `${result.username}@${result.domain}`,
+            handle: getAccountHandle(result.domain, result.username),
             avatarUrl: result.avatar_url || null,
             followedByMe: false,
             blockedByMe: true,


### PR DESCRIPTION
ref PROD-2347

- Used existing `getAccountHandle` function for blocked users endpoint
- Added "@" prefix to handles consistently across all user references
- Updated corresponding tests to reflect standardized handle format