### PR TITLE
Updated delivery failure backoff seconds to 60s

### DIFF
--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -51,7 +51,7 @@ type RemoteAccountFetchError =
     | 'network-failure'
     | 'not-found';
 
-export const DELIVERY_FAILURE_BACKOFF_SECONDS = 604800; // 1 week - This is temporarily high to do an initial block of broken accounts - This will be reduced to 60 seconds in the future;
+export const DELIVERY_FAILURE_BACKOFF_SECONDS = 60;
 export const DELIVERY_FAILURE_BACKOFF_MULTIPLIER = 2;
 
 export class AccountService {


### PR DESCRIPTION
no ref

This value was originally set to 1 week to try and block out all the accounts that we knew would fail delivery. This value was left to this longer than expected and should have been adjusted earlier