### PR TITLE
Added predev script to build local dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "esbuild src/app.ts --sourcemap --platform=neutral --bundle --packages=external --outfile=dist/app.js",
     "build:watch": "concurrently \"yarn build --watch\" \"node --inspect=0.0.0.0:9229 --watch dist/app.js\"",
+    "predev": "docker compose build migrate fake-gcs",
     "dev": "docker compose up activitypub nginx -d --build",
     "stop": "docker compose stop",
     "db": "docker compose exec mysql mysql -uroot -proot activitypub",


### PR DESCRIPTION
no issue

- When running `yarn dev` for the first time, new developers run into "Error response from daemon: No such image: activitypub-fake-gcs:latest" and "Error response from daemon: No such image: activitypub-migrate:latest"
- This happens because migrate and fake-gcs are *local* dependencies to the activitypub service