### PR TITLE
Fixed Renovate automerge schedule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,10 +8,13 @@
     // See: https://docs.renovatebot.com/presets-docker/#dockerdisablemajor
     "docker:disableMajor"
   ],
-  // Automerge only on Monday, Tuesday and Wednesday, during common working hours (08:00 - 16:00 UTC)
-  // Rationale: merging to main ships to production, so we want to avoid automerging when no engineer is online
-  // Note: this doesn't restrict when the PRs are opened by Renovate, only when they are merged
-  "automergeSchedule": ["* 8-15 * * 1,2,3"],
+  // Automerge only on Monday, Tuesday, Wednesday and Thursday mornings UTC (08:00 - 11:59 UTC)
+  // Why? Merging to main ships to production, so we want to avoid automerging when no engineer is online
+  // Notes:
+  // - this doesn't restrict when the PRs are opened by Renovate, only when they are merged
+  // - this works only if we're using Renovate automerge over platform automerge (Github)
+  "platformAutomerge": false,
+  "automergeSchedule": ["* 8-11 * * 1,2,3,4"],
   // Automerge lock file updates, whenever available
   // Note: the base config file has this enabled, but on a weekly basis only
   "lockFileMaintenance": {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2695

- as merging to main ships to production for ActivityPub, we'd like to avoid merging dependency updates during the night or over weekends, when no engineer is online
- Fixed previous automerging config by switching to Renovate automerge over Github automerge (platformAutomerge = false), as per Renovate docs: https://docs.renovatebot.com/configuration-options/#automergeschedule
- Updated the automerge schedule to be Monday, Tuesday, Wednesday and Thursday mornings UTC (08:00 - 11:59 UTC), to be during working hours of the team that owns the ActivityPub workload (GMT/UTC)