### PR TITLE
Fixed old posts being federated on update

### DIFF
--- a/src/ghost/ghost-post.service.integration.test.ts
+++ b/src/ghost/ghost-post.service.integration.test.ts
@@ -308,9 +308,26 @@ describe('GhostPostService', () => {
         });
 
         it('should handle posts with ghost authors metadata', async () => {
+            const ghostPostUuid = 'ee218320-b2e6-11ef-8a80-0242ac120008';
+
+            // Initial post
+            await ghostPostService.createGhostPost(account, {
+                title: 'Test Article',
+                uuid: ghostPostUuid,
+                html: '<p>Original content</p>',
+                excerpt: 'Original excerpt',
+                custom_excerpt: null,
+                feature_image: null,
+                published_at: new Date().toISOString(),
+                url: 'https://example.com/test-article',
+                visibility: 'public',
+                authors: [],
+            });
+
+            // Update the post
             const ghostPost = {
                 title: 'Test Article with Authors',
-                uuid: 'ee218320-b2e6-11ef-8a80-0242ac120008',
+                uuid: ghostPostUuid,
                 html: '<p>Content with authors</p>',
                 excerpt: 'Test excerpt',
                 custom_excerpt: null,
@@ -326,7 +343,6 @@ describe('GhostPostService', () => {
                     { name: 'Jane Smith', profile_image: null },
                 ],
             };
-
             await ghostPostService.updateArticleFromGhostPost(
                 account,
                 ghostPost,
@@ -338,9 +354,9 @@ describe('GhostPostService', () => {
                 .first();
             expect(apIdForPost).not.toBeNull();
             const apId = new URL(apIdForPost.ap_id);
-            const createdPost = await postRepository.getByApId(apId);
-            expect(createdPost).not.toBeNull();
-            expect(createdPost!.metadata).toEqual({
+            const updatedPost = await postRepository.getByApId(apId);
+            expect(updatedPost).not.toBeNull();
+            expect(updatedPost!.metadata).toEqual({
                 ghostAuthors: [
                     {
                         name: 'John Doe',

--- a/src/ghost/ghost-post.service.ts
+++ b/src/ghost/ghost-post.service.ts
@@ -50,19 +50,11 @@ export class GhostPostService {
         const apIdForPost = await this.getApIdForGhostPost(ghostPost.uuid);
         if (!apIdForPost) {
             this.logger.info(
-                'No apId found for ghost post {uuid}, creating new post',
-                { uuid: ghostPost.uuid },
+                'Could not update post: Ghost post with UUID {uuid} was not found.',
+                {
+                    uuid: ghostPost.uuid,
+                },
             );
-            const newPostResult = await this.createGhostPost(
-                account,
-                ghostPost,
-            );
-            if (isError(newPostResult)) {
-                this.logger.error(
-                    'Failed to create new post with uuid: {uuid}, error: {error}',
-                    { uuid: ghostPost.uuid, error: getError(newPostResult) },
-                );
-            }
             return;
         }
         const apId = new URL(apIdForPost);
@@ -113,26 +105,17 @@ export class GhostPostService {
             const error = getError(updatedPostResult);
             switch (error) {
                 case 'post-not-found': {
-                    this.logger.info(
-                        'Post not found for apId: {apId}, creating new post',
-                        { apId },
-                    );
-                    const newPostResult = await this.createGhostPost(
-                        account,
-                        ghostPost,
-                    );
-                    if (isError(newPostResult)) {
-                        this.logger.error(
-                            'Failed to create new post with apId: {apId}, error: {error}',
-                            { apId, error: getError(newPostResult) },
-                        );
-                    }
+                    this.logger.error('Could not update post: post not found', {
+                        apId,
+                    });
                     return;
                 }
                 case 'not-author':
                     this.logger.error(
-                        'Cannot update post, not authorized for apId: {apId}',
-                        { apId },
+                        'Could not update post: actor is not the author of the post',
+                        {
+                            apId,
+                        },
                     );
                     return;
                 default:

--- a/src/ghost/ghost-post.service.unit.test.ts
+++ b/src/ghost/ghost-post.service.unit.test.ts
@@ -180,7 +180,7 @@ describe('GhostPostService', () => {
     });
 
     describe('updateArticleFromGhostPost', () => {
-        it('should create a new post when ghost post mapping does not exist', async () => {
+        it('should return early if the post does not exist', async () => {
             mockQueryBuilder.first.mockResolvedValue(null); // No mapping found
 
             const ghostPostData = {
@@ -195,20 +195,17 @@ describe('GhostPostService', () => {
                 visibility: 'public' as const,
                 authors: [],
             };
-            const createGhostPostSpy = vi
-                .spyOn(ghostPostService, 'createGhostPost')
-                .mockResolvedValue(ok(mockPost));
 
             const result = await ghostPostService.updateArticleFromGhostPost(
                 mockAccount,
                 ghostPostData,
             );
 
-            expect(mockDb).toHaveBeenCalledWith('ghost_ap_post_mappings');
-            expect(createGhostPostSpy).toHaveBeenCalledWith(
-                mockAccount,
-                ghostPostData,
+            expect(mockLogger.info).toHaveBeenCalledWith(
+                'Could not update post: Ghost post with UUID {uuid} was not found.',
+                { uuid: ghostPostData.uuid },
             );
+            expect(mockPostService.updateByApId).not.toHaveBeenCalled();
             expect(result).toBeUndefined();
         });
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2458

- Currently, ActivityPub service listens to the "post.updated" event from Ghost, and if the post does not exist yet in ActivityPub, creates a new post (i.e. it federates it)
- This is unwanted behaviour: it leads to old posts being federated unintentionally