### PR TITLE
Fixed flakey test in post service integration tests

### DIFF
--- a/src/post/post.service.integration.test.ts
+++ b/src/post/post.service.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
     Collection,
@@ -63,8 +63,11 @@ describe('PostService', () => {
     let events: AsyncEvents;
     let logger: Logger;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         db = await createTestDb();
+    });
+
+    beforeEach(async () => {
         events = new AsyncEvents();
         logger = {
             info: vi.fn(),
@@ -138,11 +141,6 @@ describe('PostService', () => {
 
         // Create a test account
         [account] = await fixtureManager.createInternalAccount();
-    });
-
-    afterEach(async () => {
-        // Clean up database connections
-        await db.destroy();
     });
 
     describe('createNote', () => {


### PR DESCRIPTION
The PostService integration test was creating a fresh MySQL database in every beforeEach hook (40+ tests), which involves multiple SHOW CREATE TABLE / CREATE TABLE round-trips per test. Under CI load this could exceed the 10 second hook timeout, causing flaky failures (e.g. "should handle deleting an external post").

We now match the pattern used by other integration tests (e.g. KnexPostRepository, NotificationService): create the test database once in beforeAll and only reset fixtures in beforeEach. The afterEach db.destroy() is no longer needed since createTestDb registers its own afterAll cleanup.