### PR TITLE
Support dynamic versioning of ActivityPub client

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -77,6 +77,7 @@ import type { GhostPostService } from '@/ghost/ghost-post.service';
 import { getTraceContext } from '@/helpers/context-header';
 import { AccountController } from '@/http/api/account.controller';
 import { BlockController } from '@/http/api/block.controller';
+import { ClientConfigController } from '@/http/api/client-config.controller';
 import { FeedController } from '@/http/api/feed.controller';
 import { FollowController } from '@/http/api/follow.controller';
 import { BadRequest } from '@/http/api/helpers/response';
@@ -868,6 +869,10 @@ routeRegistry.registerController(
 );
 routeRegistry.registerController('mediaController', MediaController);
 routeRegistry.registerController('blockController', BlockController);
+routeRegistry.registerController(
+    'clientConfigController',
+    ClientConfigController,
+);
 
 // Mount all registered routes
 routeRegistry.mountRoutes(app, container);

--- a/src/configuration/registrations.ts
+++ b/src/configuration/registrations.ts
@@ -48,6 +48,7 @@ import { GhostPostService } from '@/ghost/ghost-post.service';
 import { getSiteSettings } from '@/helpers/ghost';
 import { AccountController } from '@/http/api/account.controller';
 import { BlockController } from '@/http/api/block.controller';
+import { ClientConfigController } from '@/http/api/client-config.controller';
 import { FeedController } from '@/http/api/feed.controller';
 import { FollowController } from '@/http/api/follow.controller';
 import { LikeController } from '@/http/api/like.controller';
