### PR TITLE
Added timeout to queue outbound requests to minimize in-flight requests

### DIFF
--- a/src/mq/gcloud-pubsub-push/error-utils.ts
+++ b/src/mq/gcloud-pubsub-push/error-utils.ts
@@ -103,7 +103,8 @@ function isNetworkConnectivityError(error: Error, depth = 0): boolean {
         error.message.match(/(read|connect) ECONNRESET/i) !== null ||
         error.message.match(/socket hang up/i) !== null ||
         error.message.match(/Connect Timeout Error/i) !== null ||
-        error.message.match(/other side closed/i) !== null
+        error.message.match(/other side closed/i) !== null ||
+        error.name === 'TimeoutError'
     ) {
         return true;
     }

--- a/src/mq/gcloud-pubsub-push/mq.ts
+++ b/src/mq/gcloud-pubsub-push/mq.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 import type {
     MessageQueue,
     MessageQueueEnqueueOptions,
@@ -13,6 +15,21 @@ import { z } from 'zod';
 import type { AccountService } from '@/account/account.service';
 import { parseURL } from '@/core/url';
 import { analyzeError } from '@/mq/gcloud-pubsub-push/error-utils';
+
+const OUTGOING_FETCH_TIMEOUT_MS = 10_000;
+
+const fetchTimeoutStorage = new AsyncLocalStorage<number>();
+const originalFetch = globalThis.fetch;
+globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+    const timeout = fetchTimeoutStorage.getStore();
+    if (timeout && !init?.signal) {
+        return originalFetch(input, {
+            ...init,
+            signal: AbortSignal.timeout(timeout),
+        });
+    }
+    return originalFetch(input, init);
+};
 
 /**
  * Message from Fedify
@@ -298,7 +315,9 @@ export class GCloudPubSubPushMessageQueue implements MessageQueue {
         );
 
         try {
-            await this.messageHandler(message.data);
+            await fetchTimeoutStorage.run(OUTGOING_FETCH_TIMEOUT_MS, () =>
+                this.messageHandler!(message.data),
+            );
 
             await this.handleSuccess(message.data);
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3241

- Adds a 10s timeout to all outbound requests. The timeout is more than enough for servers to process the request and triggers a fail-fast mechanism that frees up resources.