### PR TITLE
Added API for Bluesky integration

### DIFF
--- a/features/step_definitions/activitypub_steps.js
+++ b/features/step_definitions/activitypub_steps.js
@@ -303,13 +303,19 @@ Then(
         const inbox = new URL(actor.inbox);
         const activity = this.activities[activityName];
 
-        const found = await waitForRequest('POST', inbox.pathname, (call) => {
-            const json = JSON.parse(call.request.body);
-            return (
-                json.type === activity.type &&
-                json.object.id === activity.object.id
-            );
-        });
+        const found = await waitForRequest(
+            'POST',
+            inbox.pathname,
+            (call) => {
+                const json = JSON.parse(call.request.body);
+                return (
+                    json.type === activity.type &&
+                    json.object.id === activity.object.id
+                );
+            },
+            5000,
+            200,
+        );
 
         assert(found);
     },

--- a/features/support/request.js
+++ b/features/support/request.js
@@ -40,8 +40,8 @@ export async function waitForRequest(
     method,
     path,
     matcher,
-    step = 100,
     milliseconds = 1000,
+    step = 100,
 ) {
     const externalActivityPub = getExternalWiremock();
 
@@ -58,5 +58,5 @@ export async function waitForRequest(
 
     await wait(step);
 
-    return waitForRequest(method, path, matcher, step, milliseconds - step);
+    return waitForRequest(method, path, matcher, milliseconds - step, step);
 }

--- a/migrate/migrations/000066_add-bluesky-integration-account-handles-table.down.sql
+++ b/migrate/migrations/000066_add-bluesky-integration-account-handles-table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS bluesky_integration_account_handles;

--- a/migrate/migrations/000066_add-bluesky-integration-account-handles-table.up.sql
+++ b/migrate/migrations/000066_add-bluesky-integration-account-handles-table.up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE bluesky_integration_account_handles (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    created_at TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+    account_id INT UNSIGNED NOT NULL,
+    handle VARCHAR(255) NOT NULL,
+
+    UNIQUE KEY idx_bluesky_integration_account_handles_account (account_id),
+    UNIQUE KEY idx_bluesky_integration_account_handles_handle (handle),
+
+    CONSTRAINT fk_bluesky_integration_account_handles_account
+        FOREIGN KEY (account_id) REFERENCES accounts(id)
+        ON DELETE CASCADE
+);

--- a/src/app.ts
+++ b/src/app.ts
@@ -77,6 +77,7 @@ import type { GhostPostService } from '@/ghost/ghost-post.service';
 import { getTraceContext } from '@/helpers/context-header';
 import { AccountController } from '@/http/api/account.controller';
 import { BlockController } from '@/http/api/block.controller';
+import { BlueskyController } from '@/http/api/bluesky.controller';
 import { ClientConfigController } from '@/http/api/client-config.controller';
 import { FeedController } from '@/http/api/feed.controller';
 import { FollowController } from '@/http/api/follow.controller';
@@ -97,6 +98,7 @@ import {
 } from '@/http/middleware/role-guard';
 import { RouteRegistry } from '@/http/routing/route-registry';
 import { setupInstrumentation, spanWrapper } from '@/instrumentation';
+import type { BlueskyService } from '@/integration/bluesky.service';
 import {
     createPushMessageHandler,
     type GCloudPubSubPushMessageQueue,
@@ -207,20 +209,15 @@ if (process.env.MANUALLY_START_QUEUE === 'true') {
 }
 
 // Initialize services that need it
+container.resolve<BlueskyService>('blueskyService').init();
 container.resolve<FediverseBridge>('fediverseBridge').init();
-
 container.resolve<FeedUpdateService>('feedUpdateService').init();
-
 container.resolve<NotificationEventService>('notificationEventService').init();
-
 container.resolve<GhostExploreService>('ghostExploreService').init();
-
 container.resolve<GhostPostService>('ghostPostService').init();
-
 container
     .resolve<PostInteractionCountsService>('postInteractionCountsService')
     .init();
-
 container
     .resolve<EventSerializer>('eventSerializer')
     .register(
@@ -885,6 +882,7 @@ routeRegistry.registerController(
     'clientConfigController',
     ClientConfigController,
 );
+routeRegistry.registerController('blueskyController', BlueskyController);
 
 // Mount all registered routes
 routeRegistry.mountRoutes(app, container);

--- a/src/configuration/registrations.ts
+++ b/src/configuration/registrations.ts
@@ -48,6 +48,7 @@ import { GhostPostService } from '@/ghost/ghost-post.service';
 import { getSiteSettings } from '@/helpers/ghost';
 import { AccountController } from '@/http/api/account.controller';
 import { BlockController } from '@/http/api/block.controller';
+import { BlueskyController } from '@/http/api/bluesky.controller';
 import { ClientConfigController } from '@/http/api/client-config.controller';
 import { FeedController } from '@/http/api/feed.controller';
 import { FollowController } from '@/http/api/follow.controller';
@@ -65,6 +66,7 @@ import { BlocksView } from '@/http/api/views/blocks.view';
 import { ReplyChainView } from '@/http/api/views/reply.chain.view';
 import { WebFingerController } from '@/http/api/webfinger.controller';
 import { WebhookController } from '@/http/api/webhook.controller';
+import { BlueskyService } from '@/integration/bluesky.service';
 import { KnexKvStore } from '@/knex.kvstore';
 import { ModerationService } from '@/moderation/moderation.service';
 import { GCloudPubSubPushMessageQueue } from '@/mq/gcloud-pubsub-push/mq';
@@ -332,6 +334,7 @@ export function registerDependencies(
         'ghostExploreService',
         asClass(GhostExploreService).singleton(),
     );
+    container.register('blueskyService', asClass(BlueskyService).singleton());
 
     container.register('accountView', asClass(AccountView).singleton());
     container.register(
@@ -480,4 +483,9 @@ export function registerDependencies(
     );
 
     container.register('postController', asClass(PostController).singleton());
+
+    container.register(
+        'blueskyController',
+        asClass(BlueskyController).singleton(),
+    );
 }

--- a/src/http/api/bluesky.controller.ts
+++ b/src/http/api/bluesky.controller.ts
@@ -1,5 +1,5 @@
 import type { AppContext } from '@/app';
-import { InternalServerError, Ok } from '@/http/api/helpers/response';
+import { InternalServerError } from '@/http/api/helpers/response';
 import { RequireRoles, Route } from '@/http/decorators/route.decorator';
 import { GhostRole } from '@/http/middleware/role-guard';
 import type { BlueskyService } from '@/integration/bluesky.service';
@@ -48,6 +48,11 @@ export class BlueskyController {
             return InternalServerError('Failed to disable Bluesky integration');
         }
 
-        return Ok();
+        return new Response(null, {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            status: 204,
+        });
     }
 }

--- a/src/http/api/bluesky.controller.ts
+++ b/src/http/api/bluesky.controller.ts
@@ -1,0 +1,47 @@
+import type { AppContext } from '@/app';
+import { InternalServerError, Ok } from '@/http/api/helpers/response';
+import { RequireRoles, Route } from '@/http/decorators/route.decorator';
+import { GhostRole } from '@/http/middleware/role-guard';
+import type { BlueskyService } from '@/integration/bluesky.service';
+
+export class BlueskyController {
+    constructor(private readonly blueskyService: BlueskyService) {}
+
+    @Route('POST', '/.ghost/activitypub/v1/actions/bluesky/enable')
+    @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
+    async handleEnable(ctx: AppContext) {
+        const account = ctx.get('account');
+        const logger = ctx.get('logger');
+
+        try {
+            await this.blueskyService.enableForAccount(account);
+        } catch (error) {
+            logger.error('Failed to enable Bluesky integration', {
+                error,
+            });
+
+            return InternalServerError('Failed to enable Bluesky integration');
+        }
+
+        return Ok();
+    }
+
+    @Route('POST', '/.ghost/activitypub/v1/actions/bluesky/disable')
+    @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
+    async handleDisable(ctx: AppContext) {
+        const account = ctx.get('account');
+        const logger = ctx.get('logger');
+
+        try {
+            await this.blueskyService.disableForAccount(account);
+        } catch (error) {
+            logger.error('Failed to disable Bluesky integration', {
+                error,
+            });
+
+            return InternalServerError('Failed to disable Bluesky integration');
+        }
+
+        return Ok();
+    }
+}

--- a/src/http/api/bluesky.controller.ts
+++ b/src/http/api/bluesky.controller.ts
@@ -13,8 +13,10 @@ export class BlueskyController {
         const account = ctx.get('account');
         const logger = ctx.get('logger');
 
+        let handle: string;
+
         try {
-            await this.blueskyService.enableForAccount(account);
+            handle = await this.blueskyService.enableForAccount(account);
         } catch (error) {
             logger.error('Failed to enable Bluesky integration', {
                 error,
@@ -23,7 +25,11 @@ export class BlueskyController {
             return InternalServerError('Failed to enable Bluesky integration');
         }
 
-        return Ok();
+        return new Response(JSON.stringify({ handle }), {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
     }
 
     @Route('POST', '/.ghost/activitypub/v1/actions/bluesky/disable')

--- a/src/http/api/bluesky.controller.unit.test.ts
+++ b/src/http/api/bluesky.controller.unit.test.ts
@@ -32,7 +32,9 @@ describe('BlueskyController', () => {
         } as unknown as AppContext;
 
         blueskyService = {
-            enableForAccount: vi.fn().mockResolvedValue(undefined),
+            enableForAccount: vi
+                .fn()
+                .mockResolvedValue('@index.example.com.ap.brid.gy'),
             disableForAccount: vi.fn().mockResolvedValue(undefined),
         } as unknown as BlueskyService;
 
@@ -43,11 +45,11 @@ describe('BlueskyController', () => {
         it('should enable the Bluesky integration for the account associated with the request user', async () => {
             const result = await controller.handleEnable(ctx);
 
-            expect(blueskyService.enableForAccount).toHaveBeenCalledWith(
-                account,
-            );
             expect(result.status).toBe(200);
-            expect(result.body).toBe(null);
+
+            const body = await result.json();
+
+            expect(body.handle).toBe('@index.example.com.ap.brid.gy');
         });
 
         it('should return 500 if an error occurs', async () => {
@@ -76,7 +78,7 @@ describe('BlueskyController', () => {
             expect(blueskyService.disableForAccount).toHaveBeenCalledWith(
                 account,
             );
-            expect(result.status).toBe(200);
+            expect(result.status).toBe(204);
             expect(result.body).toBe(null);
         });
 

--- a/src/http/api/bluesky.controller.unit.test.ts
+++ b/src/http/api/bluesky.controller.unit.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Account } from '@/account/account.entity';
+import type { AppContext } from '@/app';
+import { BlueskyController } from '@/http/api/bluesky.controller';
+import type { BlueskyService } from '@/integration/bluesky.service';
+
+describe('BlueskyController', () => {
+    let account: Account;
+    let ctx: AppContext;
+    let blueskyService: BlueskyService;
+    let controller: BlueskyController;
+
+    beforeEach(() => {
+        account = {
+            id: 1,
+        } as unknown as Account;
+
+        ctx = {
+            get: (key: string) => {
+                if (key === 'account') {
+                    return account;
+                }
+
+                if (key === 'logger') {
+                    return {
+                        error: vi.fn(),
+                    };
+                }
+                return null;
+            },
+        } as unknown as AppContext;
+
+        blueskyService = {
+            enableForAccount: vi.fn().mockResolvedValue(undefined),
+            disableForAccount: vi.fn().mockResolvedValue(undefined),
+        } as unknown as BlueskyService;
+
+        controller = new BlueskyController(blueskyService);
+    });
+
+    describe('handleEnable', () => {
+        it('should enable the Bluesky integration for the account associated with the request user', async () => {
+            const result = await controller.handleEnable(ctx);
+
+            expect(blueskyService.enableForAccount).toHaveBeenCalledWith(
+                account,
+            );
+            expect(result.status).toBe(200);
+            expect(result.body).toBe(null);
+        });
+
+        it('should return 500 if an error occurs', async () => {
+            const error = new Error('Something went wrong');
+
+            vi.mocked(blueskyService.enableForAccount).mockRejectedValue(error);
+
+            const result = await controller.handleEnable(ctx);
+
+            expect(blueskyService.enableForAccount).toHaveBeenCalledWith(
+                account,
+            );
+
+            expect(result.status).toBe(500);
+
+            const body = await result.json();
+
+            expect(body.message).toBe('Failed to enable Bluesky integration');
+        });
+    });
+
+    describe('handleDisable', () => {
+        it('should disable the Bluesky integration for the account associated with the request user', async () => {
+            const result = await controller.handleDisable(ctx);
+
+            expect(blueskyService.disableForAccount).toHaveBeenCalledWith(
+                account,
+            );
+            expect(result.status).toBe(200);
+            expect(result.body).toBe(null);
+        });
+
+        it('should return 500 if an error occurs', async () => {
+            const error = new Error('Something went wrong');
+
+            vi.mocked(blueskyService.disableForAccount).mockRejectedValue(
+                error,
+            );
+
+            const result = await controller.handleDisable(ctx);
+
+            expect(blueskyService.disableForAccount).toHaveBeenCalledWith(
+                account,
+            );
+
+            expect(result.status).toBe(500);
+
+            const body = await result.json();
+
+            expect(body.message).toBe('Failed to disable Bluesky integration');
+        });
+    });
+});

--- a/src/http/api/helpers/response.ts
+++ b/src/http/api/helpers/response.ts
@@ -1,5 +1,7 @@
-function jsonResponse(message: string, status: number) {
-    return new Response(JSON.stringify({ message }), {
+function jsonResponse(message: string | null, status: number) {
+    const body = message ? JSON.stringify({ message }) : null;
+
+    return new Response(body, {
         headers: {
             'Content-Type': 'application/json',
         },
@@ -7,7 +9,10 @@ function jsonResponse(message: string, status: number) {
     });
 }
 
+export const Ok = (message: string | null = null) => jsonResponse(message, 200);
 export const BadRequest = (message: string) => jsonResponse(message, 400);
 export const Forbidden = (message: string) => jsonResponse(message, 403);
 export const NotFound = (message: string) => jsonResponse(message, 404);
 export const Conflict = (message: string) => jsonResponse(message, 409);
+export const InternalServerError = (message: string) =>
+    jsonResponse(message, 500);

--- a/src/http/api/helpers/response.ts
+++ b/src/http/api/helpers/response.ts
@@ -1,4 +1,4 @@
-function jsonResponse(message: string | null, status: number) {
+function jsonResponse(message: string, status: number) {
     const body = message ? JSON.stringify({ message }) : null;
 
     return new Response(body, {
@@ -9,7 +9,6 @@ function jsonResponse(message: string | null, status: number) {
     });
 }
 
-export const Ok = (message: string | null = null) => jsonResponse(message, 200);
 export const BadRequest = (message: string) => jsonResponse(message, 400);
 export const Forbidden = (message: string) => jsonResponse(message, 403);
 export const NotFound = (message: string) => jsonResponse(message, 404);

--- a/src/http/api/types.ts
+++ b/src/http/api/types.ts
@@ -85,6 +85,20 @@ export interface AccountDTO extends Omit<MinimalAccountDTO, 'isFollowing'> {
     followsMe: boolean;
 }
 
+/**
+ * Account returned by the API with Bluesky integration details included
+ */
+export interface AccountDTOWithBluesky extends AccountDTO {
+    /**
+     * Whether the account has the Bluesky integration enabled
+     */
+    blueskyEnabled: boolean;
+    /**
+     * Handle of the Bluesky account (if enabled)
+     */
+    blueskyHandle: string | null;
+}
+
 export type AuthorDTO = Pick<
     AccountDTO,
     'id' | 'handle' | 'avatarUrl' | 'name' | 'url' | 'followedByMe'

--- a/src/integration/bluesky.service.integration.test.ts
+++ b/src/integration/bluesky.service.integration.test.ts
@@ -1,0 +1,327 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Create, Follow, Note, Undo } from '@fedify/fedify';
+import { Temporal } from '@js-temporal/polyfill';
+import type { Logger } from '@logtape/logtape';
+import type { Knex } from 'knex';
+
+import type { Account } from '@/account/account.entity';
+import { KnexAccountRepository } from '@/account/account.repository.knex';
+import { AccountService } from '@/account/account.service';
+import { AccountFollowedEvent } from '@/account/events';
+import { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
+import type { FedifyContext } from '@/app';
+import { AsyncEvents } from '@/core/events';
+import { error, ok } from '@/core/result';
+import { BlueskyService, BRIDGY_AP_ID } from '@/integration/bluesky.service';
+import { generateTestCryptoKeyPair } from '@/test/crypto-key-pair';
+import { createTestDb } from '@/test/db';
+import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
+
+describe('BlueskyService', () => {
+    let client: Knex;
+    let events: AsyncEvents;
+    let fixtureManager: FixtureManager;
+    let fedifyContext: FedifyContext;
+    let fedifyContextFactory: FedifyContextFactory;
+    let logger: Logger;
+    let accountService: AccountService;
+    let blueskyService: BlueskyService;
+
+    const bridgyAccount = {
+        id: 123,
+        apId: BRIDGY_AP_ID,
+        apInbox: new URL(`${BRIDGY_AP_ID.href}/inbox`),
+    } as Account;
+
+    beforeAll(async () => {
+        client = await createTestDb();
+        events = new AsyncEvents();
+        fixtureManager = createFixtureManager(client, events);
+    });
+
+    beforeEach(async () => {
+        await fixtureManager.reset();
+
+        const accountRepository = new KnexAccountRepository(client, events);
+
+        fedifyContext = {
+            sendActivity: vi.fn().mockResolvedValue(undefined),
+            getObjectUri: (type: { name: string }, { id }: { id: string }) =>
+                new URL(`https://example.com/${type.name.toLowerCase()}/${id}`),
+            data: {
+                globaldb: {
+                    set: vi.fn().mockResolvedValue(undefined),
+                },
+            },
+        } as unknown as FedifyContext;
+
+        fedifyContextFactory = new FedifyContextFactory();
+
+        fedifyContextFactory.getFedifyContext = vi
+            .fn()
+            .mockReturnValue(fedifyContext);
+
+        logger = {
+            info: vi.fn(),
+            error: vi.fn(),
+        } as unknown as Logger;
+
+        accountService = new AccountService(
+            client,
+            events,
+            accountRepository,
+            fedifyContextFactory,
+            generateTestCryptoKeyPair,
+        );
+
+        accountService.ensureByApId = vi
+            .fn()
+            .mockImplementation(async (url: URL) => {
+                if (url.href === BRIDGY_AP_ID.href) {
+                    return ok(bridgyAccount);
+                }
+
+                return error(
+                    new Error(`Unexpected ensureByApId call with ${url.href}`),
+                );
+            });
+
+        blueskyService = new BlueskyService(
+            client,
+            accountService,
+            accountRepository,
+            events,
+            fedifyContextFactory,
+            logger,
+        );
+
+        blueskyService.init();
+
+        vi.clearAllMocks();
+    });
+
+    describe('enableForAccount', () => {
+        it('should send a follow request to brid.gy', async () => {
+            const [account] = await fixtureManager.createInternalAccount();
+
+            await blueskyService.enableForAccount(account);
+
+            // Verify sendActivity was called with the expected arguments
+            expect(fedifyContext.sendActivity).toHaveBeenCalledTimes(1);
+            expect(fedifyContext.sendActivity).toHaveBeenCalledWith(
+                { username: account.username },
+                {
+                    id: bridgyAccount.apId,
+                    inboxId: bridgyAccount.apInbox,
+                },
+                expect.any(Follow),
+            );
+
+            // Verify the Follow activity is correct
+            const followActivity = vi.mocked(fedifyContext.sendActivity).mock
+                .calls[0][2];
+            expect(followActivity).toBeInstanceOf(Follow);
+            expect(followActivity.id).toBeInstanceOf(URL);
+            expect(followActivity.id!.href).toContain('/follow/');
+            expect(followActivity.actorId).toEqual(account.apId);
+            expect(followActivity.objectId).toEqual(BRIDGY_AP_ID);
+
+            // Verify the Follow activity was stored in the globaldb
+            expect(fedifyContext.data.globaldb.set).toHaveBeenCalledTimes(1);
+            expect(fedifyContext.data.globaldb.set).toHaveBeenCalledWith(
+                [followActivity.id!.href],
+                await followActivity.toJsonLd(),
+            );
+
+            // Verify no handle mapping was created (this happens when Bridgy follows back)
+            const handleMapping = await client(
+                'bluesky_integration_account_handles',
+            )
+                .where('account_id', account.id)
+                .first();
+
+            expect(handleMapping).toBeUndefined();
+        });
+
+        it('should not send a follow request to brid.gy if the Bluesky integration is already enabled for the account', async () => {
+            const [account] = await fixtureManager.createInternalAccount();
+
+            await fixtureManager.enableBlueskyIntegration(account);
+
+            await blueskyService.enableForAccount(account);
+
+            expect(fedifyContext.sendActivity).not.toHaveBeenCalled();
+            expect(fedifyContext.data.globaldb.set).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Handling Account Followed Event', () => {
+        it('should create a handle mapping when brid.gy accepts a follow request', async () => {
+            const [account] = await fixtureManager.createInternalAccount();
+
+            await events.emitAsync(
+                AccountFollowedEvent.getName(),
+                new AccountFollowedEvent(bridgyAccount.id, account.id),
+            );
+
+            const handleMapping = await client(
+                'bluesky_integration_account_handles',
+            )
+                .where('account_id', account.id)
+                .first();
+
+            expect(handleMapping).toBeDefined();
+            expect(handleMapping.handle).toBe(
+                `@${account.username}.${account.url.hostname}.ap.brid.gy`,
+            );
+        });
+
+        it('should not create a handle mapping when the account followed is not brid.gy', async () => {
+            const [account] = await fixtureManager.createInternalAccount();
+            const [otherAccount] = await fixtureManager.createInternalAccount();
+
+            await events.emitAsync(
+                AccountFollowedEvent.getName(),
+                new AccountFollowedEvent(otherAccount.id, account.id),
+            );
+
+            const handleMapping = await client(
+                'bluesky_integration_account_handles',
+            )
+                .where('account_id', account.id)
+                .first();
+
+            expect(handleMapping).toBeUndefined();
+        });
+
+        it('should ensure the correct handle is used when the follower has a www. in their hostname', async () => {
+            const site = await fixtureManager.createSite('www.example.com');
+            const [account] = await fixtureManager.createInternalAccount(site);
+
+            await events.emitAsync(
+                AccountFollowedEvent.getName(),
+                new AccountFollowedEvent(bridgyAccount.id, account.id),
+            );
+
+            const handleMapping = await client(
+                'bluesky_integration_account_handles',
+            )
+                .where('account_id', account.id)
+                .first();
+
+            expect(handleMapping).toBeDefined();
+            expect(handleMapping.handle).toBe(
+                `@${account.username}.${account.url.hostname.replace(/^www\./i, '')}.ap.brid.gy`,
+            );
+        });
+    });
+
+    describe('disableForAccount', () => {
+        it('should send a stop message, unfollow brid.gy, and delete the handle mapping', async () => {
+            const [account] = await fixtureManager.createInternalAccount();
+
+            await fixtureManager.enableBlueskyIntegration(account);
+
+            await blueskyService.disableForAccount(account);
+
+            // Verify sendActivity was called twice (once for DM, once for unfollow)
+            expect(fedifyContext.sendActivity).toHaveBeenCalledTimes(2);
+
+            // Verify the first call sends a Create activity with a Note containing "stop"
+            expect(fedifyContext.sendActivity).toHaveBeenNthCalledWith(
+                1,
+                { username: account.username },
+                {
+                    id: bridgyAccount.apId,
+                    inboxId: bridgyAccount.apInbox,
+                },
+                expect.any(Create),
+            );
+
+            // Verify the Create activity structure
+            const createActivity = vi.mocked(fedifyContext.sendActivity).mock
+                .calls[0][2];
+            expect(createActivity).toBeInstanceOf(Create);
+            expect(createActivity.id).toBeInstanceOf(URL);
+            expect(createActivity.id!.href).toContain('/create/');
+            expect(createActivity.actorId).toEqual(account.apId);
+            expect(createActivity.toId).toEqual(bridgyAccount.apId);
+
+            const createActivityObject = await createActivity.getObject();
+            expect(createActivityObject).toBeInstanceOf(Note);
+            expect(createActivityObject!.id).toBeInstanceOf(URL);
+            expect(createActivityObject!.id!.href).toContain('/note/');
+            expect(createActivityObject!.attributionId).toEqual(account.apId);
+            expect(createActivityObject!.content).toBe('stop');
+            expect(createActivityObject!.published).toBeInstanceOf(
+                Temporal.Instant,
+            );
+            expect(createActivityObject!.toId).toEqual(bridgyAccount.apId);
+
+            // Verify the second call sends an Undo activity for the Follow
+            expect(fedifyContext.sendActivity).toHaveBeenNthCalledWith(
+                2,
+                { username: account.username },
+                {
+                    id: bridgyAccount.apId,
+                    inboxId: bridgyAccount.apInbox,
+                },
+                expect.any(Undo),
+            );
+
+            // Verify the Undo activity structure
+            const undoActivity = vi.mocked(fedifyContext.sendActivity).mock
+                .calls[1][2];
+            expect(undoActivity).toBeInstanceOf(Undo);
+            expect(undoActivity.id).toBeInstanceOf(URL);
+            expect(undoActivity.id!.href).toContain('/undo/');
+            expect(undoActivity.actorId).toEqual(account.apId);
+
+            const undoActivityObject = await undoActivity.getObject();
+            expect(undoActivityObject).toBeInstanceOf(Follow);
+            expect(undoActivityObject!.id).toBeNull();
+            expect((undoActivityObject as Follow).actorId).toEqual(
+                account.apId,
+            );
+            expect((undoActivityObject as Follow).objectId).toEqual(
+                bridgyAccount.apId,
+            );
+
+            // Verify activities were stored in globaldb (Note, Create, Undo)
+            expect(fedifyContext.data.globaldb.set).toHaveBeenCalledTimes(3);
+
+            // Verify each activity was stored with its ID
+            expect(fedifyContext.data.globaldb.set).toHaveBeenCalledWith(
+                [createActivityObject!.id!.href],
+                await createActivityObject!.toJsonLd(),
+            );
+            expect(fedifyContext.data.globaldb.set).toHaveBeenCalledWith(
+                [createActivity.id!.href],
+                await createActivity!.toJsonLd(),
+            );
+            expect(fedifyContext.data.globaldb.set).toHaveBeenCalledWith(
+                [undoActivity.id!.href],
+                await undoActivity.toJsonLd(),
+            );
+
+            // Verify the handle mapping was deleted
+            const handleMappingPostDisable = await client(
+                'bluesky_integration_account_handles',
+            )
+                .where('account_id', account.id)
+                .first();
+
+            expect(handleMappingPostDisable).toBeUndefined();
+        });
+
+        it('should do nothing if the Bluesky integration is already disabled for the account', async () => {
+            const [account] = await fixtureManager.createInternalAccount();
+
+            await blueskyService.disableForAccount(account);
+
+            expect(fedifyContext.sendActivity).not.toHaveBeenCalled();
+            expect(fedifyContext.data.globaldb.set).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/integration/bluesky.service.integration.test.ts
+++ b/src/integration/bluesky.service.integration.test.ts
@@ -194,27 +194,6 @@ describe('BlueskyService', () => {
 
             expect(handleMapping).toBeUndefined();
         });
-
-        it('should ensure the correct handle is used when the follower has a www. in their hostname', async () => {
-            const site = await fixtureManager.createSite('www.example.com');
-            const [account] = await fixtureManager.createInternalAccount(site);
-
-            await events.emitAsync(
-                AccountFollowedEvent.getName(),
-                new AccountFollowedEvent(bridgyAccount.id, account.id),
-            );
-
-            const handleMapping = await client(
-                'bluesky_integration_account_handles',
-            )
-                .where('account_id', account.id)
-                .first();
-
-            expect(handleMapping).toBeDefined();
-            expect(handleMapping.handle).toBe(
-                `@${account.username}.${account.url.hostname.replace(/^www\./i, '')}.ap.brid.gy`,
-            );
-        });
     });
 
     describe('disableForAccount', () => {

--- a/src/integration/bluesky.service.integration.test.ts
+++ b/src/integration/bluesky.service.integration.test.ts
@@ -154,6 +154,16 @@ describe('BlueskyService', () => {
             expect(fedifyContext.sendActivity).not.toHaveBeenCalled();
             expect(fedifyContext.data.globaldb.set).not.toHaveBeenCalled();
         });
+
+        it('should return the handle for the account', async () => {
+            const [account] = await fixtureManager.createInternalAccount();
+
+            const handle = await blueskyService.enableForAccount(account);
+
+            expect(handle).toBe(
+                `@${account.username}.${account.apId.hostname}.ap.brid.gy`,
+            );
+        });
     });
 
     describe('Handling Account Followed Event', () => {
@@ -173,7 +183,7 @@ describe('BlueskyService', () => {
 
             expect(handleMapping).toBeDefined();
             expect(handleMapping.handle).toBe(
-                `@${account.username}.${account.url.hostname}.ap.brid.gy`,
+                `@${account.username}.${account.apId.hostname}.ap.brid.gy`,
             );
         });
 

--- a/src/integration/bluesky.service.integration.test.ts
+++ b/src/integration/bluesky.service.integration.test.ts
@@ -43,6 +43,8 @@ describe('BlueskyService', () => {
     beforeEach(async () => {
         await fixtureManager.reset();
 
+        events.removeAllListeners();
+
         const accountRepository = new KnexAccountRepository(client, events);
 
         fedifyContext = {

--- a/src/integration/bluesky.service.ts
+++ b/src/integration/bluesky.service.ts
@@ -179,9 +179,7 @@ export class BlueskyService {
     }
 
     private getHandleForAccount(account: Account) {
-        const host = account.url.hostname.replace(/^www\./i, '');
-
-        return `@${account.username}.${host}.ap.brid.gy`;
+        return `@${account.username}.${account.url.hostname}.ap.brid.gy`;
     }
 
     private async getBridgyAccount() {

--- a/src/integration/bluesky.service.ts
+++ b/src/integration/bluesky.service.ts
@@ -1,0 +1,205 @@
+import { Create, Follow, Note, Undo } from '@fedify/fedify';
+import { Temporal } from '@js-temporal/polyfill';
+import type { Logger } from '@logtape/logtape';
+import type { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+
+import type { Account } from '@/account/account.entity';
+import type { KnexAccountRepository } from '@/account/account.repository.knex';
+import type { AccountService } from '@/account/account.service';
+import { AccountFollowedEvent } from '@/account/events';
+import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
+import type { AsyncEvents } from '@/core/events';
+import { getValue, isError } from '@/core/result';
+
+/**
+ * @see https://fed.brid.gy/docs
+ */
+
+export const BRIDGY_AP_ID = new URL('https://bsky.brid.gy/bsky.brid.gy');
+
+export class BlueskyService {
+    constructor(
+        private readonly db: Knex,
+        private readonly accountService: AccountService,
+        private readonly accountRepository: KnexAccountRepository,
+        private readonly events: AsyncEvents,
+        private readonly fedifyContextFactory: FedifyContextFactory,
+        private readonly logger: Logger,
+    ) {}
+
+    init() {
+        this.events.on(
+            AccountFollowedEvent.getName(),
+            this.handleAccountFollowed.bind(this),
+        );
+    }
+
+    async enableForAccount(account: Account) {
+        if (await this.isEnabledForAccount(account)) {
+            this.logger.info(
+                `Bluesky integration already enabled for account {id}`,
+                { id: account.id },
+            );
+
+            return;
+        }
+
+        const bridgyAccount = await this.getBridgyAccount();
+
+        // Send follow request to brid.gy account
+        const ctx = this.fedifyContextFactory.getFedifyContext();
+
+        const followId = ctx.getObjectUri(Follow, { id: uuidv4() });
+
+        const follow = new Follow({
+            id: followId,
+            actor: account.apId,
+            object: bridgyAccount.apId,
+        });
+
+        await ctx.data.globaldb.set([follow.id!.href], await follow.toJsonLd());
+
+        await ctx.sendActivity(
+            { username: account.username },
+            {
+                id: bridgyAccount.apId,
+                inboxId: bridgyAccount.apInbox,
+            },
+            follow,
+        );
+    }
+
+    async disableForAccount(account: Account) {
+        if (!(await this.isEnabledForAccount(account))) {
+            this.logger.info(
+                `Bluesky integration already disabled for account {id}`,
+                { id: account.id },
+            );
+
+            return;
+        }
+
+        const bridgyAccount = await this.getBridgyAccount();
+
+        const ctx = this.fedifyContextFactory.getFedifyContext();
+
+        // Send "stop" dm to brid.gy account
+        const note = new Note({
+            id: ctx.getObjectUri(Note, { id: uuidv4() }),
+            attribution: account.apId,
+            content: 'stop',
+            published: Temporal.Now.instant(),
+            to: bridgyAccount.apId,
+        });
+
+        const create = new Create({
+            id: ctx.getObjectUri(Create, { id: uuidv4() }),
+            actor: account.apId,
+            object: note,
+            to: bridgyAccount.apId,
+        });
+
+        await ctx.data.globaldb.set([note.id!.href], await note.toJsonLd());
+        await ctx.data.globaldb.set([create.id!.href], await create.toJsonLd());
+
+        await ctx.sendActivity(
+            { username: account.username },
+            {
+                id: bridgyAccount.apId,
+                inboxId: bridgyAccount.apInbox,
+            },
+            create,
+        );
+
+        // Unfollow brid.gy account
+        await this.accountRepository.save(account.unfollow(bridgyAccount));
+
+        const follow = new Follow({
+            id: null,
+            actor: account.apId,
+            object: bridgyAccount.apId,
+        });
+
+        const undoId = ctx.getObjectUri(Undo, { id: uuidv4() });
+
+        const undo = new Undo({
+            id: undoId,
+            actor: account.apId,
+            object: follow,
+        });
+
+        await ctx.data.globaldb.set([undo.id!.href], await undo.toJsonLd());
+
+        await ctx.sendActivity(
+            { username: account.username },
+            {
+                id: bridgyAccount.apId,
+                inboxId: bridgyAccount.apInbox,
+            },
+            undo,
+        );
+
+        // Delete handle → account mapping from the database
+        await this.db('bluesky_integration_account_handles')
+            .where('account_id', account.id)
+            .delete();
+    }
+
+    private async handleAccountFollowed(event: AccountFollowedEvent) {
+        const bridgyAccount = await this.getBridgyAccount();
+
+        if (event.getAccountId() !== bridgyAccount.id) {
+            return;
+        }
+
+        const followerAccount = await this.accountService.getAccountById(
+            event.getFollowerId(),
+        );
+
+        if (!followerAccount) {
+            this.logger.warn(
+                'Could not find account {id} to enable Bluesky integration',
+                { id: event.getFollowerId() },
+            );
+
+            return;
+        }
+
+        // Insert handle → account mapping into the database
+        const handle = this.getHandleForAccount(followerAccount);
+
+        await this.db('bluesky_integration_account_handles')
+            .insert({
+                account_id: followerAccount.id,
+                handle,
+            })
+            .onConflict('account_id')
+            .merge();
+    }
+
+    private getHandleForAccount(account: Account) {
+        const host = account.url.hostname.replace(/^www\./i, '');
+
+        return `@${account.username}.${host}.ap.brid.gy`;
+    }
+
+    private async getBridgyAccount() {
+        const ensureBridgyAccountResult =
+            await this.accountService.ensureByApId(BRIDGY_AP_ID);
+
+        if (isError(ensureBridgyAccountResult)) {
+            throw new Error('Failed to retrieve brid.gy account');
+        }
+
+        return getValue(ensureBridgyAccountResult);
+    }
+
+    private async isEnabledForAccount(account: Account) {
+        const result = await this.db('bluesky_integration_account_handles')
+            .where('account_id', account.id)
+            .first();
+
+        return result !== undefined;
+    }
+}

--- a/src/integration/bluesky.service.ts
+++ b/src/integration/bluesky.service.ts
@@ -42,7 +42,7 @@ export class BlueskyService {
                 { id: account.id },
             );
 
-            return;
+            return this.getHandleForAccount(account);
         }
 
         const bridgyAccount = await this.getBridgyAccount();
@@ -68,6 +68,8 @@ export class BlueskyService {
             },
             follow,
         );
+
+        return this.getHandleForAccount(account);
     }
 
     async disableForAccount(account: Account) {
@@ -179,7 +181,7 @@ export class BlueskyService {
     }
 
     private getHandleForAccount(account: Account) {
-        return `@${account.username}.${account.url.hostname}.ap.brid.gy`;
+        return `@${account.username}.${account.apId.hostname}.ap.brid.gy`;
     }
 
     private async getBridgyAccount() {

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -216,6 +216,21 @@ export class FixtureManager {
         });
     }
 
+    async enableBlueskyIntegration(account: Account) {
+        await this.db('bluesky_integration_account_handles').insert({
+            account_id: account.id,
+            handle: `@${account.username}@bluesky`,
+        });
+    }
+
+    async disableBlueskyIntegration(account: Account) {
+        await this.db('bluesky_integration_account_handles')
+            .where({
+                account_id: account.id,
+            })
+            .delete();
+    }
+
     async reset() {
         await this.db.raw('SET FOREIGN_KEY_CHECKS = 0');
         await Promise.all([
@@ -231,6 +246,7 @@ export class FixtureManager {
             this.db('sites').truncate(),
             this.db('outboxes').truncate(),
             this.db('mentions').truncate(),
+            this.db('bluesky_integration_account_handles').truncate(),
         ]);
         await this.db.raw('SET FOREIGN_KEY_CHECKS = 1');
     }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2410

Added API for enabling / disabling Bluesky for an account:

`POST /.ghost/activitypub/v1/actions/bluesky/enable`:
- Sends follow request to brid.gy account
- Records Bluesky handle for account in the database (upon follow request acceptance)

`POST /.ghost/activitypub/v1/actions/bluesky/disable`
- Sends "stop" DM to brid.gy account
- Sends unfollow to brid.gy account
- Removes Bluesky handle for account from the database

Bluesky handles are stored in a new database table separate from the account table to keep this table free of integration data that may not apply to all accounts ( i.e external accounts)

Bluesky integration status (enabled / handle) is returned when a request is made to `/.ghost/activitypub/v1/account/me`