@@ -461,6 +462,11 @@ export function registerDependencies(
     container.register(
         'notificationController',
         asClass(NotificationController).singleton(),
+    );
+
+    container.register(
+        'clientConfigController',
+        asClass(ClientConfigController).singleton(),
     );
 
     container.register(

--- a/src/http/api/account.controller.ts
+++ b/src/http/api/account.controller.ts
@@ -16,7 +16,7 @@ import type {
     AccountPostsView,
 } from '@/http/api/views/account.posts.view';
 import type { AccountView } from '@/http/api/views/account.view';
-import { RequireRoles, Route } from '@/http/decorators/route.decorator';
+import { APIRoute, RequireRoles } from '@/http/decorators/route.decorator';
 import { GhostRole } from '@/http/middleware/role-guard';
 import { lookupActorProfile } from '@/lookup-helpers';
 
@@ -51,7 +51,7 @@ export class AccountController {
     /**
      * Handle a request for an account
      */
-    @Route('GET', '/.ghost/activitypub/v1/account/:handle')
+    @APIRoute('GET', 'account/:handle')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetAccount(ctx: AppContext) {
         const handle = ctx.req.param('handle');
@@ -97,7 +97,7 @@ export class AccountController {
     /**
      * Handle a request for a list of account follows
      */
-    @Route('GET', '/.ghost/activitypub/v1/account/:handle/follows/:type')
+    @APIRoute('GET', 'account/:handle/follows/:type')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetAccountFollows(ctx: AppContext) {
         const logger = ctx.get('logger');
@@ -202,7 +202,7 @@ export class AccountController {
     /**
      * Handle a request for a list of posts by an account
      */
-    @Route('GET', '/.ghost/activitypub/v1/posts/:handle')
+    @APIRoute('GET', 'posts/:handle')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetAccountPosts(ctx: AppContext) {
         const params = validateRequestParams(ctx);
@@ -311,7 +311,7 @@ export class AccountController {
     /**
      * Handle a request for a list of posts liked by an account
      */
-    @Route('GET', '/.ghost/activitypub/v1/posts/:handle/liked')
+    @APIRoute('GET', 'posts/:handle/liked')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetAccountLikedPosts(ctx: AppContext) {
         const params = validateRequestParams(ctx);
@@ -344,7 +344,7 @@ export class AccountController {
     /**
      * Handle a request for an account update
      */
-    @Route('PUT', '/.ghost/activitypub/v1/account')
+    @APIRoute('PUT', 'account')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleUpdateAccount(ctx: AppContext) {
         const schema = z.object({

--- a/src/http/api/block.controller.ts
+++ b/src/http/api/block.controller.ts
@@ -4,7 +4,7 @@ import { exhaustiveCheck, getError, isError } from '@/core/result';
 import { parseURL } from '@/core/url';
 import { BadRequest, NotFound } from '@/http/api/helpers/response';
 import type { BlocksView } from '@/http/api/views/blocks.view';
-import { RequireRoles, Route } from '@/http/decorators/route.decorator';
+import { APIRoute, RequireRoles } from '@/http/decorators/route.decorator';
 import { GhostRole } from '@/http/middleware/role-guard';
 
 export class BlockController {
@@ -13,7 +13,7 @@ export class BlockController {
         private readonly blocksView: BlocksView,
     ) {}
 
-    @Route('POST', '/.ghost/activitypub/v1/actions/block/:id')
+    @APIRoute('POST', 'actions/block/:id')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleBlock(ctx: AppContext) {
         const accountToBlock = parseURL(
@@ -53,7 +53,7 @@ export class BlockController {
         });
     }
 
-    @Route('POST', '/.ghost/activitypub/v1/actions/unblock/:id')
+    @APIRoute('POST', 'actions/unblock/:id')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleUnblock(ctx: AppContext) {
         const accountToUnblock = parseURL(
@@ -93,7 +93,7 @@ export class BlockController {
         });
     }
 
-    @Route('POST', '/.ghost/activitypub/v1/actions/block/domain/:domain')
+    @APIRoute('POST', 'actions/block/domain/:domain')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleBlockDomain(ctx: AppContext) {
         const domain = parseURL(decodeURIComponent(ctx.req.param('domain')));
@@ -111,7 +111,7 @@ export class BlockController {
         });
     }
 
-    @Route('POST', '/.ghost/activitypub/v1/actions/unblock/domain/:domain')
+    @APIRoute('POST', 'actions/unblock/domain/:domain')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleUnblockDomain(ctx: AppContext) {
         const domain = parseURL(decodeURIComponent(ctx.req.param('domain')));
@@ -129,7 +129,7 @@ export class BlockController {
         });
     }
 
-    @Route('GET', '/.ghost/activitypub/v1/blocks/accounts')
+    @APIRoute('GET', 'blocks/accounts')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetBlockedAccounts(ctx: AppContext) {
         const account = ctx.get('account');
@@ -148,7 +148,7 @@ export class BlockController {
         );
     }
 
-    @Route('GET', '/.ghost/activitypub/v1/blocks/domains')
+    @APIRoute('GET', 'blocks/domains')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetBlockedDomains(ctx: AppContext) {
         const account = ctx.get('account');

--- a/src/http/api/client-config.controller.ts
+++ b/src/http/api/client-config.controller.ts
@@ -1,8 +1,8 @@
 import type { AppContext } from '@/app';
-import { Route } from '@/http/decorators/route.decorator';
+import { APIRoute } from '@/http/decorators/route.decorator';
 
 export class ClientConfigController {
-    @Route('GET', '/.ghost/activitypub/stable/client-config')
+    @APIRoute('GET', 'client-config', 'stable')
     async handleGetClientConfig(_ctx: AppContext) {
         const clientConfig = {
             requiredVersion: '^1.0.0',

--- a/src/http/api/client-config.controller.ts
+++ b/src/http/api/client-config.controller.ts
@@ -8,7 +8,7 @@ export class ClientConfigController {
         const name = 'admin-x-activitypub';
         const client = {
             name,
-            requiredVersion: `^${major}.0.0`,
+            version: `^${major}.0.0`,
             cdnUrl: `https://cdn.jsdelivr.net/ghost/${name}@${major}/dist/${name}.js`,
         };
 

--- a/src/http/api/client-config.controller.ts
+++ b/src/http/api/client-config.controller.ts
@@ -4,12 +4,15 @@ import { APIRoute } from '@/http/decorators/route.decorator';
 export class ClientConfigController {
     @APIRoute('GET', 'client-config', 'stable')
     async handleGetClientConfig(_ctx: AppContext) {
-        const clientConfig = {
-            requiredVersion: '^1.0.0',
-            cdnUrl: 'https://cdn.jsdelivr.net/ghost/admin-x-activitypub@1/dist/admin-x-activitypub.js',
+        const major = 0;
+        const name = 'admin-x-activitypub';
+        const client = {
+            name,
+            requiredVersion: `^${major}.0.0`,
+            cdnUrl: `https://cdn.jsdelivr.net/ghost/${name}@${major}/dist/${name}.js`,
         };
 
-        return new Response(JSON.stringify(clientConfig), {
+        return new Response(JSON.stringify({ client }), {
             status: 200,
             headers: {
                 'Content-Type': 'application/json',

--- a/src/http/api/client-config.controller.ts
+++ b/src/http/api/client-config.controller.ts
@@ -1,0 +1,19 @@
+import type { AppContext } from '@/app';
+import { Route } from '@/http/decorators/route.decorator';
+
+export class ClientConfigController {
+    @Route('GET', '/.ghost/activitypub/stable/client-config')
+    async handleGetClientConfig(_ctx: AppContext) {
+        const clientConfig = {
+            requiredVersion: '^1.0.0',
+            cdnUrl: 'https://cdn.jsdelivr.net/ghost/admin-x-activitypub@1/dist/admin-x-activitypub.js',
+        };
+
+        return new Response(JSON.stringify(clientConfig), {
+            status: 200,
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+    }
+}

--- a/src/http/api/feed.controller.ts
+++ b/src/http/api/feed.controller.ts
@@ -4,7 +4,7 @@ import { getAccountHandle } from '@/account/utils';
 import type { AppContext } from '@/app';
 import type { FeedService, FeedType } from '@/feed/feed.service';
 import type { PostDTO } from '@/http/api/types';
-import { RequireRoles, Route } from '@/http/decorators/route.decorator';
+import { APIRoute, RequireRoles } from '@/http/decorators/route.decorator';
 import { GhostRole } from '@/http/middleware/role-guard';
 import type { PostInteractionCountsService } from '@/post/post-interaction-counts.service';
 
@@ -27,13 +27,13 @@ export class FeedController {
         private readonly postInteractionCountsService: PostInteractionCountsService,
     ) {}
 
-    @Route('GET', '/.ghost/activitypub/v1/feed/notes')
+    @APIRoute('GET', 'feed/notes')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async getNotesFeed(ctx: AppContext) {
         return this.handleGetFeed(ctx, 'Feed');
     }
 
-    @Route('GET', '/.ghost/activitypub/v1/feed/reader')
+    @APIRoute('GET', 'feed/reader')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async getReaderFeed(ctx: AppContext) {
         return this.handleGetFeed(ctx, 'Inbox');

--- a/src/http/api/follow.controller.ts
+++ b/src/http/api/follow.controller.ts
@@ -11,7 +11,7 @@ import {
     Forbidden,
     NotFound,
 } from '@/http/api/helpers/response';
-import { RequireRoles, Route } from '@/http/decorators/route.decorator';
+import { APIRoute, RequireRoles } from '@/http/decorators/route.decorator';
 import { GhostRole } from '@/http/middleware/role-guard';
 import {
     lookupActor,
@@ -27,7 +27,7 @@ export class FollowController {
         private readonly fedify: Federation<ContextData>,
     ) {}
 
-    @Route('POST', '/.ghost/activitypub/v1/actions/follow/:handle')
+    @APIRoute('POST', 'actions/follow/:handle')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleFollow(ctx: AppContext) {
         const handle = ctx.req.param('handle');
@@ -136,7 +136,7 @@ export class FollowController {
         });
     }
 
-    @Route('POST', '/.ghost/activitypub/v1/actions/unfollow/:handle')
+    @APIRoute('POST', 'actions/unfollow/:handle')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleUnfollow(ctx: AppContext) {
         const handle = ctx.req.param('handle');

--- a/src/http/api/like.controller.ts
+++ b/src/http/api/like.controller.ts
@@ -13,7 +13,7 @@ import { ACTOR_DEFAULT_HANDLE } from '@/constants';
 import { exhaustiveCheck, getError, getValue, isError } from '@/core/result';
 import { parseURL } from '@/core/url';
 import { Forbidden } from '@/http/api/helpers/response';
-import { RequireRoles, Route } from '@/http/decorators/route.decorator';
+import { APIRoute, RequireRoles } from '@/http/decorators/route.decorator';
 import { GhostRole } from '@/http/middleware/role-guard';
 import { lookupActor, lookupObject } from '@/lookup-helpers';
 import type { KnexPostRepository } from '@/post/post.repository.knex';
@@ -26,7 +26,7 @@ export class LikeController {
         private readonly fedify: Federation<ContextData>,
     ) {}
 
-    @Route('POST', '/.ghost/activitypub/v1/actions/like/:id')
+    @APIRoute('POST', 'actions/like/:id')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleLike(ctx: AppContext) {
         const account = ctx.get('account');
@@ -159,7 +159,7 @@ export class LikeController {
         });
     }
 
-    @Route('POST', '/.ghost/activitypub/v1/actions/unlike/:id')
+    @APIRoute('POST', 'actions/unlike/:id')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleUnlike(ctx: AppContext) {
         const account = ctx.get('account');

--- a/src/http/api/media.controller.ts
+++ b/src/http/api/media.controller.ts
@@ -2,7 +2,7 @@ import type { Context } from 'hono';
 
 import type { AccountService } from '@/account/account.service';
 import { exhaustiveCheck, getError, getValue, isError } from '@/core/result';
-import { RequireRoles, Route } from '@/http/decorators/route.decorator';
+import { APIRoute, RequireRoles } from '@/http/decorators/route.decorator';
 import { GhostRole } from '@/http/middleware/role-guard';
 import type { ImageStorageService } from '@/storage/image-storage.service';
 
@@ -18,7 +18,7 @@ export class MediaController {
     /**
      * Handle image upload
      */
-    @Route('POST', '/.ghost/activitypub/v1/upload/image')
+    @APIRoute('POST', 'upload/image')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleImageUpload(ctx: Context) {
         const logger = ctx.get('logger');

--- a/src/http/api/notification.controller.ts
+++ b/src/http/api/notification.controller.ts
@@ -3,7 +3,7 @@ import { getAccountHandle } from '@/account/utils';
 import type { AppContext } from '@/app';
 import { exhaustiveCheck, getError, getValue, isError } from '@/core/result';
 import type { NotificationDTO } from '@/http/api/types';
-import { RequireRoles, Route } from '@/http/decorators/route.decorator';
+import { APIRoute, RequireRoles } from '@/http/decorators/route.decorator';
 import { GhostRole } from '@/http/middleware/role-guard';
 import type { NotificationService } from '@/notification/notification.service';
 
@@ -29,7 +29,7 @@ export class NotificationController {
         private readonly notificationService: NotificationService,
     ) {}
 
-    @Route('GET', '/.ghost/activitypub/v1/notifications')
+    @APIRoute('GET', 'notifications')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetNotifications(ctx: AppContext) {
         const queryCursor = ctx.req.query('next');
@@ -120,8 +120,7 @@ export class NotificationController {
         );
     }
 
-    @Route('GET', '/.ghost/activitypub/v1/notifications/unread/count')
-    @Route('GET', '/.ghost/activitypub/stable/notifications/unread/count')
+    @APIRoute('GET', 'notifications/unread/count', 'stable', 'v1')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetUnreadNotificationsCount(ctx: AppContext) {
         const account = ctx.get('account');
@@ -154,7 +153,7 @@ export class NotificationController {
         );
     }
 
-    @Route('PUT', '/.ghost/activitypub/v1/notifications/unread/reset')
+    @APIRoute('PUT', 'notifications/unread/reset')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleResetUnreadNotificationsCount(ctx: AppContext) {
         const account = ctx.get('account');

--- a/src/http/api/notification.controller.ts
+++ b/src/http/api/notification.controller.ts
@@ -121,6 +121,7 @@ export class NotificationController {
     }
 
     @Route('GET', '/.ghost/activitypub/v1/notifications/unread/count')
+    @Route('GET', '/.ghost/activitypub/stable/notifications/unread/count')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetUnreadNotificationsCount(ctx: AppContext) {
         const account = ctx.get('account');

--- a/src/http/api/post.controller.ts
+++ b/src/http/api/post.controller.ts
@@ -30,7 +30,7 @@ import {
     Forbidden,
     NotFound,
 } from '@/http/api/helpers/response';
-import { RequireRoles, Route } from '@/http/decorators/route.decorator';
+import { APIRoute, RequireRoles } from '@/http/decorators/route.decorator';
 import { GhostRole } from '@/http/middleware/role-guard';
 import { lookupActor, lookupObject } from '@/lookup-helpers';
 import type { ImageAttachment } from '@/post/post.entity';
@@ -52,7 +52,7 @@ export class PostController {
     /**
      * Handle a request to get a post
      */
-    @Route('GET', '/.ghost/activitypub/v1/post/:post_ap_id')
+    @APIRoute('GET', 'post/:post_ap_id')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetPost(ctx: AppContext) {
         const postApId = decodeURIComponent(ctx.req.param('post_ap_id'));
@@ -127,7 +127,7 @@ export class PostController {
     /**
      * Handle a request to delete a post
      */
-    @Route('DELETE', '/.ghost/activitypub/v1/post/:id')
+    @APIRoute('DELETE', 'post/:id')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleDeletePost(ctx: AppContext) {
         const logger = ctx.get('logger');
@@ -203,7 +203,7 @@ export class PostController {
     /**
      * Handle a request to create a note
      */
-    @Route('POST', '/.ghost/activitypub/v1/actions/note')
+    @APIRoute('POST', 'actions/note')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleCreateNote(ctx: AppContext) {
         const NoteSchema = z.object({
@@ -293,7 +293,7 @@ export class PostController {
     /**
      * Handle a request to create a reply
      */
-    @Route('POST', '/.ghost/activitypub/v1/actions/reply/:id')
+    @APIRoute('POST', 'actions/reply/:id')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleCreateReply(ctx: AppContext) {
         const account = ctx.get('account');
@@ -572,7 +572,7 @@ export class PostController {
     /**
      * Handle a request to repost
      */
-    @Route('POST', '/.ghost/activitypub/v1/actions/repost/:id')
+    @APIRoute('POST', 'actions/repost/:id')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleRepost(ctx: AppContext): Promise<Response> {
         const id = ctx.req.param('id');
@@ -653,7 +653,7 @@ export class PostController {
     /**
      * Handle a request to derepost
      */
-    @Route('POST', '/.ghost/activitypub/v1/actions/derepost/:id')
+    @APIRoute('POST', 'actions/derepost/:id')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleDerepost(ctx: AppContext) {
         const account = ctx.get('account');

--- a/src/http/api/reply-chain.controller.ts
+++ b/src/http/api/reply-chain.controller.ts
@@ -2,13 +2,13 @@ import type { AppContext } from '@/app';
 import { exhaustiveCheck, getError, getValue, isError } from '@/core/result';
 import { NotFound } from '@/http/api/helpers/response';
 import type { ReplyChainView } from '@/http/api/views/reply.chain.view';
-import { RequireRoles, Route } from '@/http/decorators/route.decorator';
+import { APIRoute, RequireRoles } from '@/http/decorators/route.decorator';
 import { GhostRole } from '@/http/middleware/role-guard';
 
 export class ReplyChainController {
     constructor(private readonly replyChainView: ReplyChainView) {}
 
-    @Route('GET', '/.ghost/activitypub/v1/replies/:post_ap_id')
+    @APIRoute('GET', 'replies/:post_ap_id')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetReplies(ctx: AppContext) {
         const account = ctx.get('account');

--- a/src/http/api/search.controller.ts
+++ b/src/http/api/search.controller.ts
@@ -5,7 +5,7 @@ import { isHandle } from '@/helpers/activitypub/actor';
 import { isUri } from '@/helpers/uri';
 import type { AccountDTO } from '@/http/api/types';
 import type { AccountView } from '@/http/api/views/account.view';
-import { RequireRoles, Route } from '@/http/decorators/route.decorator';
+import { APIRoute, RequireRoles } from '@/http/decorators/route.decorator';
 import { GhostRole } from '@/http/middleware/role-guard';
 
 type AccountSearchResult = Pick<
@@ -45,7 +45,7 @@ export class SearchController {
      *
      * @param ctx App context instance
      */
-    @Route('GET', '/.ghost/activitypub/v1/actions/search')
+    @APIRoute('GET', 'actions/search')
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleSearch(ctx: AppContext) {
         // Parse "query" from query parameters

--- a/src/http/decorators/route.decorator.ts
+++ b/src/http/decorators/route.decorator.ts
@@ -4,6 +4,7 @@ import type { GhostRole } from '@/http/middleware/role-guard';
 
 export const ROUTES_METADATA_KEY = Symbol('routes');
 export const ROLES_METADATA_KEY = Symbol('roles');
+export const DEFAULT_API_VERSION = 'v1';
 
 export function Route(method: string, path: string) {
     return (target: object, propertyKey: string) => {
@@ -13,6 +14,28 @@ export function Route(method: string, path: string) {
             method,
             path,
             methodName: propertyKey,
+        });
+        Reflect.defineMetadata(ROUTES_METADATA_KEY, existingRoutes, target);
+    };
+}
+
+export function APIRoute(method: string, path: string, ...versions: string[]) {
+    if (path.startsWith('/')) {
+        path = path.slice(1);
+    }
+
+    if (versions.length === 0) {
+        versions = [DEFAULT_API_VERSION];
+    }
+
+    return (target: object, propertyKey: string) => {
+        const existingRoutes =
+            Reflect.getMetadata(ROUTES_METADATA_KEY, target) || [];
+        existingRoutes.push({
+            method,
+            path: `/.ghost/activitypub/:version/${path}`,
+            methodName: propertyKey,
+            versions,
         });
         Reflect.defineMetadata(ROUTES_METADATA_KEY, existingRoutes, target);
     };

--- a/src/http/decorators/route.decorator.unit.test.ts
+++ b/src/http/decorators/route.decorator.unit.test.ts
@@ -1,0 +1,250 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import 'reflect-metadata';
+
+import { GhostRole } from '@/http/middleware/role-guard';
+import {
+    APIRoute,
+    DEFAULT_API_VERSION,
+    RequireRoles,
+    ROLES_METADATA_KEY,
+    ROUTES_METADATA_KEY,
+    Route,
+} from './route.decorator';
+
+// Define a test controller class type
+class TestController {
+    testMethod() {}
+    anotherMethod() {}
+}
+
+describe('Route Decorators', () => {
+    let TestClass: typeof TestController;
+
+    beforeEach(() => {
+        TestClass = class {
+            testMethod() {}
+            anotherMethod() {}
+        };
+    });
+
+    describe('Route', () => {
+        it('should add route metadata to the target', () => {
+            Route('GET', '/test')(TestClass.prototype, 'testMethod');
+
+            const routes = Reflect.getMetadata(
+                ROUTES_METADATA_KEY,
+                TestClass.prototype,
+            );
+
+            expect(routes).toHaveLength(1);
+            expect(routes[0]).toEqual({
+                method: 'GET',
+                path: '/test',
+                methodName: 'testMethod',
+            });
+        });
+
+        it('should append multiple routes to the same target', () => {
+            Route('GET', '/test1')(TestClass.prototype, 'testMethod');
+            Route('POST', '/test2')(TestClass.prototype, 'anotherMethod');
+
+            const routes = Reflect.getMetadata(
+                ROUTES_METADATA_KEY,
+                TestClass.prototype,
+            );
+
+            expect(routes).toHaveLength(2);
+            expect(routes[0]).toEqual({
+                method: 'GET',
+                path: '/test1',
+                methodName: 'testMethod',
+            });
+            expect(routes[1]).toEqual({
+                method: 'POST',
+                path: '/test2',
+                methodName: 'anotherMethod',
+            });
+        });
+    });
+
+    describe('APIRoute', () => {
+        it('should add versioned API route with default version', () => {
+            APIRoute('GET', '/users')(TestClass.prototype, 'testMethod');
+
+            const routes = Reflect.getMetadata(
+                ROUTES_METADATA_KEY,
+                TestClass.prototype,
+            );
+
+            expect(routes).toHaveLength(1);
+            expect(routes[0]).toEqual({
+                method: 'GET',
+                path: '/.ghost/activitypub/:version/users',
+                methodName: 'testMethod',
+                versions: [DEFAULT_API_VERSION],
+            });
+        });
+
+        it('should add versioned API route with specified versions', () => {
+            APIRoute(
+                'POST',
+                '/posts',
+                'v1',
+                'v2',
+            )(TestClass.prototype, 'testMethod');
+
+            const routes = Reflect.getMetadata(
+                ROUTES_METADATA_KEY,
+                TestClass.prototype,
+            );
+
+            expect(routes).toHaveLength(1);
+            expect(routes[0]).toEqual({
+                method: 'POST',
+                path: '/.ghost/activitypub/:version/posts',
+                methodName: 'testMethod',
+                versions: ['v1', 'v2'],
+            });
+        });
+
+        it('should strip leading slash from path', () => {
+            APIRoute('GET', '/users', 'v1')(TestClass.prototype, 'testMethod');
+
+            const routes = Reflect.getMetadata(
+                ROUTES_METADATA_KEY,
+                TestClass.prototype,
+            );
+
+            expect(routes[0].path).toBe('/.ghost/activitypub/:version/users');
+        });
+
+        it('should work without leading slash', () => {
+            APIRoute('GET', 'users', 'v1')(TestClass.prototype, 'testMethod');
+
+            const routes = Reflect.getMetadata(
+                ROUTES_METADATA_KEY,
+                TestClass.prototype,
+            );
+
+            expect(routes[0].path).toBe('/.ghost/activitypub/:version/users');
+        });
+
+        it('should support multiple versions', () => {
+            APIRoute(
+                'GET',
+                '/resource',
+                'v1',
+                'v2',
+                'v3',
+            )(TestClass.prototype, 'testMethod');
+
+            const routes = Reflect.getMetadata(
+                ROUTES_METADATA_KEY,
+                TestClass.prototype,
+            );
+
+            expect(routes[0].versions).toEqual(['v1', 'v2', 'v3']);
+        });
+
+        it('should use default version when no versions specified', () => {
+            APIRoute('GET', '/resource')(TestClass.prototype, 'testMethod');
+
+            const routes = Reflect.getMetadata(
+                ROUTES_METADATA_KEY,
+                TestClass.prototype,
+            );
+
+            expect(routes[0].versions).toEqual([DEFAULT_API_VERSION]);
+        });
+    });
+
+    describe('RequireRoles', () => {
+        it('should add roles metadata to the target method', () => {
+            RequireRoles(GhostRole.Administrator, GhostRole.Editor)(
+                TestClass.prototype,
+                'testMethod',
+            );
+
+            const roles = Reflect.getMetadata(
+                ROLES_METADATA_KEY,
+                TestClass.prototype,
+                'testMethod',
+            );
+
+            expect(roles).toEqual([GhostRole.Administrator, GhostRole.Editor]);
+        });
+
+        it('should allow single role', () => {
+            RequireRoles(GhostRole.Administrator)(
+                TestClass.prototype,
+                'testMethod',
+            );
+
+            const roles = Reflect.getMetadata(
+                ROLES_METADATA_KEY,
+                TestClass.prototype,
+                'testMethod',
+            );
+
+            expect(roles).toEqual([GhostRole.Administrator]);
+        });
+
+        it('should allow multiple roles on different methods', () => {
+            RequireRoles(GhostRole.Administrator)(
+                TestClass.prototype,
+                'testMethod',
+            );
+            RequireRoles(GhostRole.Editor, GhostRole.Author)(
+                TestClass.prototype,
+                'anotherMethod',
+            );
+
+            const roles1 = Reflect.getMetadata(
+                ROLES_METADATA_KEY,
+                TestClass.prototype,
+                'testMethod',
+            );
+            const roles2 = Reflect.getMetadata(
+                ROLES_METADATA_KEY,
+                TestClass.prototype,
+                'anotherMethod',
+            );
+
+            expect(roles1).toEqual([GhostRole.Administrator]);
+            expect(roles2).toEqual([GhostRole.Editor, GhostRole.Author]);
+        });
+    });
+
+    describe('Combined decorators', () => {
+        it('should work together on the same method', () => {
+            APIRoute(
+                'GET',
+                '/admin/users',
+                'v1',
+                'v2',
+            )(TestClass.prototype, 'testMethod');
+            RequireRoles(GhostRole.Administrator)(
+                TestClass.prototype,
+                'testMethod',
+            );
+
+            const routes = Reflect.getMetadata(
+                ROUTES_METADATA_KEY,
+                TestClass.prototype,
+            );
+            const roles = Reflect.getMetadata(
+                ROLES_METADATA_KEY,
+                TestClass.prototype,
+                'testMethod',
+            );
+
+            expect(routes[0]).toEqual({
+                method: 'GET',
+                path: '/.ghost/activitypub/:version/admin/users',
+                methodName: 'testMethod',
+                versions: ['v1', 'v2'],
+            });
+            expect(roles).toEqual([GhostRole.Administrator]);
+        });
+    });
+});

--- a/src/http/routing/route-registry.ts
+++ b/src/http/routing/route-registry.ts
@@ -93,7 +93,7 @@ export class RouteRegistry {
                             requestedVersion: requestVersion,
                             supportedVersions: route.versions,
                         },
-                        404,
+                        410,
                     );
                 }
                 return await next();

--- a/src/http/routing/route-registry.ts
+++ b/src/http/routing/route-registry.ts
@@ -18,6 +18,7 @@ interface RouteRegistration {
     controllerToken: string;
     methodName: string;
     requiredRoles?: GhostRole[];
+    versions?: string[];
 }
 
 export class RouteRegistry {
@@ -76,6 +77,28 @@ export class RouteRegistry {
         const middleware: MiddlewareHandler<{
             Variables: HonoContextVariables;
         }>[] = [];
+
+        if (route.versions && route.versions.length > 0) {
+            middleware.push(async (ctx: AppContext, next: Next) => {
+                const requestVersion = ctx.req.param('version');
+                if (!route.versions) {
+                    throw new Error('RouteRegistration was modified');
+                }
+
+                if (!route.versions.includes(requestVersion)) {
+                    return ctx.json(
+                        {
+                            message: `Version ${requestVersion} is not supported.`,
+                            code: 'INVALID_VERSION',
+                            requestedVersion: requestVersion,
+                            supportedVersions: route.versions,
+                        },
+                        404,
+                    );
+                }
+                return await next();
+            });
+        }
 
         if (route.requiredRoles && route.requiredRoles.length > 0) {
             middleware.push(

--- a/src/http/routing/route-registry.ts
+++ b/src/http/routing/route-registry.ts
@@ -51,6 +51,7 @@ export class RouteRegistry {
                 controllerToken,
                 methodName: route.methodName,
                 requiredRoles: roles,
+                versions: route.versions,
             });
         }
     }

--- a/src/http/routing/route-registry.unit.test.ts
+++ b/src/http/routing/route-registry.unit.test.ts
@@ -216,7 +216,7 @@ describe('RouteRegistry', () => {
                     requestedVersion: 'v3',
                     supportedVersions: ['v1', 'v2'],
                 },
-                404,
+                410,
             );
             expect(result).toBe(
                 (
@@ -256,7 +256,7 @@ describe('RouteRegistry', () => {
                 expect.objectContaining({
                     supportedVersions: ['v1', 'v2', 'v3'],
                 }),
-                404,
+                410,
             );
         });
 

--- a/src/http/routing/route-registry.unit.test.ts
+++ b/src/http/routing/route-registry.unit.test.ts
@@ -180,7 +180,7 @@ describe('RouteRegistry', () => {
             expect(mockContext.json).not.toHaveBeenCalled();
         });
 
-        it('should return 404 with INVALID_VERSION when version does not match', async () => {
+        it('should return 410 with INVALID_VERSION when version does not match', async () => {
             const registration = {
                 method: 'GET' as const,
                 path: '/:version/test',

--- a/src/http/routing/route-registry.unit.test.ts
+++ b/src/http/routing/route-registry.unit.test.ts
@@ -1,0 +1,352 @@
+import type { MockedFunction } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AwilixContainer } from 'awilix';
+import type { Hono, MiddlewareHandler } from 'hono';
+
+import type { AppContext, HonoContextVariables } from '@/app';
+import { ROUTES_METADATA_KEY } from '../decorators/route.decorator';
+import { GhostRole } from '../middleware/role-guard';
+import { RouteRegistry } from './route-registry';
+
+// Mock types for Hono app methods
+type MockedHono = {
+    get: MockedFunction<(...args: unknown[]) => unknown>;
+    post: MockedFunction<(...args: unknown[]) => unknown>;
+    put: MockedFunction<(...args: unknown[]) => unknown>;
+    delete: MockedFunction<(...args: unknown[]) => unknown>;
+};
+
+// Mock type for Awilix container
+type MockedContainer = {
+    resolve: MockedFunction<(token: string) => unknown>;
+};
+
+describe('RouteRegistry', () => {
+    let routeRegistry: RouteRegistry;
+    let mockApp: MockedHono;
+    let mockContainer: MockedContainer;
+
+    beforeEach(() => {
+        routeRegistry = new RouteRegistry();
+        mockApp = {
+            get: vi.fn(),
+            post: vi.fn(),
+            put: vi.fn(),
+            delete: vi.fn(),
+        };
+        mockContainer = {
+            resolve: vi.fn(),
+        };
+    });
+
+    describe('registerRoute', () => {
+        it('should register a route', () => {
+            const registration = {
+                method: 'GET' as const,
+                path: '/test',
+                controllerToken: 'TestController',
+                methodName: 'testMethod',
+            };
+
+            routeRegistry.registerRoute(registration);
+
+            // Routes are private, so we'll test via mountRoutes
+            routeRegistry.mountRoutes(
+                mockApp as unknown as Hono<{ Variables: HonoContextVariables }>,
+                mockContainer as unknown as AwilixContainer,
+            );
+            expect(mockApp.get).toHaveBeenCalledWith(
+                '/test',
+                expect.any(Function),
+            );
+        });
+
+        it('should register a route with versions', () => {
+            const registration = {
+                method: 'GET' as const,
+                path: '/:version/test',
+                controllerToken: 'TestController',
+                methodName: 'testMethod',
+                versions: ['v1', 'v2'],
+            };
+
+            routeRegistry.registerRoute(registration);
+
+            routeRegistry.mountRoutes(
+                mockApp as unknown as Hono<{ Variables: HonoContextVariables }>,
+                mockContainer as unknown as AwilixContainer,
+            );
+            expect(mockApp.get).toHaveBeenCalled();
+            const call = mockApp.get.mock.calls[0];
+            expect(call[0]).toBe('/:version/test');
+            // Should have multiple middlewares when versions are specified
+            expect(call.length).toBeGreaterThan(2);
+        });
+    });
+
+    describe('registerController', () => {
+        it('should register all routes from controller metadata', () => {
+            const TestController = class {};
+            const routes = [
+                {
+                    method: 'GET',
+                    path: '/test1',
+                    methodName: 'method1',
+                },
+                {
+                    method: 'POST',
+                    path: '/:version/test2',
+                    methodName: 'method2',
+                    versions: ['v1', 'v2'],
+                },
+            ];
+
+            Reflect.defineMetadata(
+                ROUTES_METADATA_KEY,
+                routes,
+                TestController.prototype,
+            );
+
+            routeRegistry.registerController('TestController', TestController);
+            routeRegistry.mountRoutes(
+                mockApp as unknown as Hono<{ Variables: HonoContextVariables }>,
+                mockContainer as unknown as AwilixContainer,
+            );
+
+            expect(mockApp.get).toHaveBeenCalledWith(
+                '/test1',
+                expect.any(Function),
+            );
+            expect(mockApp.post).toHaveBeenCalled();
+            const postCall = mockApp.post.mock.calls[0];
+            expect(postCall[0]).toBe('/:version/test2');
+            // Should have at least 2 middlewares when versions are specified (version + controller)
+            expect(postCall.length).toBeGreaterThanOrEqual(2);
+        });
+    });
+
+    describe('version middleware', () => {
+        let mockContext: Partial<AppContext>;
+        let mockNext: MockedFunction<() => Promise<void>>;
+        let mockController: {
+            testMethod: MockedFunction<() => Promise<{ status: number }>>;
+        };
+
+        beforeEach(() => {
+            mockNext = vi.fn().mockResolvedValue(undefined);
+            mockController = {
+                testMethod: vi.fn().mockResolvedValue({ status: 200 }),
+            };
+            mockContainer.resolve = vi.fn().mockReturnValue(mockController);
+
+            mockContext = {
+                req: {
+                    param: vi.fn() as MockedFunction<(key: string) => string>,
+                } as unknown as AppContext['req'],
+                json: vi.fn().mockReturnValue({ status: 404 }),
+                get: vi.fn().mockReturnValue({ info: vi.fn(), error: vi.fn() }),
+            };
+        });
+
+        it('should allow request when version matches', async () => {
+            const registration = {
+                method: 'GET' as const,
+                path: '/:version/test',
+                controllerToken: 'TestController',
+                methodName: 'testMethod',
+                versions: ['v1', 'v2'],
+            };
+
+            routeRegistry.registerRoute(registration);
+            routeRegistry.mountRoutes(
+                mockApp as unknown as Hono<{ Variables: HonoContextVariables }>,
+                mockContainer as unknown as AwilixContainer,
+            );
+
+            // Get the middleware array from the first call
+            const callArgs = mockApp.get.mock.calls[0];
+            // Skip the path argument, the rest are middlewares
+            const middlewares = callArgs.slice(1);
+            const versionMiddleware = middlewares[0] as MiddlewareHandler;
+
+            (mockContext.req!.param as unknown as MockedFunction<
+                (key: string) => string
+            >) = vi.fn().mockReturnValue('v1');
+
+            await versionMiddleware(mockContext as AppContext, mockNext);
+
+            expect(mockNext).toHaveBeenCalled();
+            expect(mockContext.json).not.toHaveBeenCalled();
+        });
+
+        it('should return 404 with INVALID_VERSION when version does not match', async () => {
+            const registration = {
+                method: 'GET' as const,
+                path: '/:version/test',
+                controllerToken: 'TestController',
+                methodName: 'testMethod',
+                versions: ['v1', 'v2'],
+            };
+
+            routeRegistry.registerRoute(registration);
+            routeRegistry.mountRoutes(
+                mockApp as unknown as Hono<{ Variables: HonoContextVariables }>,
+                mockContainer as unknown as AwilixContainer,
+            );
+
+            const callArgs = mockApp.get.mock.calls[0];
+            const middlewares = callArgs.slice(1);
+            const versionMiddleware = middlewares[0] as MiddlewareHandler;
+
+            (mockContext.req!.param as unknown as MockedFunction<
+                (key: string) => string
+            >) = vi.fn().mockReturnValue('v3');
+
+            const result = await versionMiddleware(
+                mockContext as AppContext,
+                mockNext,
+            );
+
+            expect(mockNext).not.toHaveBeenCalled();
+            expect(mockContext.json).toHaveBeenCalledWith(
+                {
+                    message: 'Version v3 is not supported.',
+                    code: 'INVALID_VERSION',
+                    requestedVersion: 'v3',
+                    supportedVersions: ['v1', 'v2'],
+                },
+                404,
+            );
+            expect(result).toBe(
+                (
+                    mockContext.json as MockedFunction<
+                        (...args: unknown[]) => unknown
+                    >
+                ).mock.results[0].value,
+            );
+        });
+
+        it('should include supported versions in error response', async () => {
+            const registration = {
+                method: 'POST' as const,
+                path: '/:version/resource',
+                controllerToken: 'TestController',
+                methodName: 'testMethod',
+                versions: ['v1', 'v2', 'v3'],
+            };
+
+            routeRegistry.registerRoute(registration);
+            routeRegistry.mountRoutes(
+                mockApp as unknown as Hono<{ Variables: HonoContextVariables }>,
+                mockContainer as unknown as AwilixContainer,
+            );
+
+            const callArgs = mockApp.post.mock.calls[0];
+            const middlewares = callArgs.slice(1);
+            const versionMiddleware = middlewares[0] as MiddlewareHandler;
+
+            (mockContext.req!.param as unknown as MockedFunction<
+                (key: string) => string
+            >) = vi.fn().mockReturnValue('v4');
+
+            await versionMiddleware(mockContext as AppContext, mockNext);
+
+            expect(mockContext.json).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    supportedVersions: ['v1', 'v2', 'v3'],
+                }),
+                404,
+            );
+        });
+
+        it('should not add version middleware when versions array is empty', () => {
+            const registration = {
+                method: 'GET' as const,
+                path: '/test',
+                controllerToken: 'TestController',
+                methodName: 'testMethod',
+                versions: [],
+            };
+
+            routeRegistry.registerRoute(registration);
+            routeRegistry.mountRoutes(
+                mockApp as unknown as Hono<{ Variables: HonoContextVariables }>,
+                mockContainer as unknown as AwilixContainer,
+            );
+
+            // Should only have one middleware (the controller handler)
+            const middlewares = mockApp.get.mock.calls[0];
+            expect(middlewares.length).toBe(2); // path + handler
+        });
+
+        it('should not add version middleware when versions is undefined', () => {
+            const registration = {
+                method: 'GET' as const,
+                path: '/test',
+                controllerToken: 'TestController',
+                methodName: 'testMethod',
+            };
+
+            routeRegistry.registerRoute(registration);
+            routeRegistry.mountRoutes(
+                mockApp as unknown as Hono<{ Variables: HonoContextVariables }>,
+                mockContainer as unknown as AwilixContainer,
+            );
+
+            // Should only have one middleware (the controller handler)
+            const middlewares = mockApp.get.mock.calls[0];
+            expect(middlewares.length).toBe(2); // path + handler
+        });
+    });
+
+    describe('middleware ordering', () => {
+        it('should apply middlewares in correct order: version -> roles -> controller', async () => {
+            const registration = {
+                method: 'GET' as const,
+                path: '/:version/protected',
+                controllerToken: 'TestController',
+                methodName: 'testMethod',
+                versions: ['v1'],
+                requiredRoles: [GhostRole.Administrator],
+            };
+
+            const mockController = {
+                testMethod: vi.fn().mockResolvedValue({ status: 200 }),
+            };
+            mockContainer.resolve = vi.fn().mockReturnValue(mockController);
+
+            routeRegistry.registerRoute(registration);
+            routeRegistry.mountRoutes(
+                mockApp as unknown as Hono<{ Variables: HonoContextVariables }>,
+                mockContainer as unknown as AwilixContainer,
+            );
+
+            const middlewares = mockApp.get.mock.calls[0].slice(1);
+
+            // Should have 3 middlewares: version, role, controller
+            expect(middlewares.length).toBe(3);
+
+            // Test that version middleware is first by checking if it handles version param
+            const mockTestContext = {
+                req: {
+                    param: vi.fn().mockReturnValue('v1') as MockedFunction<
+                        (key: string) => string
+                    >,
+                },
+                json: vi.fn(),
+                get: vi.fn().mockReturnValue({ info: vi.fn(), error: vi.fn() }),
+            } as unknown as AppContext;
+            const mockTestNext = vi.fn();
+
+            // First middleware should be version check
+            const firstMiddleware = middlewares[0] as MiddlewareHandler;
+            await firstMiddleware(mockTestContext, mockTestNext);
+            expect(
+                mockTestContext.req.param as unknown as MockedFunction<
+                    (key: string) => string
+                >,
+            ).toHaveBeenCalledWith('version');
+        });
+    });
+});


### PR DESCRIPTION
ref https://github.com/TryGhost/ActivityPub/pull/1161
ref https://linear.app/ghost/issue/PROD-2441/

- Added two new stable API endpoints:
   - client-config (used by the admin)
   - notifications/unread/count (used by the admin)

- Updated the route decorators to handle versioning automatically:
    - If a request is made to an unsupported API version (e.g. request v1 but only v2 is registered), the response is a 410 with a JSON body containing an error code for "invalid version".
    - This will allow the frontend to display a version mismatch message

- Added new route decorator pattern:
    - One decorator per endpoint
    - If two versions must be supported in parallel, the decorator can take multiple versions as parameters, and the handler can branch internally on `ctx.req.param('version')`