### PR TITLE
Added index to expires column of key_value table

### DIFF
--- a/migrate/migrations/000065_add-expires-index-to-key-value.down.sql
+++ b/migrate/migrations/000065_add-expires-index-to-key-value.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE key_value DROP INDEX idx_expires;

--- a/migrate/migrations/000065_add-expires-index-to-key-value.up.sql
+++ b/migrate/migrations/000065_add-expires-index-to-key-value.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE key_value ADD INDEX idx_expires (expires);


### PR DESCRIPTION
We need to delete old records from this table, and having an index on the expires column makes this a lot faster.