### PR TITLE
Updated image_url column size from 1024 -> 2000

### DIFF
--- a/migrate/migrations/000068_increase-image-url-field-size-to-2000.down.sql
+++ b/migrate/migrations/000068_increase-image-url-field-size-to-2000.down.sql
@@ -1,0 +1,26 @@
+/*  This rollback migration should be executed manually in production.
+    The alter table query executed on a very large table can cause downtime
+    Instead, it should be executed with gh-ost
+        $ docker run -it \
+            -e DB_USER=${DB_USER} \
+            -e DB_PASS=${DB_PASS} \
+            -e DB_HOST=${DB_HOST} \
+            -e DB_NAME=${DB_NAME} \
+            gh-ost bash
+        $ gh-ost \
+            --user="${DB_USER}" \
+            --password="${DB_PASS}" \
+            --host="${DB_HOST}" \
+            --database="${DB_NAME}" \
+            --table="posts" \
+            --verbose \
+            --alter="MODIFY image_url VARCHAR(1024) NULL" \
+            --allow-on-master \
+            --exact-rowcount \
+            --concurrent-rowcount \
+            --default-retries=120 \
+            --ssl \
+            --ssl-allow-insecure \
+            --execute
+*/
+ALTER TABLE posts MODIFY image_url VARCHAR(1024) NULL;

--- a/migrate/migrations/000068_increase-image-url-field-size-to-2000.up.sql
+++ b/migrate/migrations/000068_increase-image-url-field-size-to-2000.up.sql
@@ -1,0 +1,26 @@
+/*  This migration should be executed manually in production.
+    The alter table query executed on a very large table can cause downtime
+    Instead, it should be executed with gh-ost
+        $ docker run -it \
+            -e DB_USER=${DB_USER} \
+            -e DB_PASS=${DB_PASS} \
+            -e DB_HOST=${DB_HOST} \
+            -e DB_NAME=${DB_NAME} \
+            gh-ost bash
+        $ gh-ost \
+            --user="${DB_USER}" \
+            --password="${DB_PASS}" \
+            --host="${DB_HOST}" \
+            --database="${DB_NAME}" \
+            --table="posts" \
+            --verbose \
+            --alter="MODIFY image_url VARCHAR(2000) NULL" \
+            --allow-on-master \
+            --exact-rowcount \
+            --concurrent-rowcount \
+            --default-retries=120 \
+            --ssl \
+            --ssl-allow-insecure \
+            --execute
+*/
+ALTER TABLE posts MODIFY image_url VARCHAR(2000) NULL;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2650

We've seen a couple ER_DATA_TOO_LONG for image urls, which can be up to 2000 characters in the Ghost DB. This brings us in line with Ghost so we avoid these errors.