### PR TITLE
Updated biome config schema ref

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
no ref

Updated biome config schema ref to reference the schema of the installed biome version rather than a static version. This allows us to automatically update biome via renovate without neededing to manually maintain this config