### PR TITLE
Return error when followers list is empty

### DIFF
--- a/src/http/api/views/account.follows.view.ts
+++ b/src/http/api/views/account.follows.view.ts
@@ -261,7 +261,6 @@ export class AccountFollowsView {
 
                 page = follows ? await follows.getFirst() : null;
                 if (!page) {
-                    console.log('No page found here in getFollowsByRemoteLookUp');
                     return this.getUnpaginatedFollows(
                         actor,
                         type,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2366/

- sometimes the remote server might not provide a list of followers, return early in that cases