### PR TITLE
Improved local pubsub emulator usage

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -98,7 +98,6 @@ import {
 import { RouteRegistry } from '@/http/routing/route-registry';
 import { setupInstrumentation, spanWrapper } from '@/instrumentation';
 import {
-    createDevMiddleware,
     createPushMessageHandler,
     type GCloudPubSubPushMessageQueue,
 } from '@/mq/gcloud-pubsub-push/mq';
@@ -571,11 +570,8 @@ app.post('/.ghost/activitypub/pubsub/ghost/push', async (ctx) => {
     return handler(ctx);
 });
 
-const pubsubFedifyPushPath = '/.ghost/activitypub/pubsub/fedify/push';
-
 app.post(
-    pubsubFedifyPushPath,
-    createDevMiddleware(pubsubFedifyPushPath, globalLogging),
+    '/.ghost/activitypub/pubsub/fedify/push',
     spanWrapper(createPushMessageHandler(globalQueue, globalLogging)),
 );
 


### PR DESCRIPTION
no ref

Improved local pubsub emulator usage:
- Ensured emulator uses a backoff strategy for retries to prevent infinite loops
- ~~Added dev middleware that adds `deliveryAttempt` property to a message body because the emulator does provide this~~