### PR TITLE
Enabled more frequent auto-merges for lock file maintenance

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,6 +12,12 @@
   // Rationale: merging to main ships to production, so we want to avoid automerging when no engineer is online
   // Note: this doesn't restrict when the PRs are opened by Renovate, only when they are merged
   "automergeSchedule": ["* 8-15 * * 1,2,3"],
+  // Automerge lock file updates, whenever available
+  // Note: the base config file has this enabled, but on a weekly basis only
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  },
   "packageRules": [
     {
       "matchDatasources": ["docker"],


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2315

- lock file maintenance PRs are auto-merged on a weekly basis in the base config
- with this change, we allow lock file maintenance to be auto-merged more frequently