### PR TITLE
Removed redundant `ACTIVITYPUB_COLLECTION_PAGE_SIZE` env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,6 @@ services:
       - GCP_BUCKET_NAME=activitypub
       - GCP_STORAGE_EMULATOR_HOST=http://fake-gcs:4443
       # - GCS_LOCAL_STORAGE_HOSTING_URL=https://<tailscale-url>/.ghost/activitypub/gcs
-      - ACTIVITYPUB_COLLECTION_PAGE_SIZE=20
       - LOCAL_STORAGE_PATH=/opt/activitypub/content
       # - LOCAL_STORAGE_HOSTING_URL=https://<tailscale-url>/.ghost/activitypub/local-storage
       # - GHOST_PRO_IP_ADDRESSES=100.83.192.90,192.168.65.1
@@ -168,7 +167,6 @@ services:
       - GCP_BUCKET_NAME=activitypub
       - GCS_LOCAL_STORAGE_HOSTING_URL=http://fake-gcs:4443/.ghost/activitypub/gcs
       - GCP_STORAGE_EMULATOR_HOST=http://fake-gcs:4443
-      - ACTIVITYPUB_COLLECTION_PAGE_SIZE=2
       - REDIS_HOST=redis-testing
       - REDIS_PORT=6379
       - FEDIFY_KV_STORE_TYPE=redis

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -20,8 +20,6 @@ This ActivityPub service uses a variety of environment variables to configure it
 - `SKIP_SIGNATURE_VERIFICATION` - Set to `true` to skip ActivityPub signature verification
   - This is only used in `development` and `testing` environments
   - See [https://github.com/fedify-dev/fedify/issues/110](https://github.com/fedify-dev/fedify/issues/110) for more details
-- `ACTIVITYPUB_COLLECTION_PAGE_SIZE`* - Set the number of items to return per page for an ActivityPub collection
-  - This used by the `outbox` and `following` collections
 - `FEDIFY_KV_STORE_TYPE` - Set to `redis` to use Redis as the [key-value store for Fedify](https://fedify.dev/manual/kv)
   - If not set, MySQL will be used
 - `USE_MQ` - Set to `true` to enable message queue usage

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,3 +8,5 @@ export const ACTIVITY_OBJECT_TYPE_ARTICLE = 'Article';
 export const ACTIVITY_OBJECT_TYPE_NOTE = 'Note';
 
 export const HANDLE_REGEX = /@([\w.-]+)@([\w-]+\.[\w.-]+[a-zA-Z])/;
+
+export const ACTIVITYPUB_COLLECTION_PAGE_SIZE = 20;

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -23,6 +23,7 @@ import type { KnexAccountRepository } from '@/account/account.repository.knex';
 import type { AccountService } from '@/account/account.service';
 import type { FollowersService } from '@/activitypub/followers.service';
 import type { ContextData } from '@/app';
+import { ACTIVITYPUB_COLLECTION_PAGE_SIZE } from '@/constants';
 import { exhaustiveCheck, getError, getValue, isError } from '@/core/result';
 import {
     buildAnnounceActivityForPost,
@@ -801,14 +802,6 @@ export function createFollowingDispatcher(
     ) {
         ctx.data.logger.info('Following Dispatcher');
 
-        const pageSize = Number.parseInt(
-            process.env.ACTIVITYPUB_COLLECTION_PAGE_SIZE || '',
-        );
-
-        if (Number.isNaN(pageSize)) {
-            throw new Error(`Page size: ${pageSize} is not valid`);
-        }
-
         const offset = Number.parseInt(cursor ?? '0');
         let nextCursor: string | null = null;
 
@@ -827,7 +820,7 @@ export function createFollowingDispatcher(
             siteDefaultAccount,
             {
                 fields: ['ap_id'],
-                limit: pageSize,
+                limit: ACTIVITYPUB_COLLECTION_PAGE_SIZE,
                 offset,
             },
         );
@@ -836,8 +829,8 @@ export function createFollowingDispatcher(
         );
 
         nextCursor =
-            totalFollowing > offset + pageSize
-                ? (offset + pageSize).toString()
+            totalFollowing > offset + ACTIVITYPUB_COLLECTION_PAGE_SIZE
+                ? (offset + ACTIVITYPUB_COLLECTION_PAGE_SIZE).toString()
                 : null;
 
         ctx.data.logger.info('Following results', { results });
@@ -909,10 +902,6 @@ export function createOutboxDispatcher(
     ) {
         ctx.data.logger.info('Outbox Dispatcher');
 
-        const pageSize = Number.parseInt(
-            process.env.ACTIVITYPUB_COLLECTION_PAGE_SIZE || '20',
-        );
-
         const host = ctx.request.headers.get('host')!;
         const site = await siteService.getSiteByHost(host);
         if (!site) {
@@ -924,7 +913,7 @@ export function createOutboxDispatcher(
         const outbox = await postService.getOutboxForAccount(
             siteDefaultAccount.id,
             cursor,
-            pageSize,
+            ACTIVITYPUB_COLLECTION_PAGE_SIZE,
         );
         const outboxItems = await Promise.all(
             outbox.items.map(async (item: { post: Post; type: OutboxType }) => {

--- a/src/dispatchers.unit.test.ts
+++ b/src/dispatchers.unit.test.ts
@@ -11,7 +11,10 @@ import type {
 import type { AccountEntity } from '@/account/account.entity';
 import type { AccountService } from '@/account/account.service';
 import type { ContextData } from '@/app';
-import { ACTOR_DEFAULT_HANDLE } from '@/constants';
+import {
+    ACTIVITYPUB_COLLECTION_PAGE_SIZE,
+    ACTOR_DEFAULT_HANDLE,
+} from '@/constants';
 import {
     createOutboxCounter,
     createOutboxDispatcher,
@@ -98,7 +101,6 @@ describe('dispatchers', () => {
         });
 
         vi.clearAllMocks();
-        process.env.ACTIVITYPUB_COLLECTION_PAGE_SIZE = '2';
         vi.mocked(mockSiteService.getSiteByHost).mockResolvedValue(mockSite);
         vi.mocked(mockAccountService.getAccountForSite).mockResolvedValue(
             mockAccount,
@@ -180,7 +182,7 @@ describe('dispatchers', () => {
             expect(mockPostService.getOutboxForAccount).toHaveBeenCalledWith(
                 1,
                 cursor,
-                2,
+                ACTIVITYPUB_COLLECTION_PAGE_SIZE,
             );
             expect(result.items).toBeDefined();
             expect(result.nextCursor).toBe(nextCursor);
@@ -228,23 +230,6 @@ describe('dispatchers', () => {
 
             expect(result.items).toEqual([]);
             expect(result.nextCursor).toBeNull();
-        });
-
-        it('handles custom page size from environment variable', async () => {
-            process.env.ACTIVITYPUB_COLLECTION_PAGE_SIZE = '5';
-            const outboxDispatcher = createOutboxDispatcher(
-                mockAccountService,
-                mockPostService,
-                mockSiteService,
-            );
-
-            await outboxDispatcher(ctx, 'test-handle', cursor);
-
-            expect(mockPostService.getOutboxForAccount).toHaveBeenCalledWith(
-                1,
-                cursor,
-                5,
-            );
         });
 
         it('returns create activity for original posts', async () => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2539

The `ACTIVITYPUB_COLLECTION_PAGE_SIZE` env var is no longer needed by the activitypub service so has been removed. A static value has been provided in its place