### PR TITLE
Fixed flakey test for unread notifications

### DIFF
--- a/features/notifications.feature
+++ b/features/notifications.feature
@@ -7,22 +7,14 @@ Feature: Notifications
     When an authenticated request is made to "/.ghost/activitypub/v1/notifications?limit=200"
     Then the request is rejected with a 400
 
-  Scenario: Requests for unread notifications count
+  Scenario: Getting unread notifications count
     Given we are following "Alice"
     And we are not following "Bob"
+    And we reset unread notifications count
     When we get a like notification from "Alice"
     And we get a like notification from "Bob"
     And we get a reply notification from "Alice"
     And we get a reply notification from "Bob"
     Then the unread notifications count is 4
-
-  Scenario: Reset unread notifications count
-    Given we are following "Alice"
-    And we are not following "Bob"
-    And we get a like notification from "Alice"
-    And we get a like notification from "Bob"
-    And we get a reply notification from "Alice"
-    And we get a reply notification from "Bob"
-    And the unread notifications count is 4
     When we reset unread notifications count
     Then the unread notifications count is 0

--- a/features/notifications.feature
+++ b/features/notifications.feature
@@ -14,7 +14,7 @@ Feature: Notifications
     And we get a reply notification from "Bob"
     Then we have unread notifications
 
-  Scenario: Reading notifications resets the unread count
+  Scenario: Visiting the notifications marks notifications as read
     Given we are following "Alice"
     And we are not following "Bob"
     And we get a like notification from "Alice"

--- a/features/notifications.feature
+++ b/features/notifications.feature
@@ -7,14 +7,18 @@ Feature: Notifications
     When an authenticated request is made to "/.ghost/activitypub/v1/notifications?limit=200"
     Then the request is rejected with a 400
 
-  Scenario: Getting unread notifications count
+  Scenario: New notifications are marked as unread
     Given we are following "Alice"
     And we are not following "Bob"
-    And we reset unread notifications count
     When we get a like notification from "Alice"
-    And we get a like notification from "Bob"
-    And we get a reply notification from "Alice"
     And we get a reply notification from "Bob"
-    Then the unread notifications count is 4
-    When we reset unread notifications count
-    Then the unread notifications count is 0
+    Then we have unread notifications
+
+  Scenario: Reading notifications resets the unread count
+    Given we are following "Alice"
+    And we are not following "Bob"
+    And we get a like notification from "Alice"
+    And we get a reply notification from "Bob"
+    And we have unread notifications
+    When we visit the notifications page
+    Then we don't have unread notifications

--- a/features/notifications.feature
+++ b/features/notifications.feature
@@ -21,4 +21,4 @@ Feature: Notifications
     And we get a reply notification from "Bob"
     And we have unread notifications
     When we visit the notifications page
-    Then we don't have unread notifications
+    Then all notifications are marked as read

--- a/features/notifications.feature
+++ b/features/notifications.feature
@@ -14,7 +14,7 @@ Feature: Notifications
     And we get a reply notification from "Bob"
     Then we have unread notifications
 
-  Scenario: Visiting the notifications marks notifications as read
+  Scenario: Visiting the notifications page marks notifications as read
     Given we are following "Alice"
     And we are not following "Bob"
     And we get a like notification from "Alice"

--- a/features/step_definitions/notifications_steps.js
+++ b/features/step_definitions/notifications_steps.js
@@ -7,13 +7,9 @@ import { createActivity, createObject } from '../support/fixtures.js';
 import {
     waitForItemInNotifications,
     waitForUnreadNotifications,
+    waitForZeroUnreadNotifications,
 } from '../support/notifications.js';
 import { fetchActivityPub } from '../support/request.js';
-
-Then('the unread notifications count is {int}', async (count) => {
-    const found = await waitForUnreadNotifications(count);
-    assert(found);
-});
 
 When('we get a like notification from {string}', async function (actorName) {
     if (!this.articleId) {
@@ -76,11 +72,21 @@ When('we get a reply notification from {string}', async function (actorName) {
     await waitForItemInNotifications(object.id);
 });
 
-When('we reset unread notifications count', async () => {
+When('we visit the notifications page', async () => {
     await fetchActivityPub(
         'https://self.test/.ghost/activitypub/v1/notifications/unread/reset',
         {
             method: 'PUT',
         },
     );
+});
+
+Then('we have unread notifications', async () => {
+    const unreadNotifications = await waitForUnreadNotifications();
+    assert(unreadNotifications);
+});
+
+Then("we don't have unread notifications", async () => {
+    const zeroUnreadNotifications = await waitForZeroUnreadNotifications();
+    assert(zeroUnreadNotifications);
 });

--- a/features/step_definitions/notifications_steps.js
+++ b/features/step_definitions/notifications_steps.js
@@ -86,7 +86,7 @@ Then('we have unread notifications', async () => {
     assert(unreadNotifications);
 });
 
-Then("we don't have unread notifications", async () => {
+Then('all notifications are marked as read', async () => {
     const zeroUnreadNotifications = await waitForZeroUnreadNotifications();
     assert(zeroUnreadNotifications);
 });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2663

- The notification count test scenario was flaky when running the entire cucumber test suite, returning a count of 6 instead of 4, sometimes
- We’re not testing the exact count of unread notifications anymore, but rather whether new notifications are marked as unread / visiting the notifications marks them as read - which is closer to the main use case for the notification badge 