### PR TITLE
Replaced unmaintained url-regex dependency with linkifyjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "reflect-metadata": "0.2.2",
     "sanitize-html": "2.17.4",
     "sharp": "0.34.5",
-    "url-regex": "5.0.0",
     "uuid": "14.0.0",
     "x-forwarded-fetch": "0.2.0",
     "zod": "4.4.3"

--- a/src/post/content.ts
+++ b/src/post/content.ts
@@ -1,7 +1,7 @@
 import { htmlToText } from 'html-to-text';
 import linkifyHtml from 'linkify-html';
+import { find as findLinks } from 'linkifyjs';
 import { parse } from 'node-html-parser';
-import urlRegex from 'url-regex';
 
 import { HANDLE_REGEX } from '@/constants';
 import { isEqual } from '@/helpers/uri';
@@ -150,10 +150,17 @@ export class ContentPreparer {
     private addMentions(content: string, mentions: Mention[]) {
         // Protect URLs by replacing them with placeholders
         const urls: string[] = [];
-        let preparedContent = content.replace(urlRegex(), (url) => {
-            urls.push(url);
-            return `__URL_${urls.length - 1}__`;
-        });
+        const tokens = findLinks(content, 'url');
+
+        let preparedContent = '';
+        let lastEnd = 0;
+        for (const token of tokens) {
+            preparedContent += content.substring(lastEnd, token.start);
+            preparedContent += `__URL_${urls.length}__`;
+            urls.push(token.value);
+            lastEnd = token.end;
+        }
+        preparedContent += content.substring(lastEnd);
 
         for (const mention of mentions) {
             const mentionRegex = new RegExp(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2835,11 +2835,6 @@ ioredis@5.10.1:
     redis-parser "^3.0.0"
     standard-as-callback "^2.1.0"
 
-ip-regex@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
-  integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
-
 is-core-module@^2.16.1:
   version "2.16.2"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.2.tgz#3e07450a8080ebce3fbf0cac494f4d2ab324e082"
@@ -4309,11 +4304,6 @@ tinyrainbow@^3.1.0:
   resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-3.1.0.tgz#1d8a623893f95cf0a2ddb9e5d11150e191409421"
   integrity sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==
 
-tlds@^1.203.0:
-  version "1.261.0"
-  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.261.0.tgz#055e412e92f01f84a9c8ac0504d3472d68b3c4c9"
-  integrity sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==
-
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
@@ -4411,14 +4401,6 @@ uri-template-router@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/uri-template-router/-/uri-template-router-1.0.0.tgz#b29c5bcbf96863dfb7fa17b88e9ae14e85aa671e"
   integrity sha512-WKcL9ZSIEhHE3f5P4Z47Tf0nWbcgV1ISb/OBuF8YKEYi0SQOyTLCzM6B/gAKFWZhRhqA+C/Ks8UXe2qU5W0FVg==
-
-url-regex@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/url-regex/-/url-regex-5.0.0.tgz#8f5456ab83d898d18b2f91753a702649b873273a"
-  integrity sha512-O08GjTiAFNsSlrUWfqF1jH0H1W3m35ZyadHrGv5krdnmPPoxP27oDTqux/579PtaroiSGm5yma6KT1mHFH6Y/g==
-  dependencies:
-    ip-regex "^4.1.0"
-    tlds "^1.203.0"
 
 url-template@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
- Removes `url-regex@5.0.0` unmaintained package
- Switches the single call site in `ContentPreparer.addMentions()` to `linkifyjs.find()`, which is already a direct dependency (used by `linkify-html` in the same file) and scans for URLs with a hand-written tokenizer rather than a backtracking regex.


