### PR TITLE
Fixed `posts` table `content` column type

### DIFF
--- a/migrate/migrations/000067_update-posts-content-to-longtext.down.sql
+++ b/migrate/migrations/000067_update-posts-content-to-longtext.down.sql
@@ -1,0 +1,26 @@
+/*  This rollback migration should be executed manually in production.
+    The alter table query executed on a very large table can cause downtime
+    Instead, it should be executed with gh-ost
+        $ docker run -it \
+            -e DB_USER=${DB_USER} \
+            -e DB_PASS=${DB_PASS} \
+            -e DB_HOST=${DB_HOST} \
+            -e DB_NAME=${DB_NAME} \
+            gh-ost bash
+        $ gh-ost \
+            --user="${DB_USER}" \
+            --password="${DB_PASS}" \
+            --host="${DB_HOST}" \
+            --database="${DB_NAME}" \
+            --table="posts" \
+            --verbose \
+            --alter="MODIFY content TEXT" \
+            --allow-on-master \
+            --exact-rowcount \
+            --concurrent-rowcount \
+            --default-retries=120 \
+            --ssl \
+            --ssl-allow-insecure \
+            --execute
+*/
+ALTER TABLE posts MODIFY content TEXT;

--- a/migrate/migrations/000067_update-posts-content-to-longtext.up.sql
+++ b/migrate/migrations/000067_update-posts-content-to-longtext.up.sql
@@ -1,0 +1,26 @@
+/*  This migration should be executed manually in production.
+    The alter table query executed on a very large table can cause downtime
+    Instead, it should be executed with gh-ost
+        $ docker run -it \
+            -e DB_USER=${DB_USER} \
+            -e DB_PASS=${DB_PASS} \
+            -e DB_HOST=${DB_HOST} \
+            -e DB_NAME=${DB_NAME} \
+            gh-ost bash
+        $ gh-ost \
+            --user="${DB_USER}" \
+            --password="${DB_PASS}" \
+            --host="${DB_HOST}" \
+            --database="${DB_NAME}" \
+            --table="posts" \
+            --verbose \
+            --alter="MODIFY content LONGTEXT" \
+            --allow-on-master \
+            --exact-rowcount \
+            --concurrent-rowcount \
+            --default-retries=120 \
+            --ssl \
+            --ssl-allow-insecure \
+            --execute
+*/
+ALTER TABLE posts MODIFY content LONGTEXT;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2589

We're seeing ER_DATA_TOO_LONG errors when federating posts with large HTML content. The Ghost schema uses LONGTEXT for the html of posts, and by matching it in AP, we ensure we can handle all posts from Ghost