### PR TITLE
Fixed Redis KV store usage

### DIFF
--- a/dev/redis/start.sh
+++ b/dev/redis/start.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# This script starts Redis in cluster mode and initializes a single-node cluster
+
+set -e
+
+# The port to use for the Redis server
+PORT=6379
+
+# Get the container's hostname automatically
+HOSTNAME=$(hostname)
+
+echo "Starting Redis in cluster mode..."
+
+# Start Redis in cluster mode in the background
+redis-server --port ${PORT} --cluster-enabled yes --cluster-announce-ip ${HOSTNAME} --cluster-announce-port ${PORT} --daemonize yes
+
+# Wait for Redis to start
+sleep 3
+
+# Initialize cluster with all slots
+redis-cli -p ${PORT} cluster addslots $(seq 0 16383)
+echo "Redis cluster initialized successfully"
+
+# Stop the background Redis server
+redis-cli -p ${PORT} shutdown nosave
+sleep 1
+
+# Start Redis in foreground so Docker can manage the process
+echo "Starting Redis cluster in foreground..."
+exec redis-server --port ${PORT} --cluster-enabled yes --cluster-announce-ip ${HOSTNAME} --cluster-announce-port ${PORT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,8 @@ services:
       - LOCAL_STORAGE_PATH=/opt/activitypub/content
       # - LOCAL_STORAGE_HOSTING_URL=https://<tailscale-url>/.ghost/activitypub/local-storage
       # - GHOST_PRO_IP_ADDRESSES=100.83.192.90,192.168.65.1
-      - REDIS_HOST=redis-1
-      - REDIS_PORT=7000
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
       - FEDIFY_KV_STORE_TYPE=redis
     command: yarn build:watch
     depends_on:
@@ -41,8 +41,8 @@ services:
         condition: service_completed_successfully
       mysql:
         condition: service_healthy
-      redis-cluster-init:
-        condition: service_completed_successfully
+      redis:
+        condition: service_healthy
       pubsub:
         condition: service_healthy
       fake-gcs:
@@ -103,62 +103,17 @@ services:
       interval: 1s
       retries: 120
 
-  redis-1:
-    container_name: redis-1
+  redis:
     image: redis:7-alpine@sha256:bb186d083732f669da90be8b0f975a37812b15e913465bb14d845db72a4e3e08
-    command: redis-server --port 7000 --cluster-enabled yes --cluster-announce-ip redis-1 --cluster-announce-port 7000
+    volumes:
+      - ./dev/redis/start.sh:/usr/local/bin/start.sh
+    command: /usr/local/bin/start.sh
     ports:
-      - "7000:7000"
+      - "6379:6379"
     healthcheck:
-      test: ["CMD", "redis-cli", "-p", "7000", "ping"]
+      test: ["CMD", "redis-cli", "-p", "6379", "cluster", "info"]
       interval: 1s
       retries: 120
-
-  redis-2:
-    container_name: redis-2
-    image: redis:7-alpine@sha256:bb186d083732f669da90be8b0f975a37812b15e913465bb14d845db72a4e3e08
-    command: redis-server --port 7001 --cluster-enabled yes --cluster-announce-ip redis-2 --cluster-announce-port 7001
-    ports:
-      - "7001:7001"
-    healthcheck:
-      test: ["CMD", "redis-cli", "-p", "7001", "ping"]
-      interval: 1s
-      retries: 120
-
-  redis-3:
-    container_name: redis-3
-    image: redis:7-alpine@sha256:bb186d083732f669da90be8b0f975a37812b15e913465bb14d845db72a4e3e08
-    command: redis-server --port 7002 --cluster-enabled yes --cluster-announce-ip redis-3 --cluster-announce-port 7002
-    ports:
-      - "7002:7002"
-    healthcheck:
-      test: ["CMD", "redis-cli", "-p", "7002", "ping"]
-      interval: 1s
-      retries: 120
-
-  redis-cluster-init:
-    container_name: redis-cluster-init
-    image: redis:7-alpine@sha256:bb186d083732f669da90be8b0f975a37812b15e913465bb14d845db72a4e3e08
-    depends_on:
-      redis-1:
-        condition: service_healthy
-      redis-2:
-        condition: service_healthy
-      redis-3:
-        condition: service_healthy
-    restart: "no"
-    entrypoint: ["/bin/sh", "-c"]
-    command:
-      - |
-        sleep 10
-        if redis-cli -h redis-1 -p 7000 cluster info 2>/dev/null | grep -q 'cluster_state:ok'; then
-          echo "Cluster already initialized"
-        else
-          echo "Creating Redis cluster (3 nodes, no replicas)..."
-          echo "yes" | redis-cli --cluster create \
-            redis-1:7000 redis-2:7001 redis-3:7002 \
-            --cluster-replicas 0
-        fi
 
   pubsub:
     image: gcr.io/google.com/cloudsdktool/google-cloud-cli:499.0.0-emulators@sha256:38606e0ec8b892ff2be6fb7238c6b98e7b0b69f60ed433fa2b196bdf4646caf9
@@ -214,8 +169,8 @@ services:
       - GCS_LOCAL_STORAGE_HOSTING_URL=http://fake-gcs:4443/.ghost/activitypub/gcs
       - GCP_STORAGE_EMULATOR_HOST=http://fake-gcs:4443
       - ACTIVITYPUB_COLLECTION_PAGE_SIZE=2
-      - REDIS_HOST=redis-testing-1
-      - REDIS_PORT=7000
+      - REDIS_HOST=redis-testing
+      - REDIS_PORT=6379
       - FEDIFY_KV_STORE_TYPE=redis
     command: yarn build:watch
     depends_on:
@@ -223,8 +178,8 @@ services:
         condition: service_completed_successfully
       mysql-testing:
         condition: service_healthy
-      redis-testing-cluster-init:
-        condition: service_completed_successfully
+      redis-testing:
+        condition: service_healthy
       pubsub-testing:
         condition: service_healthy
       fake-gcs:
@@ -298,64 +253,17 @@ services:
       interval: 1s
       retries: 120
 
-  redis-testing-1:
+  redis-testing:
     networks:
       - test_network
-    container_name: redis-testing-1
     image: redis:7-alpine@sha256:bb186d083732f669da90be8b0f975a37812b15e913465bb14d845db72a4e3e08
-    command: redis-server --port 7000 --cluster-enabled yes --cluster-announce-ip redis-testing-1 --cluster-announce-port 7000
+    volumes:
+      - ./dev/redis/start.sh:/usr/local/bin/start.sh
+    command: /usr/local/bin/start.sh
     healthcheck:
-      test: ["CMD", "redis-cli", "-p", "7000", "ping"]
+      test: ["CMD", "redis-cli", "-p", "6379", "cluster", "info"]
       interval: 1s
       retries: 120
-
-  redis-testing-2:
-    networks:
-      - test_network
-    container_name: redis-testing-2
-    image: redis:7-alpine@sha256:bb186d083732f669da90be8b0f975a37812b15e913465bb14d845db72a4e3e08
-    command: redis-server --port 7001 --cluster-enabled yes --cluster-announce-ip redis-testing-2 --cluster-announce-port 7001
-    healthcheck:
-      test: ["CMD", "redis-cli", "-p", "7001", "ping"]
-      interval: 1s
-      retries: 120
-
-  redis-testing-3:
-    networks:
-      - test_network
-    container_name: redis-testing-3
-    image: redis:7-alpine@sha256:bb186d083732f669da90be8b0f975a37812b15e913465bb14d845db72a4e3e08
-    command: redis-server --port 7002 --cluster-enabled yes --cluster-announce-ip redis-testing-3 --cluster-announce-port 7002
-    healthcheck:
-      test: ["CMD", "redis-cli", "-p", "7002", "ping"]
-      interval: 1s
-      retries: 120
-
-  redis-testing-cluster-init:
-    networks:
-      - test_network
-    container_name: redis-testing-cluster-init
-    image: redis:7-alpine@sha256:bb186d083732f669da90be8b0f975a37812b15e913465bb14d845db72a4e3e08
-    depends_on:
-      redis-testing-1:
-        condition: service_healthy
-      redis-testing-2:
-        condition: service_healthy
-      redis-testing-3:
-        condition: service_healthy
-    restart: "no"
-    entrypoint: ["/bin/sh", "-c"]
-    command:
-      - |
-        sleep 10
-        if redis-cli -h redis-testing-1 -p 7000 cluster info 2>/dev/null | grep -q 'cluster_state:ok'; then
-          echo "Testing cluster already initialized"
-        else
-          echo "Creating Redis testing cluster (3 nodes, no replicas)..."
-          echo "yes" | redis-cli --cluster create \
-            redis-testing-1:7000 redis-testing-2:7001 redis-testing-3:7002 \
-            --cluster-replicas 0
-        fi
 
   pubsub-testing:
     networks:

--- a/src/app.ts
+++ b/src/app.ts
@@ -196,10 +196,11 @@ export type FedifyContext = Context<ContextData>;
 
 const globalFedify = container.resolve<Federation<ContextData>>('fedify');
 const globalFedifyKv = container.resolve<KvStore>('fedifyKv');
+const globalKv = container.resolve<KvStore>('kv');
 
 if (process.env.MANUALLY_START_QUEUE === 'true') {
     globalFedify.startQueue({
-        globaldb: globalFedifyKv,
+        globaldb: globalKv,
         logger: globalLogging,
     });
 }
@@ -242,7 +243,7 @@ function ensureCorrectContext<B, R>(
             (ctx as any).data = {};
         }
         if (!ctx.data.globaldb) {
-            ctx.data.globaldb = globalFedifyKv;
+            ctx.data.globaldb = globalKv;
         }
         if (!ctx.data.logger) {
             ctx.data.logger = globalLogging;
@@ -554,7 +555,7 @@ app.use(async (ctx, next) => {
 });
 
 app.use(async (ctx, next) => {
-    ctx.set('globaldb', globalFedifyKv);
+    ctx.set('globaldb', globalKv);
 
     return next();
 });

--- a/src/configuration/registrations.ts
+++ b/src/configuration/registrations.ts
@@ -157,7 +157,7 @@ export function registerDependencies(
 
             return knexKvStore;
         }).singleton(),
-        globalDb: asFunction((db: Knex, logging: Logger) => {
+        kv: asFunction((db: Knex, logging: Logger) => {
             return KnexKvStore.create(db, 'key_value', logging);
         }).singleton(),
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2439

Fixed Redis KV store usage so that only Fedify ephemeral data is stored in Redis and all other keys are stored in the mysql kv store

As part of this the confusing `globalDb` registration in `src/configuration/registrations.ts` was renamed to `kv` and used in `app.ts` wherever `globaldb` (notice the lowercase `d`) is used

The local Redis setup has also been simplified to use a single Redis node, but force it into cluster mode so we don't have to have different initiaialization logic in the app itself (in prod we have a valkey cluster)