### PR TITLE
Misc cucumber updates

### DIFF
--- a/features/step_definitions/activitypub_steps.js
+++ b/features/step_definitions/activitypub_steps.js
@@ -303,19 +303,13 @@ Then(
         const inbox = new URL(actor.inbox);
         const activity = this.activities[activityName];
 
-        const found = await waitForRequest(
-            'POST',
-            inbox.pathname,
-            (call) => {
-                const json = JSON.parse(call.request.body);
-                return (
-                    json.type === activity.type &&
-                    json.object.id === activity.object.id
-                );
-            },
-            5000,
-            200,
-        );
+        const found = await waitForRequest('POST', inbox.pathname, (call) => {
+            const json = JSON.parse(call.request.body);
+            return (
+                json.type === activity.type &&
+                json.object.id === activity.object.id
+            );
+        });
 
         assert(found);
     },
@@ -428,8 +422,6 @@ Then(
 
                     return json.object.id === object.id;
                 },
-                5000,
-                200,
             );
 
             assert(

--- a/features/step_definitions/activitypub_steps.js
+++ b/features/step_definitions/activitypub_steps.js
@@ -428,6 +428,8 @@ Then(
 
                     return json.object.id === object.id;
                 },
+                5000,
+                200,
             );
 
             assert(

--- a/features/step_definitions/index.js
+++ b/features/step_definitions/index.js
@@ -94,14 +94,6 @@ async function setupSelfSite() {
         .where('id', '=', json.id);
 }
 
-BeforeAll(async function setupLocalSites() {
-    await Promise.all([
-        fetchActivityPub('https://alice.test/.ghost/activitypub/v1/site'),
-        fetchActivityPub('https://bob.test/.ghost/activitypub/v1/site'),
-        fetchActivityPub('https://carol.test/.ghost/activitypub/v1/site'),
-    ]);
-});
-
 Before(async function reset() {
     await resetWiremock();
     await resetDatabase();

--- a/features/step_definitions/internal_account_steps.js
+++ b/features/step_definitions/internal_account_steps.js
@@ -3,6 +3,7 @@ import { Given, Then, When } from '@cucumber/cucumber';
 import assert from 'node:assert';
 import { createHmac } from 'node:crypto';
 
+import { waitForAPObjectInFeed, waitForItemInFeed } from '../support/feed.js';
 import { createWebhookPost, getWebhookSecret } from '../support/fixtures.js';
 import { fetchActivityPub } from '../support/request.js';
 
@@ -66,29 +67,25 @@ When('I create a post in ghost', async function () {
 });
 
 Then('the article is in my followers feeds', async function () {
-    const feeds = await Promise.all([
-        fetchActivityPub(
+    const feeds = await Promise.allSettled([
+        waitForItemInFeed(
+            this.article.id,
             'https://alice.test/.ghost/activitypub/v1/feed/reader',
-            { method: 'GET' },
         ),
-        fetchActivityPub('https://bob.test/.ghost/activitypub/v1/feed/reader', {
-            method: 'GET',
-        }),
-        fetchActivityPub(
+        waitForItemInFeed(
+            this.article.id,
+            'https://bob.test/.ghost/activitypub/v1/feed/reader',
+        ),
+        waitForItemInFeed(
+            this.article.id,
             'https://carol.test/.ghost/activitypub/v1/feed/reader',
-            { method: 'GET' },
         ),
     ]);
 
-    const articleId = this.article.id;
-
-    for (const feed of feeds) {
-        const json = await feed.json();
-        assert(
-            json.posts.find((post) => post.id === articleId),
-            'Article is not in feed',
-        );
-    }
+    assert(
+        feeds.every((feed) => feed.status === 'fulfilled'),
+        'Article is not in all feeds',
+    );
 });
 
 When('I create a note which mentions alice', async function () {
@@ -110,29 +107,25 @@ When('I create a note which mentions alice', async function () {
 });
 
 Then('the note is in my followers feeds', async function () {
-    const feeds = await Promise.all([
-        fetchActivityPub(
+    const feeds = await Promise.allSettled([
+        waitForAPObjectInFeed(
+            this.note.id,
             'https://alice.test/.ghost/activitypub/v1/feed/notes',
-            { method: 'GET' },
         ),
-        fetchActivityPub('https://bob.test/.ghost/activitypub/v1/feed/notes', {
-            method: 'GET',
-        }),
-        fetchActivityPub(
+        waitForAPObjectInFeed(
+            this.note.id,
+            'https://bob.test/.ghost/activitypub/v1/feed/notes',
+        ),
+        waitForAPObjectInFeed(
+            this.note.id,
             'https://carol.test/.ghost/activitypub/v1/feed/notes',
-            { method: 'GET' },
         ),
     ]);
 
-    const noteId = this.note.id;
-
-    for (const feed of feeds) {
-        const json = await feed.json();
-        assert(
-            json.posts.find((post) => post.id === noteId),
-            'Note is not in feed',
-        );
-    }
+    assert(
+        feeds.every((feed) => feed.status === 'fulfilled'),
+        'Note is not in all feeds',
+    );
 });
 
 Then('alice receives a mention notification', async function () {

--- a/features/step_definitions/repost_steps.js
+++ b/features/step_definitions/repost_steps.js
@@ -93,18 +93,13 @@ Then('an Undo\\(Announce) is sent to {string}', async function (actorName) {
 
     const inboxUrl = new URL(actor.inbox);
 
-    const foundInInbox = await waitForRequest(
-        'POST',
-        inboxUrl.pathname,
-        (call) => {
-            const body = JSON.parse(call.request.body);
-            return body.type === 'Undo' && body.object.type === 'Announce';
-        },
-    );
+    const found = await waitForRequest('POST', inboxUrl.pathname, (call) => {
+        const body = JSON.parse(call.request.body);
 
-    const foundActivity = JSON.parse(foundInInbox.request.body);
+        return body.type === 'Undo' && body.object.type === 'Announce';
+    });
 
-    assert(foundActivity);
+    assert(found);
 });
 
 Then('an Announce\\(Note) is sent to {string}', async function (actorName) {
@@ -117,29 +112,25 @@ Then('an Announce\\(Note) is sent to {string}', async function (actorName) {
 
     const inboxUrl = new URL(actor.inbox);
 
-    const foundInInbox = await waitForRequest(
-        'POST',
-        inboxUrl.pathname,
-        (call) => {
-            const body = JSON.parse(call.request.body);
-            if (body.type !== 'Announce') {
-                return false;
+    const found = await waitForRequest('POST', inboxUrl.pathname, (call) => {
+        const body = JSON.parse(call.request.body);
+
+        if (body.type !== 'Announce') {
+            return false;
+        }
+
+        if (object) {
+            if (typeof body.object === 'string') {
+                return body.object === object.id;
             }
 
-            if (object) {
-                if (typeof body.object === 'string') {
-                    return body.object === object.id;
-                }
-                return body.object.id === object.id;
-            }
+            return body.object.id === object.id;
+        }
 
-            return body.object.type === 'Note';
-        },
-    );
+        return body.object.type === 'Note';
+    });
 
-    const foundActivity = JSON.parse(foundInInbox.request.body);
-
-    assert(foundActivity);
+    assert(found);
 });
 
 When('{string} reposts our note', async function (actorName) {

--- a/features/support/db.js
+++ b/features/support/db.js
@@ -9,7 +9,7 @@ export function getClient() {
             client: 'mysql2',
             connection: {
                 host: process.env.MYSQL_HOST,
-                port: Number.parseInt(process.env.MYSQL_PORT),
+                port: Number.parseInt(process.env.MYSQL_PORT, 10),
                 user: process.env.MYSQL_USER,
                 password: process.env.MYSQL_PASSWORD,
                 database: process.env.MYSQL_DATABASE,
@@ -25,18 +25,22 @@ export async function reset() {
     const db = getClient();
 
     await db.raw('SET FOREIGN_KEY_CHECKS = 0');
-    await db('key_value').truncate();
-    await db('notifications').truncate();
-    await db('feeds').truncate();
-    await db('blocks').truncate();
-    await db('follows').truncate();
-    await db('likes').truncate();
-    await db('reposts').truncate();
-    await db('posts').truncate();
-    await db('outboxes').truncate();
-    await db('accounts').truncate();
-    await db('users').truncate();
     await db('account_delivery_backoffs').truncate();
+    await db('accounts').truncate();
+    await db('blocks').truncate();
+    await db('bluesky_integration_account_handles').truncate();
+    await db('domain_blocks').truncate();
+    await db('feeds').truncate();
+    await db('follows').truncate();
+    await db('ghost_ap_post_mappings').truncate();
+    await db('key_value').truncate();
+    await db('likes').truncate();
     await db('mentions').truncate();
+    await db('notifications').truncate();
+    await db('outboxes').truncate();
+    await db('posts').truncate();
+    await db('reposts').truncate();
+    await db('sites').truncate();
+    await db('users').truncate();
     await db.raw('SET FOREIGN_KEY_CHECKS = 1');
 }

--- a/features/support/db.js
+++ b/features/support/db.js
@@ -24,23 +24,35 @@ export function getClient() {
 export async function reset() {
     const db = getClient();
 
-    await db.raw('SET FOREIGN_KEY_CHECKS = 0');
-    await db('account_delivery_backoffs').truncate();
-    await db('accounts').truncate();
-    await db('blocks').truncate();
-    await db('bluesky_integration_account_handles').truncate();
-    await db('domain_blocks').truncate();
-    await db('feeds').truncate();
-    await db('follows').truncate();
-    await db('ghost_ap_post_mappings').truncate();
-    await db('key_value').truncate();
-    await db('likes').truncate();
-    await db('mentions').truncate();
-    await db('notifications').truncate();
-    await db('outboxes').truncate();
-    await db('posts').truncate();
-    await db('reposts').truncate();
-    await db('sites').truncate();
-    await db('users').truncate();
-    await db.raw('SET FOREIGN_KEY_CHECKS = 1');
+    const tables = [
+        'account_delivery_backoffs',
+        'accounts',
+        'blocks',
+        'bluesky_integration_account_handles',
+        'domain_blocks',
+        'feeds',
+        'follows',
+        'ghost_ap_post_mappings',
+        'key_value',
+        'likes',
+        'mentions',
+        'notifications',
+        'outboxes',
+        'posts',
+        'reposts',
+        'sites',
+        'users',
+    ];
+
+    await db.transaction(async (trx) => {
+        await trx.raw('SET FOREIGN_KEY_CHECKS = 0');
+
+        try {
+            for (const table of tables) {
+                await trx(table).truncate();
+            }
+        } finally {
+            await trx.raw('SET FOREIGN_KEY_CHECKS = 1');
+        }
+    });
 }

--- a/features/support/feed.js
+++ b/features/support/feed.js
@@ -2,6 +2,7 @@ import { fetchActivityPub } from './request.js';
 
 export async function waitForItemInFeed(
     itemId,
+    feedUrl = 'https://self.test/.ghost/activitypub/v1/feed/notes',
     options = {
         retryCount: 0,
         delay: 0,
@@ -9,14 +10,11 @@ export async function waitForItemInFeed(
 ) {
     const MAX_RETRIES = 5;
 
-    const response = await fetchActivityPub(
-        'https://self.test/.ghost/activitypub/v1/feed/notes',
-        {
-            headers: {
-                Accept: 'application/ld+json',
-            },
+    const response = await fetchActivityPub(feedUrl, {
+        headers: {
+            Accept: 'application/ld+json',
         },
-    );
+    });
 
     const json = await response.json();
 
@@ -38,7 +36,7 @@ export async function waitForItemInFeed(
         await new Promise((resolve) => setTimeout(resolve, options.delay));
     }
 
-    return await waitForItemInFeed(itemId, {
+    return await waitForItemInFeed(itemId, feedUrl, {
         retryCount: options.retryCount + 1,
         delay: options.delay + 500,
     });
@@ -46,11 +44,11 @@ export async function waitForItemInFeed(
 
 export async function waitForAPObjectInFeed(
     objectId,
+    feedUrl = 'https://self.test/.ghost/activitypub/v1/feed/notes',
     options = {
         retryCount: 0,
         delay: 0,
     },
-    feedUrl = 'https://self.test/.ghost/activitypub/v1/feed/notes',
 ) {
     const MAX_RETRIES = 5;
 
@@ -80,7 +78,7 @@ export async function waitForAPObjectInFeed(
         await new Promise((resolve) => setTimeout(resolve, options.delay));
     }
 
-    return await waitForAPObjectInFeed(objectId, {
+    return await waitForAPObjectInFeed(objectId, feedUrl, {
         retryCount: options.retryCount + 1,
         delay: options.delay + 500,
     });

--- a/features/support/request.js
+++ b/features/support/request.js
@@ -4,7 +4,6 @@ import { resolve } from 'node:path';
 import jwt from 'jsonwebtoken';
 
 import { getCurrentDirectory } from './path.js';
-import { wait } from './utils.js';
 import { getExternalWiremock } from './wiremock.js';
 
 export async function fetchActivityPub(url, options = {}, auth = true) {
@@ -40,9 +39,13 @@ export async function waitForRequest(
     method,
     path,
     matcher,
-    milliseconds = 1000,
-    step = 100,
+    options = {
+        retryCount: 0,
+        delay: 0,
+    },
 ) {
+    const MAX_RETRIES = 5;
+
     const externalActivityPub = getExternalWiremock();
 
     const calls = await externalActivityPub.getRequestsForAPI(method, path);
@@ -52,11 +55,18 @@ export async function waitForRequest(
         return found;
     }
 
-    if (milliseconds <= 0) {
-        return null;
+    if (options.retryCount >= MAX_RETRIES) {
+        throw new Error(
+            `Max retries reached (${MAX_RETRIES}) when waiting for request ${method} ${path}`,
+        );
     }
 
-    await wait(step);
+    if (options.delay > 0) {
+        await new Promise((resolve) => setTimeout(resolve, options.delay));
+    }
 
-    return waitForRequest(method, path, matcher, milliseconds - step, step);
+    return waitForRequest(method, path, matcher, {
+        retryCount: options.retryCount + 1,
+        delay: options.delay + 500,
+    });
 }

--- a/features/support/request.js
+++ b/features/support/request.js
@@ -49,7 +49,16 @@ export async function waitForRequest(
     const externalActivityPub = getExternalWiremock();
 
     const calls = await externalActivityPub.getRequestsForAPI(method, path);
-    const found = calls.find(matcher);
+
+    let found;
+
+    try {
+        found = calls.find(matcher);
+    } catch (error) {
+        throw new Error(
+            `Matcher failed for request ${method} ${path}: ${error.message}`,
+        );
+    }
 
     if (found) {
         return found;

--- a/features/support/request.js
+++ b/features/support/request.js
@@ -50,15 +50,13 @@ export async function waitForRequest(
 
     const calls = await externalActivityPub.getRequestsForAPI(method, path);
 
-    let found;
-
-    try {
-        found = calls.find(matcher);
-    } catch (error) {
-        throw new Error(
-            `Matcher failed for request ${method} ${path}: ${error.message}`,
-        );
-    }
+    const found = calls.find((call) => {
+        try {
+            return matcher(call);
+        } catch {
+            return false;
+        }
+    });
 
     if (found) {
         return found;


### PR DESCRIPTION
no ref

Bunch of cucumber updates to try and make the test suite less flakey:

- Added missing tables from `Before` and sorted alphabetically
- Removed redundant global `BeforeAll`
- Refactored  `Then the note is in my followers feeds` step to allow for retries to occur in-case there is latency in the system
- Refactored `waitForRequest` to follow same pattern as other `waitFor...` functions to allow for proper exponential backoff
- Refactored `activitypub` steps when checking an activity has been sent to multiple followers in an effort to make these steps more reliable
- Removed unused `Activity {string} is sent to all followers` step