### PR TITLE
Fixed `slack-notify` job not running on workflow failure (again)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -62,7 +62,7 @@ jobs:
     if: always()
     steps:
       - uses: tryghost/actions/actions/slack-build@main
-        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: contains(needs.*.result, 'failure') && github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
           status: ${{ job.status }}
         env:


### PR DESCRIPTION
ref https://github.com/TryGhost/ActivityPub/pull/1324

Apparently the previous fix did not work, but it's not totally clear why. There seems to be an issue using `always()` and `failure()` together.

According to the official GitHub docs, `failure()` should return true `when any ancestor job fails,` but in practice (as documented in https://github.com/orgs/community/discussions/80788), it always returns false even when dependent jobs fail.

Have changed condition to explicitly check on the results of the previous jobs