### PR TITLE
Improved logging for delivery backoffs

### DIFF
--- a/src/mq/gcloud-pubsub-push/mq.ts
+++ b/src/mq/gcloud-pubsub-push/mq.ts
@@ -438,6 +438,10 @@ export class GCloudPubSubPushMessageQueue implements MessageQueue {
             return;
         }
 
+        this.logger.info(
+            'Recording delivery failure [FedifyID: {fedifyId}]: {error}',
+            { fedifyId: message.id, error, mq_message: message },
+        );
         try {
             const inboxUrl = new URL(message.inbox);
 
@@ -447,7 +451,7 @@ export class GCloudPubSubPushMessageQueue implements MessageQueue {
             );
         } catch (error) {
             this.logger.error(
-                `Failed to record delivery failure [FedifyID: ${message.id}]: ${error}`,
+                'Failed to record delivery failure [FedifyID: {fedifyId}]: {error}',
                 { fedifyId: message.id, error, mq_message: message },
             );
 


### PR DESCRIPTION
We didn't have any logs for when we're recording a delivery failure, which leaves us a little blind when debugging. Also updates the log message to use the structured data which is more idiomatic for logtape