### PR TITLE
Fixed lint warnings

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "includes": ["**", "!**/package.json", "!**/__snapshots__/**"]
+    "includes": ["**", "!**/package.json", "!**/__snapshots__"]
   },
   "formatter": {
     "enabled": true,

--- a/jobs/__template__/index.ts
+++ b/jobs/__template__/index.ts
@@ -20,7 +20,7 @@ async function main() {
               }
             : {
                   host: process.env.DB_HOST,
-                  port: Number.parseInt(process.env.DB_PORT || '3306'),
+                  port: Number.parseInt(process.env.DB_PORT || '3306', 10),
                   user: process.env.DB_USER,
                   password: process.env.DB_PASSWORD,
                   database: process.env.DB_NAME,

--- a/jobs/migrate-bluesky-handles/index.ts
+++ b/jobs/migrate-bluesky-handles/index.ts
@@ -183,7 +183,7 @@ async function main(bridgyAccountId: number) {
               }
             : {
                   host: process.env.DB_HOST,
-                  port: Number.parseInt(process.env.DB_PORT || '3306'),
+                  port: Number.parseInt(process.env.DB_PORT || '3306', 10),
                   user: process.env.DB_USER,
                   password: process.env.DB_PASSWORD,
                   database: process.env.DB_NAME,
@@ -224,6 +224,7 @@ async function main(bridgyAccountId: number) {
 if (import.meta.main) {
     const bridgyAccountId = parseInt(
         process.env.BRIDGY_ACCOUNT_ID || process.argv[2] || '',
+        10,
     );
 
     if (!bridgyAccountId || Number.isNaN(bridgyAccountId)) {

--- a/jobs/populate-explore-json/index.ts
+++ b/jobs/populate-explore-json/index.ts
@@ -22,8 +22,14 @@ const config = {
     s3FilePath: process.env.S3_FILE_PATH || 'explore/accounts.json',
     s3AccessKeyId: process.env.S3_ACCESS_KEY_ID,
     s3SecretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
-    maxConcurrent: Number.parseInt(process.env.MAX_CONCURRENT_REQUESTS || '10'),
-    requestTimeout: Number.parseInt(process.env.REQUEST_TIMEOUT_MS || '30000'), // 30 seconds default
+    maxConcurrent: Number.parseInt(
+        process.env.MAX_CONCURRENT_REQUESTS || '10',
+        10,
+    ),
+    requestTimeout: Number.parseInt(
+        process.env.REQUEST_TIMEOUT_MS || '30000',
+        10,
+    ), // 30 seconds default
 };
 
 // AccountDTO interface

--- a/src/db.ts
+++ b/src/db.ts
@@ -87,7 +87,7 @@ export const knex = Knex({
           }
         : {
               host: process.env.MYSQL_HOST,
-              port: Number.parseInt(process.env.MYSQL_PORT!),
+              port: Number.parseInt(process.env.MYSQL_PORT!, 10),
               user: process.env.MYSQL_USER,
               password: process.env.MYSQL_PASSWORD,
               database: process.env.MYSQL_DATABASE,

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -809,7 +809,7 @@ export function createFollowingDispatcher(
     ) {
         ctx.data.logger.info('Following Dispatcher');
 
-        const offset = Number.parseInt(cursor ?? '0');
+        const offset = Number.parseInt(cursor ?? '0', 10);
         let nextCursor: string | null = null;
 
         const host = ctx.request.headers.get('host')!;

--- a/src/http/api/account.controller.ts
+++ b/src/http/api/account.controller.ts
@@ -124,7 +124,7 @@ export class AccountController {
             accountFollows = await this.accountFollowsView.getFollowsByAccount(
                 siteDefaultAccount,
                 type,
-                Number.parseInt(next || '0'),
+                Number.parseInt(next || '0', 10),
                 siteDefaultAccount,
             );
         } else {
@@ -147,7 +147,7 @@ export class AccountController {
                     await this.accountFollowsView.getFollowsByAccount(
                         account,
                         type,
-                        Number.parseInt(next || '0'),
+                        Number.parseInt(next || '0', 10),
                         siteDefaultAccount,
                     );
             } else {

--- a/src/post/content.ts
+++ b/src/post/content.ts
@@ -169,7 +169,7 @@ export class ContentPreparer {
         // Restore URLs
         return preparedContent.replace(
             /__URL_(\d+)__/g,
-            (_, index) => urls[Number.parseInt(index)],
+            (_, index) => urls[Number.parseInt(index, 10)],
         );
     }
 

--- a/src/test/db.ts
+++ b/src/test/db.ts
@@ -21,7 +21,7 @@ export async function createTestDb() {
               }
             : {
                   host: process.env.MYSQL_HOST,
-                  port: Number.parseInt(process.env.MYSQL_PORT!),
+                  port: Number.parseInt(process.env.MYSQL_PORT!, 10),
                   user: process.env.MYSQL_USER,
                   password: process.env.MYSQL_PASSWORD,
                   database: 'mysql',
@@ -65,7 +65,7 @@ export async function createTestDb() {
               }
             : {
                   host: process.env.MYSQL_HOST,
-                  port: Number.parseInt(process.env.MYSQL_PORT!),
+                  port: Number.parseInt(process.env.MYSQL_PORT!, 10),
                   user: process.env.MYSQL_USER,
                   password: process.env.MYSQL_PASSWORD,
                   database: dbName,
@@ -87,7 +87,7 @@ export async function createTestDb() {
                   }
                 : {
                       host: process.env.MYSQL_HOST,
-                      port: Number.parseInt(process.env.MYSQL_PORT!),
+                      port: Number.parseInt(process.env.MYSQL_PORT!, 10),
                       user: process.env.MYSQL_USER,
                       password: process.env.MYSQL_PASSWORD,
                       database: 'mysql',


### PR DESCRIPTION
no ref

Since we upgraded to the latest version of Biome we have been seeing lint warnings being reported on the usage of `Number.parseInt` as a new rule was added as part of the `recommended` ruleset