### PR TITLE
Updated client config controller to reference updated script name

### DIFF
--- a/adr/0002-frontend-backend-versioning.md
+++ b/adr/0002-frontend-backend-versioning.md
@@ -62,9 +62,9 @@ Implement a backend-driven frontend configuration endpoint that tells the JS bun
    ```json
    {
       "client": {
-         "name": "admin-x-activitypub",
+         "name": "activitypub",
          "version": "^1.0.0",
-         "cdnUrl": "https://cdn.jsdelivr.net/ghost/admin-x-activitypub@1/dist/admin-x-activitypub.js"
+         "cdnUrl": "https://cdn.jsdelivr.net/ghost/activitypub@1/dist/activitypub.js"
       }
    }
    ```

--- a/src/http/api/client-config.controller.ts
+++ b/src/http/api/client-config.controller.ts
@@ -5,7 +5,7 @@ export class ClientConfigController {
     @APIRoute('GET', 'client-config', 'stable')
     async handleGetClientConfig(_ctx: AppContext) {
         const major = 1;
-        const name = 'admin-x-activitypub';
+        const name = 'activitypub';
         const client = {
             name,
             version: `^${major}.0.0`,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2455
ref https://github.com/TryGhost/Ghost/pull/24985

The `admin-x-activitypub` script has been renamed to just `activitypub` so the client config endpoint should be updated to reflect this change