### PR TITLE
Fixed flakey AccountSearchView integration test

### DIFF
--- a/src/http/api/views/account.search.view.integration.test.ts
+++ b/src/http/api/views/account.search.view.integration.test.ts
@@ -43,7 +43,16 @@ describe('AccountSearchView', () => {
 
         accountSearchView = new AccountSearchView(db);
 
-        [viewerAccount] = await fixtureManager.createInternalAccount();
+        // Use a deterministic host/name for the viewer so faker-generated
+        // values can never collide with the search queries below
+        [viewerAccount] = await fixtureManager.createInternalAccount(
+            undefined,
+            'viewer-fixture.invalid',
+        );
+
+        await db('accounts')
+            .where('id', viewerAccount.id)
+            .update({ name: 'Generic Fixture Viewer' });
     });
 
     describe('search', () => {


### PR DESCRIPTION
The `AccountSearchView > search > should be case-insensitive` integration test failed intermittently on CI (most recently on [#1814](https://github.com/TryGhost/ActivityPub/pull/1814)) with:

```
AssertionError: expected [ { …(7) }, { …(7) } ] to have a length of 1 but got 2
 ❯ src/http/api/views/account.search.view.integration.test.ts:102:34
```

Root cause: the test searches for `'TRO'` (and other case variants) and expects exactly one match — `Troy Hunt` from the search fixtures. The viewer account in `beforeEach` is created via `fixtureManager.createInternalAccount()`, which falls back to `faker.person.fullName()` for its name (via [fixtures.ts:312](src/test/fixtures.ts:312)) and `faker.internet.domainName()` for its host. When faker happens to produce a name or domain with a word starting with `Tro` (e.g. `Troy`, `Tronquise`, `trotter.com`), the FULLTEXT prefix match `+TRO*` returns the viewer alongside `Troy Hunt`, breaking the assertion.

Fix: force a deterministic host and name on the viewer in `beforeEach` so faker output can never collide with any of the search queries exercised in this file.