### PR TITLE
Fixed `slack-notify` job not running on workflow failure

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -59,9 +59,10 @@ jobs:
     name: Slack Notification on Failure
     needs: [build, test, push, deploy]
     runs-on: ubuntu-latest
+    if: always()
     steps:
       - uses: tryghost/actions/actions/slack-build@main
-        if: always() && failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
           status: ${{ job.status }}
         env:


### PR DESCRIPTION
no refs

Slack notifications were not working when the pipeline failed due to the `slack-notify` job relying on all prior jobs to be successful:

> If a job fails or is skipped, all jobs that need it are skipped unless the jobs use a conditional expression that causes the job to continue

> If you would like a job to run even if a job it is dependent on did not succeed, use the always() conditional expression

(https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow)

This change ensures that the job is always run, and the existing `failure()` check ensures that the jobs steps are only run when the pipeline fails