### PR TITLE
Made connection pool configurable

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -46,6 +46,10 @@ This ActivityPub service uses a variety of environment variables to configure it
 - `MYSQL_USER`* - MySQL database username
 - `MYSQL_PASSWORD`* - MySQL database password
 - `MYSQL_DATABASE`* - MySQL database name
+- `MYSQL_CONN_POOL_MIN` - Minimum number of connections in the MySQL connection pool
+  - Default: `1`
+- `MYSQL_CONN_POOL_MAX` - Maximum number of connections in the MySQL connection pool
+  - Default: `200`
 
 ## Redis Configuration
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -32,8 +32,8 @@ export const knex = Knex({
               timezone: '+00:00',
           },
     pool: {
-        min: 1,
-        max: 200,
+        min: parseInt(process.env.MYSQL_CONN_POOL_MIN ?? '1'),
+        max: parseInt(process.env.MYSQL_CONN_POOL_MAX ?? '200'),
     },
 });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2530

The connection pool size is generally an infrastructure concern and we want to be able to configure it via the env in terraform.