### PR TITLE
Excluded jobs/update-external-accounts from Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,7 +23,7 @@
     },
     {
       // Exclude dependencies in jobs that don't have automated tests
-      "matchPaths": ["jobs/populate-explore-json/**", "jobs/cleanup-expired-key-value-records/**"],
+      "matchPaths": ["jobs/populate-explore-json/**", "jobs/cleanup-expired-key-value-records/**", "jobs/update-external-accounts/**"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2315

- Our working agreement is not auto-merge dependency updates on jobs that do not have automated tests
- The job "update-external-account" was added about a month ago and is not tested, therefore we're excluding it from Renovate too