### PR TITLE
Pin @types/node to the deployed Node runtime major

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,5 +35,17 @@
         '@fedify/*',
       ]
     },
+
+    // Pin @types/node to the deployed Node runtime major (22.x, see Dockerfile
+    // and .nvmrc). Bumping the typings ahead of the runtime lets the compiler
+    // accept Node-24-only APIs that won't exist in production. Bump
+    // allowedVersions in lockstep when the Node base image is upgraded.
+    {
+      description: 'Pin @types/node to the deployed Node runtime major',
+      matchPackageNames: [
+        '@types/node',
+      ],
+      allowedVersions: '<23',
+    },
   ],
 }


### PR DESCRIPTION
## Summary

- Adds a Renovate `packageRule` constraining `@types/node` to `<23`, matching the Node 22 base image (`Dockerfile`, `.nvmrc`).
- Prevents Renovate from proposing `@types/node` major bumps ahead of the deployed runtime, which would let the compiler accept Node-24-only APIs that fail at runtime in production (the situation in #1572).

## Maintenance note

When the Node base image is upgraded (e.g. to Node 24), bump `allowedVersions` in the same PR so the typings catch up.

