### PR TITLE
Add inbound Move activity handling

### DIFF
--- a/features/move.feature
+++ b/features/move.feature
@@ -1,0 +1,12 @@
+Feature: Migrating follows when a remote account moves
+
+  Scenario: We follow the new account when a followed account moves
+    Given an Actor "Person(Alice)"
+    And an Actor "Person(AliceNew)" with alias "Alice"
+    And we are following "Alice"
+    And a "Move(Alice)" Activity "Move" by "Alice" with target "AliceNew"
+    When "Alice" sends "Move" to the Inbox
+    Then a "Follow(AliceNew)" activity is sent to "AliceNew"
+    And a "Undo(Follow)" activity is sent to "Alice"
+    And "AliceNew" is in our following
+    And "Alice" is not in our following

--- a/features/step_definitions/move_steps.js
+++ b/features/step_definitions/move_steps.js
@@ -1,0 +1,73 @@
+import { Given } from '@cucumber/cucumber';
+
+import { createActivity, createActor } from '../support/fixtures.js';
+import { parseActivityString, parseActorString } from '../support/steps.js';
+
+async function ensureActor(world, input) {
+    const parsed = parseActorString(input);
+    const name = parsed.name ?? input;
+    const type = parsed.type ?? 'Person';
+
+    if (!world.actors[name]) {
+        world.actors[name] = await createActor(name, { type });
+    }
+
+    return { name, actor: world.actors[name] };
+}
+
+Given(
+    'an Actor {string} with alias {string}',
+    async function (actorInput, aliasInput) {
+        const { actor: aliasActor } = await ensureActor(this, aliasInput);
+        const parsed = parseActorString(actorInput);
+        const name = parsed.name ?? actorInput;
+        const type = parsed.type ?? 'Person';
+
+        this.actors[name] = await createActor(name, {
+            type,
+            aliases: [aliasActor],
+        });
+    },
+);
+
+Given(
+    'a {string} Activity {string} by {string} with target {string}',
+    async function (activityDef, name, actorName, targetName) {
+        const { activity: activityType, object: objectName } =
+            parseActivityString(activityDef);
+        if (!activityType) {
+            throw new Error(`could not match ${activityDef} to an activity`);
+        }
+
+        const actor = this.actors[actorName];
+        if (!actor) {
+            throw new Error(`Could not find Actor ${actorName}`);
+        }
+
+        const object =
+            this.actors[objectName] ??
+            this.activities[objectName] ??
+            this.objects[objectName];
+        if (!object) {
+            throw new Error(`Could not find object ${objectName}`);
+        }
+
+        const target = this.actors[targetName];
+        if (!target) {
+            throw new Error(`Could not find target Actor ${targetName}`);
+        }
+
+        const activity = await createActivity(activityType, object, actor, {
+            target,
+        });
+
+        const parsedName = parseActivityString(name);
+        if (parsedName.activity === null || parsedName.object === null) {
+            this.activities[name] = activity;
+            this.objects[name] = object;
+        } else {
+            this.activities[parsedName.activity] = activity;
+            this.objects[parsedName.object] = object;
+        }
+    },
+);

--- a/features/support/fixtures.js
+++ b/features/support/fixtures.js
@@ -104,7 +104,7 @@ export async function createObject(
     return object;
 }
 
-export async function createActivity(type, object, actor) {
+export async function createActivity(type, object, actor, extras = {}) {
     let activity;
 
     if (type === 'Follow') {
@@ -219,6 +219,21 @@ export async function createActivity(type, object, actor) {
         };
     }
 
+    if (type === 'Move') {
+        activity = {
+            '@context': [
+                'https://www.w3.org/ns/activitystreams',
+                'https://w3id.org/security/data-integrity/v1',
+            ],
+            type: 'Move',
+            id: `${process.env.URL_EXTERNAL_ACTIVITY_PUB}/move/${uuidv4()}`,
+            to: 'as:Public',
+            object: object,
+            target: extras.target,
+            actor: actor,
+        };
+    }
+
     const externalActivityPub = getExternalWiremock();
 
     await externalActivityPub.register(
@@ -243,7 +258,7 @@ export async function createActivity(type, object, actor) {
 
 export async function createActor(
     name,
-    { remote = true, type = 'Person' } = {},
+    { remote = true, type = 'Person', aliases } = {},
 ) {
     if (remote === false) {
         return {
@@ -310,6 +325,10 @@ export async function createActor(
                 '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtSc3IqGjRaO3vcFdQ15D\nF90WVJC6tb2QwYBh9kQYVlQ1VhBiF6E4GK2okvyvukIL5PHLCgfQrfJmSiopk9Xo\n46Qri6rJbcPoWoZz/jWN0pfmU20hNuTQx6ebSoSkg6rHv1MKuy5LmDGLFC2ze3kU\nsY8u7X6TOBrifs/N+goLaH3+SkT2hZDKWJrmDyHzj043KLvXs/eiyu50M+ERoSlg\n70uO7QAXQFuLMILdy0UNJFM4xjlK6q4Jfbm4MC8QRG+i31AkmNvpY9JqCLqu0mGD\nBrdfJeN8PN+7DHW/Pzspf5RlJtlvBx1dS8Bxo2xteUyLGIaTZ9HZFhHc3IrmmKeW\naQIDAQAB\n-----END PUBLIC KEY-----\n',
         },
     };
+
+    if (aliases) {
+        user.alsoKnownAs = aliases.map((alias) => alias?.id ?? alias);
+    }
 
     const externalActivityPub = getExternalWiremock();
 

--- a/src/account/account.repository.knex.ts
+++ b/src/account/account.repository.knex.ts
@@ -389,15 +389,11 @@ export class KnexAccountRepository {
         return this.mapRowToAccountEntity(accountRow);
     }
 
-    async getInternalFollowersOf(account: Account): Promise<Account[]> {
-        const internalAccountExists = this.db('users')
-            .select(1)
-            .whereRaw('users.account_id = accounts.id');
-
+    async getInternalFollowers(account: Account): Promise<Account[]> {
         const rows = await this.db('follows')
             .innerJoin('accounts', 'accounts.id', 'follows.follower_id')
+            .innerJoin('users', 'users.account_id', 'accounts.id')
             .where('follows.following_id', account.id)
-            .whereExists(internalAccountExists)
             .select(
                 'accounts.id',
                 'accounts.uuid',
@@ -414,7 +410,7 @@ export class KnexAccountRepository {
                 'accounts.ap_following_url',
                 'accounts.ap_liked_url',
                 'accounts.custom_fields',
-                this.db.raw('1 as site_id'),
+                'users.site_id',
             );
 
         return Promise.all(rows.map((row) => this.mapRowToAccountEntity(row)));

--- a/src/account/account.repository.knex.ts
+++ b/src/account/account.repository.knex.ts
@@ -389,6 +389,37 @@ export class KnexAccountRepository {
         return this.mapRowToAccountEntity(accountRow);
     }
 
+    async getInternalFollowersOf(account: Account): Promise<Account[]> {
+        const internalAccountExists = this.db('users')
+            .select(1)
+            .whereRaw('users.account_id = accounts.id');
+
+        const rows = await this.db('follows')
+            .innerJoin('accounts', 'accounts.id', 'follows.follower_id')
+            .where('follows.following_id', account.id)
+            .whereExists(internalAccountExists)
+            .select(
+                'accounts.id',
+                'accounts.uuid',
+                'accounts.username',
+                'accounts.name',
+                'accounts.bio',
+                'accounts.url',
+                'accounts.avatar_url',
+                'accounts.banner_image_url',
+                'accounts.ap_id',
+                'accounts.ap_followers_url',
+                'accounts.ap_inbox_url',
+                'accounts.ap_outbox_url',
+                'accounts.ap_following_url',
+                'accounts.ap_liked_url',
+                'accounts.custom_fields',
+                this.db.raw('1 as site_id'),
+            );
+
+        return Promise.all(rows.map((row) => this.mapRowToAccountEntity(row)));
+    }
+
     async getKeyPair(
         accountId: number,
     ): Promise<{ publicKey: string | null; privateKey: string | null } | null> {

--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -1003,6 +1003,51 @@ describe('AccountService', () => {
         });
     });
 
+    describe('getInternalFollowersOfAccount', () => {
+        it('should retrieve only internal accounts following an account', async () => {
+            const account = await fixtureManager.createExternalAccount();
+            const [internalFollower] =
+                await fixtureManager.createInternalAccount();
+            const externalFollower =
+                await fixtureManager.createExternalAccount();
+
+            await fixtureManager.createFollow(internalFollower, account);
+            await fixtureManager.createFollow(externalFollower, account);
+
+            const followers =
+                await service.getInternalFollowersOfAccount(account);
+
+            expect(followers).toHaveLength(1);
+            expect(followers[0]).toMatchObject({
+                id: internalFollower.id,
+                isInternal: true,
+            });
+        });
+
+        it('should not duplicate internal followers when an account has multiple users', async () => {
+            const account = await fixtureManager.createExternalAccount();
+            const [internalFollower] =
+                await fixtureManager.createInternalAccount();
+            const extraSite = await fixtureManager.createSite();
+
+            await db('users').insert({
+                account_id: internalFollower.id,
+                site_id: extraSite.id,
+            });
+
+            await fixtureManager.createFollow(internalFollower, account);
+
+            const followers =
+                await service.getInternalFollowersOfAccount(account);
+
+            expect(followers).toHaveLength(1);
+            expect(followers[0]).toMatchObject({
+                id: internalFollower.id,
+                isInternal: true,
+            });
+        });
+    });
+
     describe('checkIfAccountIsFollowing', () => {
         it('should check if an account is following another account', async () => {
             const [[account], [followee], [nonFollowee]] = await Promise.all([

--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -1003,7 +1003,7 @@ describe('AccountService', () => {
         });
     });
 
-    describe('getInternalFollowersOfAccount', () => {
+    describe('getInternalFollowerAccounts', () => {
         it('should retrieve only internal accounts following an account', async () => {
             const account = await fixtureManager.createExternalAccount();
             const [internalFollower] =
@@ -1015,30 +1015,7 @@ describe('AccountService', () => {
             await fixtureManager.createFollow(externalFollower, account);
 
             const followers =
-                await service.getInternalFollowersOfAccount(account);
-
-            expect(followers).toHaveLength(1);
-            expect(followers[0]).toMatchObject({
-                id: internalFollower.id,
-                isInternal: true,
-            });
-        });
-
-        it('should not duplicate internal followers when an account has multiple users', async () => {
-            const account = await fixtureManager.createExternalAccount();
-            const [internalFollower] =
-                await fixtureManager.createInternalAccount();
-            const extraSite = await fixtureManager.createSite();
-
-            await db('users').insert({
-                account_id: internalFollower.id,
-                site_id: extraSite.id,
-            });
-
-            await fixtureManager.createFollow(internalFollower, account);
-
-            const followers =
-                await service.getInternalFollowersOfAccount(account);
+                await service.getInternalFollowerAccounts(account);
 
             expect(followers).toHaveLength(1);
             expect(followers[0]).toMatchObject({

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -852,6 +852,16 @@ export class AccountService {
         await this.accountRepository.save(updated);
     }
 
+    async migrateFollow(
+        follower: Account,
+        sourceAccount: Account,
+        targetAccount: Account,
+    ) {
+        const updated = follower.unfollow(sourceAccount).follow(targetAccount);
+
+        await this.accountRepository.save(updated);
+    }
+
     async readAllNotifications(account: Account) {
         const updated = account.readAllNotifications();
 

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -818,8 +818,8 @@ export class AccountService {
         return await this.accountRepository.getById(id);
     }
 
-    async getInternalFollowersOfAccount(account: Account): Promise<Account[]> {
-        return await this.accountRepository.getInternalFollowersOf(account);
+    async getInternalFollowerAccounts(account: Account): Promise<Account[]> {
+        return await this.accountRepository.getInternalFollowers(account);
     }
 
     async saveAccount(account: Account): Promise<void> {

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -822,10 +822,6 @@ export class AccountService {
         return await this.accountRepository.getInternalFollowers(account);
     }
 
-    async saveAccount(account: Account): Promise<void> {
-        await this.accountRepository.save(account);
-    }
-
     async blockDomain(
         account: Account,
         domain: URL,

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -655,7 +655,7 @@ export class AccountService {
     async getByInternalId(id: number): Promise<AccountType | null> {
         const rows = await this.db('accounts').select('*').where({ id });
 
-        if (!rows || !rows.length) {
+        if (!rows?.length) {
             return null;
         }
 
@@ -816,6 +816,14 @@ export class AccountService {
 
     async getAccountById(id: number) {
         return await this.accountRepository.getById(id);
+    }
+
+    async getInternalFollowersOfAccount(account: Account): Promise<Account[]> {
+        return await this.accountRepository.getInternalFollowersOf(account);
+    }
+
+    async saveAccount(account: Account): Promise<void> {
+        await this.accountRepository.save(account);
     }
 
     async blockDomain(

--- a/src/activity-handlers/move.handler.integration.test.ts
+++ b/src/activity-handlers/move.handler.integration.test.ts
@@ -50,16 +50,6 @@ describe('MoveHandler', () => {
     beforeEach(async () => {
         await fixtureManager.reset();
 
-        await db.raw('SET FOREIGN_KEY_CHECKS = 0');
-        try {
-            await db('follows').truncate();
-            await db('accounts').truncate();
-            await db('users').truncate();
-            await db('sites').truncate();
-        } finally {
-            await db.raw('SET FOREIGN_KEY_CHECKS = 1');
-        }
-
         events = new AsyncEvents();
         const accountRepository = new KnexAccountRepository(db, events);
         const fedifyContextFactory = {

--- a/src/activity-handlers/move.handler.integration.test.ts
+++ b/src/activity-handlers/move.handler.integration.test.ts
@@ -1,0 +1,156 @@
+import {
+    afterEach,
+    beforeAll,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+} from 'vitest';
+
+import { lookupObject, Move, Person } from '@fedify/fedify';
+import type { Knex } from 'knex';
+
+import { KnexAccountRepository } from '@/account/account.repository.knex';
+import { AccountService } from '@/account/account.service';
+import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
+import type { FedifyContext } from '@/app';
+import { AsyncEvents } from '@/core/events';
+import { ModerationService } from '@/moderation/moderation.service';
+import { generateTestCryptoKeyPair } from '@/test/crypto-key-pair';
+import { createTestDb } from '@/test/db';
+import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
+import { MoveHandler } from './move.handler';
+
+vi.mock('@fedify/fedify', async (importOriginal) => {
+    const original = await importOriginal<typeof import('@fedify/fedify')>();
+
+    return {
+        ...original,
+        lookupObject: vi.fn(),
+    };
+});
+
+describe('MoveHandler', () => {
+    let db: Knex;
+    let events: AsyncEvents;
+    let fixtureManager: FixtureManager;
+    let handler: MoveHandler;
+    let ctx: FedifyContext;
+
+    beforeAll(async () => {
+        db = await createTestDb();
+        fixtureManager = createFixtureManager(db);
+    });
+
+    afterEach(() => {
+        events.removeAllListeners();
+    });
+
+    beforeEach(async () => {
+        await fixtureManager.reset();
+
+        await db.raw('SET FOREIGN_KEY_CHECKS = 0');
+        try {
+            await db('follows').truncate();
+            await db('accounts').truncate();
+            await db('users').truncate();
+            await db('sites').truncate();
+        } finally {
+            await db.raw('SET FOREIGN_KEY_CHECKS = 1');
+        }
+
+        events = new AsyncEvents();
+        const accountRepository = new KnexAccountRepository(db, events);
+        const fedifyContextFactory = {
+            getFedifyContext: () => ({
+                getDocumentLoader: async () => ({}),
+            }),
+        } as unknown as FedifyContextFactory;
+        const accountService = new AccountService(
+            db,
+            events,
+            accountRepository,
+            fedifyContextFactory,
+            generateTestCryptoKeyPair,
+        );
+        const moderationService = new ModerationService(db);
+
+        handler = new MoveHandler(accountService, moderationService);
+
+        ctx = {
+            data: {
+                globaldb: {
+                    set: async () => undefined,
+                },
+                logger: {
+                    debug: () => undefined,
+                    warn: () => undefined,
+                },
+            },
+            getObjectUri: (klass: { name: string }, data: { id: string }) => {
+                return new URL(
+                    `https://ghost.example/.ghost/activitypub/${klass.name.toLowerCase()}/${data.id}`,
+                );
+            },
+            getDocumentLoader: async () => ({}),
+            sendActivity: async () => undefined,
+        } as unknown as FedifyContext;
+    });
+
+    it('moves an internal follower from the old remote actor to the new remote actor', async () => {
+        const [follower] = await fixtureManager.createInternalAccount();
+        const oldAccount = await fixtureManager.createExternalAccount(
+            'https://mastodon.example/users/',
+        );
+        const newAccount = await fixtureManager.createExternalAccount(
+            'https://new.example/users/',
+        );
+
+        await fixtureManager.createFollow(follower, oldAccount);
+
+        const oldActor = new Person({
+            id: oldAccount.apId,
+            inbox: oldAccount.apInbox,
+            preferredUsername: oldAccount.username,
+        });
+        const newActor = new Person({
+            id: newAccount.apId,
+            inbox: newAccount.apInbox,
+            preferredUsername: newAccount.username,
+            aliases: [oldAccount.apId],
+        });
+        vi.mocked(lookupObject).mockResolvedValue(newActor);
+
+        await handler.handle(
+            ctx,
+            new Move({
+                id: new URL(`${oldAccount.apId.href}#moves/1`),
+                actor: oldActor,
+                object: oldActor,
+                target: newActor,
+            }),
+        );
+
+        await expect(
+            db('follows')
+                .where({
+                    follower_id: follower.id,
+                    following_id: oldAccount.id,
+                })
+                .first(),
+        ).resolves.toBeUndefined();
+
+        await expect(
+            db('follows')
+                .where({
+                    follower_id: follower.id,
+                    following_id: newAccount.id,
+                })
+                .first(),
+        ).resolves.toMatchObject({
+            follower_id: follower.id,
+            following_id: newAccount.id,
+        });
+    });
+});

--- a/src/activity-handlers/move.handler.ts
+++ b/src/activity-handlers/move.handler.ts
@@ -101,7 +101,7 @@ export class MoveHandler {
         const targetAccount = getValue(targetAccountResult);
 
         const followers =
-            await this.accountService.getInternalFollowersOfAccount(
+            await this.accountService.getInternalFollowerAccounts(
                 sourceAccount,
             );
 

--- a/src/activity-handlers/move.handler.ts
+++ b/src/activity-handlers/move.handler.ts
@@ -263,6 +263,10 @@ export class MoveHandler {
         sourceAccount: Account,
         sourceActor: Actor,
     ) {
+        // Best-effort cleanup: the follower's local state has already been
+        // migrated by this point, so a failed Undo only leaves a stale follow
+        // on the source server. Swallow the error here so that the outer loop
+        // does not treat the migration as failed.
         try {
             const follow = new Follow({
                 id: null,

--- a/src/activity-handlers/move.handler.ts
+++ b/src/activity-handlers/move.handler.ts
@@ -227,13 +227,12 @@ export class MoveHandler {
             await this.sendFollow(ctx, follower, targetActor);
         }
 
-        let updatedFollower = follower.unfollow(sourceAccount);
+        await this.accountService.unfollowAccount(follower, sourceAccount);
 
         if (!alreadyFollowingTarget) {
-            updatedFollower = updatedFollower.follow(targetAccount);
+            await this.accountService.followAccount(follower, targetAccount);
         }
 
-        await this.accountService.saveAccount(updatedFollower);
         await this.sendUndoFollow(ctx, follower, sourceAccount, sourceActor);
     }
 

--- a/src/activity-handlers/move.handler.ts
+++ b/src/activity-handlers/move.handler.ts
@@ -227,14 +227,15 @@ export class MoveHandler {
                 targetAccount.id,
             );
 
-        if (!alreadyFollowingTarget) {
+        if (alreadyFollowingTarget) {
+            await this.accountService.unfollowAccount(follower, sourceAccount);
+        } else {
             await this.sendFollow(ctx, follower, targetActor);
-        }
-
-        await this.accountService.unfollowAccount(follower, sourceAccount);
-
-        if (!alreadyFollowingTarget) {
-            await this.accountService.followAccount(follower, targetAccount);
+            await this.accountService.migrateFollow(
+                follower,
+                sourceAccount,
+                targetAccount,
+            );
         }
 
         await this.sendUndoFollow(ctx, follower, sourceAccount, sourceActor);

--- a/src/activity-handlers/move.handler.ts
+++ b/src/activity-handlers/move.handler.ts
@@ -1,0 +1,294 @@
+import {
+    type Actor,
+    Follow,
+    isActor,
+    lookupObject,
+    type Move,
+    Person,
+    Undo,
+} from '@fedify/fedify';
+import { v4 as uuidv4 } from 'uuid';
+
+import type { Account } from '@/account/account.entity';
+import type { AccountService } from '@/account/account.service';
+import type { FedifyContext } from '@/app';
+import { getValue, isError } from '@/core/result';
+import type { ModerationService } from '@/moderation/moderation.service';
+
+export class MoveHandler {
+    constructor(
+        private readonly accountService: AccountService,
+        private readonly moderationService: ModerationService,
+    ) {}
+
+    async handle(ctx: FedifyContext, move: Move) {
+        ctx.data.logger.debug('Handling Move');
+
+        if (!move.id) {
+            ctx.data.logger.debug('Move missing id, exit early');
+            return;
+        }
+
+        if (!move.actorId) {
+            ctx.data.logger.debug('Move missing actorId, exit early');
+            return;
+        }
+
+        if (!move.objectId) {
+            ctx.data.logger.debug('Move missing objectId, exit early');
+            return;
+        }
+
+        if (!move.targetId) {
+            ctx.data.logger.debug('Move missing targetId, exit early');
+            return;
+        }
+
+        if (move.actorId.href !== move.objectId.href) {
+            ctx.data.logger.debug('Move actor and object differ, exit early');
+            return;
+        }
+
+        if (move.actorId.href === move.targetId.href) {
+            ctx.data.logger.debug('Move target matches actor, exit early');
+            return;
+        }
+
+        const sourceAccountRow = await this.accountService.getAccountByApId(
+            move.actorId.href,
+        );
+
+        if (!sourceAccountRow) {
+            ctx.data.logger.debug('Move source account not found, exit early');
+            return;
+        }
+
+        const sourceAccount = await this.accountService.getAccountById(
+            sourceAccountRow.id,
+        );
+
+        if (!sourceAccount) {
+            ctx.data.logger.debug(
+                'Move source account entity not found, exit early',
+            );
+            return;
+        }
+
+        const targetActor = await this.getTargetActor(ctx, move);
+
+        if (!targetActor) {
+            return;
+        }
+
+        const sourceActor = this.createSourceActor(sourceAccount);
+
+        if (!this.targetAliasesSource(targetActor.aliasIds, move.actorId)) {
+            ctx.data.logger.debug(
+                'Move target does not alias source account, exit early',
+            );
+            return;
+        }
+
+        const targetAccountResult = await this.accountService.ensureByApId(
+            targetActor.id!,
+        );
+
+        if (isError(targetAccountResult)) {
+            ctx.data.logger.debug('Move target account not found, exit early');
+            return;
+        }
+
+        const targetAccount = getValue(targetAccountResult);
+
+        const followers =
+            await this.accountService.getInternalFollowersOfAccount(
+                sourceAccount,
+            );
+
+        if (followers.length === 0) {
+            ctx.data.logger.debug('Move source has no internal followers');
+            return;
+        }
+
+        await this.persistActivity(ctx, move, targetActor);
+
+        for (const follower of followers) {
+            try {
+                await this.moveFollower(
+                    ctx,
+                    follower,
+                    sourceAccount,
+                    targetAccount,
+                    targetActor,
+                    sourceActor,
+                );
+            } catch (err) {
+                ctx.data.logger.warn('Failed to migrate follower during Move', {
+                    error: err,
+                    follower: follower.apId.href,
+                    source: sourceAccount.apId.href,
+                    target: targetAccount.apId.href,
+                });
+            }
+        }
+    }
+
+    private targetAliasesSource(
+        targetAliases: Iterable<URL>,
+        sourceApId: URL,
+    ): boolean {
+        return Array.from(targetAliases).some(
+            (alias) => alias.href === sourceApId.href,
+        );
+    }
+
+    private async getTargetActor(
+        ctx: FedifyContext,
+        move: Move,
+    ): Promise<Actor | null> {
+        let target: unknown;
+
+        try {
+            const documentLoader = await ctx.getDocumentLoader({
+                handle: 'index',
+            });
+            target = await lookupObject(move.targetId!, { documentLoader });
+        } catch (err) {
+            ctx.data.logger.debug('Move target lookup failed, exit early', {
+                error: err,
+            });
+            return null;
+        }
+
+        if (!isActor(target) || !target.id) {
+            ctx.data.logger.debug('Move target is not an actor, exit early');
+            return null;
+        }
+
+        if (target.id.href !== move.targetId!.href) {
+            ctx.data.logger.debug('Move target id does not match, exit early');
+            return null;
+        }
+
+        return target;
+    }
+
+    private createSourceActor(sourceAccount: Account): Actor {
+        return new Person({
+            id: sourceAccount.apId,
+            inbox: sourceAccount.apInbox,
+            preferredUsername: sourceAccount.username,
+        });
+    }
+
+    private async persistActivity(
+        ctx: FedifyContext,
+        move: Move,
+        targetActor: Actor,
+    ) {
+        const [moveJson, targetJson] = await Promise.all([
+            move.toJsonLd(),
+            targetActor.toJsonLd(),
+        ]);
+
+        await Promise.all([
+            ctx.data.globaldb.set([move.id!.href], moveJson),
+            ctx.data.globaldb.set([targetActor.id!.href], targetJson),
+        ]);
+    }
+
+    private async moveFollower(
+        ctx: FedifyContext,
+        follower: Account,
+        sourceAccount: Account,
+        targetAccount: Account,
+        targetActor: Actor,
+        sourceActor: Actor,
+    ) {
+        const canInteract = await this.moderationService.canFollowAccount(
+            follower.id,
+            targetAccount.id,
+        );
+
+        if (!canInteract) {
+            ctx.data.logger.debug(
+                `${follower.apId.href} is not allowed to follow ${targetAccount.apId.href}`,
+            );
+            return;
+        }
+
+        const alreadyFollowingTarget =
+            await this.accountService.checkIfAccountIsFollowing(
+                follower.id,
+                targetAccount.id,
+            );
+
+        if (!alreadyFollowingTarget) {
+            await this.sendFollow(ctx, follower, targetActor);
+        }
+
+        let updatedFollower = follower.unfollow(sourceAccount);
+
+        if (!alreadyFollowingTarget) {
+            updatedFollower = updatedFollower.follow(targetAccount);
+        }
+
+        await this.accountService.saveAccount(updatedFollower);
+        await this.sendUndoFollow(ctx, follower, sourceAccount, sourceActor);
+    }
+
+    private async sendFollow(
+        ctx: FedifyContext,
+        follower: Account,
+        targetActor: Actor,
+    ) {
+        const follow = new Follow({
+            id: ctx.getObjectUri(Follow, { id: uuidv4() }),
+            actor: follower.apId,
+            object: targetActor.id,
+        });
+
+        const followJson = await follow.toJsonLd();
+
+        await ctx.data.globaldb.set([follow.id!.href], followJson);
+        await ctx.sendActivity(
+            { username: follower.username },
+            targetActor,
+            follow,
+        );
+    }
+
+    private async sendUndoFollow(
+        ctx: FedifyContext,
+        follower: Account,
+        sourceAccount: Account,
+        sourceActor: Actor,
+    ) {
+        try {
+            const follow = new Follow({
+                id: null,
+                actor: follower.apId,
+                object: sourceAccount.apId,
+            });
+            const undo = new Undo({
+                id: ctx.getObjectUri(Undo, { id: uuidv4() }),
+                actor: follower.apId,
+                object: follow,
+            });
+            const undoJson = await undo.toJsonLd();
+
+            await ctx.data.globaldb.set([undo.id!.href], undoJson);
+            await ctx.sendActivity(
+                { username: follower.username },
+                sourceActor,
+                undo,
+            );
+        } catch (err) {
+            ctx.data.logger.warn('Failed to send Undo for Move activity', {
+                error: err,
+                account: follower.apId.href,
+                source: sourceAccount.apId.href,
+            });
+        }
+    }
+}

--- a/src/activity-handlers/move.handler.ts
+++ b/src/activity-handlers/move.handler.ts
@@ -210,6 +210,10 @@ export class MoveHandler {
             targetAccount.id,
         );
 
+        // If either side has blocked the other, skip this follower entirely.
+        // The follow of the source account is intentionally left in place; a
+        // block expresses an explicit decision, and the Move should not be
+        // used to bypass it. The stale follow can be cleaned up manually.
         if (!canInteract) {
             ctx.data.logger.debug(
                 `${follower.apId.href} is not allowed to follow ${targetAccount.apId.href}`,

--- a/src/activity-handlers/move.handler.unit.test.ts
+++ b/src/activity-handlers/move.handler.unit.test.ts
@@ -2,10 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Follow, lookupObject, Move, Person, Undo } from '@fedify/fedify';
 
-import { type Account, AccountEntity } from '@/account/account.entity';
+import type { Account } from '@/account/account.entity';
 import type { AccountService } from '@/account/account.service';
-import { AccountFollowedEvent } from '@/account/events/account-followed.event';
-import { AccountUnfollowedEvent } from '@/account/events/account-unfollowed.event';
 import type { FedifyContext } from '@/app';
 import { error, ok } from '@/core/result';
 import type { ModerationService } from '@/moderation/moderation.service';
@@ -32,7 +30,8 @@ describe('MoveHandler', () => {
         ensureByApId: ReturnType<typeof vi.fn>;
         getInternalFollowerAccounts: ReturnType<typeof vi.fn>;
         checkIfAccountIsFollowing: ReturnType<typeof vi.fn>;
-        saveAccount: ReturnType<typeof vi.fn>;
+        followAccount: ReturnType<typeof vi.fn>;
+        unfollowAccount: ReturnType<typeof vi.fn>;
     };
     let moderationService: {
         canFollowAccount: ReturnType<typeof vi.fn>;
@@ -75,7 +74,8 @@ describe('MoveHandler', () => {
             ensureByApId: vi.fn(),
             getInternalFollowerAccounts: vi.fn(),
             checkIfAccountIsFollowing: vi.fn(),
-            saveAccount: vi.fn(),
+            followAccount: vi.fn(),
+            unfollowAccount: vi.fn(),
         };
 
         moderationService = {
@@ -272,7 +272,8 @@ describe('MoveHandler', () => {
 
         await handler.handle(ctx, createMove());
 
-        expect(accountService.saveAccount).not.toHaveBeenCalled();
+        expect(accountService.unfollowAccount).not.toHaveBeenCalled();
+        expect(accountService.followAccount).not.toHaveBeenCalled();
         expect(ctx.sendActivity).not.toHaveBeenCalled();
     });
 
@@ -281,7 +282,8 @@ describe('MoveHandler', () => {
 
         await handler.handle(ctx, createMove());
 
-        expect(accountService.saveAccount).not.toHaveBeenCalled();
+        expect(accountService.unfollowAccount).not.toHaveBeenCalled();
+        expect(accountService.followAccount).not.toHaveBeenCalled();
         expect(ctx.sendActivity).not.toHaveBeenCalled();
     });
 
@@ -297,12 +299,12 @@ describe('MoveHandler', () => {
             expect.any(Undo),
         );
 
-        const savedAccount = accountService.saveAccount.mock.calls[0][0];
-        const events = AccountEntity.pullEvents(savedAccount);
-
-        expect(events).toEqual([
-            new AccountUnfollowedEvent(sourceAccount.id, followerAccount.id),
-        ]);
+        expect(accountService.unfollowAccount).toHaveBeenCalledOnce();
+        expect(accountService.unfollowAccount).toHaveBeenCalledWith(
+            followerAccount,
+            sourceAccount,
+        );
+        expect(accountService.followAccount).not.toHaveBeenCalled();
     });
 
     it('follows the target and unfollows the old account for a valid Move', async () => {
@@ -322,13 +324,14 @@ describe('MoveHandler', () => {
             expect.any(Undo),
         );
 
-        const savedAccount = accountService.saveAccount.mock.calls[0][0];
-        const events = AccountEntity.pullEvents(savedAccount);
-
-        expect(events).toEqual([
-            new AccountUnfollowedEvent(sourceAccount.id, followerAccount.id),
-            new AccountFollowedEvent(targetAccount.id, followerAccount.id),
-        ]);
+        expect(accountService.unfollowAccount).toHaveBeenCalledWith(
+            followerAccount,
+            sourceAccount,
+        );
+        expect(accountService.followAccount).toHaveBeenCalledWith(
+            followerAccount,
+            targetAccount,
+        );
         expect(globaldb.set).toHaveBeenCalledWith(
             [createMove().id!.href],
             expect.any(Object),
@@ -342,7 +345,8 @@ describe('MoveHandler', () => {
 
         await handler.handle(ctx, createMove());
 
-        expect(accountService.saveAccount).not.toHaveBeenCalled();
+        expect(accountService.unfollowAccount).not.toHaveBeenCalled();
+        expect(accountService.followAccount).not.toHaveBeenCalled();
     });
 
     it('continues migrating later followers when one follower fails', async () => {
@@ -367,14 +371,16 @@ describe('MoveHandler', () => {
 
         await handler.handle(ctx, createMove());
 
-        expect(accountService.saveAccount).toHaveBeenCalledOnce();
-        const savedAccount = accountService.saveAccount.mock.calls[0][0];
-        const events = AccountEntity.pullEvents(savedAccount);
-
-        expect(events).toEqual([
-            new AccountUnfollowedEvent(sourceAccount.id, secondFollower.id),
-            new AccountFollowedEvent(targetAccount.id, secondFollower.id),
-        ]);
+        expect(accountService.unfollowAccount).toHaveBeenCalledOnce();
+        expect(accountService.unfollowAccount).toHaveBeenCalledWith(
+            secondFollower,
+            sourceAccount,
+        );
+        expect(accountService.followAccount).toHaveBeenCalledOnce();
+        expect(accountService.followAccount).toHaveBeenCalledWith(
+            secondFollower,
+            targetAccount,
+        );
     });
 
     it('ignores embedded target aliases when authoritative target does not alias the source', async () => {
@@ -394,6 +400,7 @@ describe('MoveHandler', () => {
         await handler.handle(ctx, createMove({ target: embeddedTarget }));
 
         expect(accountService.ensureByApId).not.toHaveBeenCalled();
-        expect(accountService.saveAccount).not.toHaveBeenCalled();
+        expect(accountService.unfollowAccount).not.toHaveBeenCalled();
+        expect(accountService.followAccount).not.toHaveBeenCalled();
     });
 });

--- a/src/activity-handlers/move.handler.unit.test.ts
+++ b/src/activity-handlers/move.handler.unit.test.ts
@@ -1,0 +1,399 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Follow, lookupObject, Move, Person, Undo } from '@fedify/fedify';
+
+import { type Account, AccountEntity } from '@/account/account.entity';
+import type { AccountService } from '@/account/account.service';
+import { AccountFollowedEvent } from '@/account/events/account-followed.event';
+import { AccountUnfollowedEvent } from '@/account/events/account-unfollowed.event';
+import type { FedifyContext } from '@/app';
+import { error, ok } from '@/core/result';
+import type { ModerationService } from '@/moderation/moderation.service';
+import {
+    createTestExternalAccount,
+    createTestInternalAccount,
+} from '@/test/account-entity-test-helpers';
+import { MoveHandler } from './move.handler';
+
+vi.mock('@fedify/fedify', async (importOriginal) => {
+    const original = await importOriginal<typeof import('@fedify/fedify')>();
+
+    return {
+        ...original,
+        lookupObject: vi.fn(),
+    };
+});
+
+describe('MoveHandler', () => {
+    let handler: MoveHandler;
+    let accountService: {
+        getAccountByApId: ReturnType<typeof vi.fn>;
+        getAccountById: ReturnType<typeof vi.fn>;
+        ensureByApId: ReturnType<typeof vi.fn>;
+        getInternalFollowersOfAccount: ReturnType<typeof vi.fn>;
+        checkIfAccountIsFollowing: ReturnType<typeof vi.fn>;
+        saveAccount: ReturnType<typeof vi.fn>;
+    };
+    let moderationService: {
+        canFollowAccount: ReturnType<typeof vi.fn>;
+    };
+    let ctx: FedifyContext;
+    let globaldb: {
+        set: ReturnType<typeof vi.fn>;
+    };
+    let sourceAccount: Account;
+    let targetAccount: Account;
+    let followerAccount: Account;
+    let sourceActor: Person;
+    let targetActor: Person;
+
+    beforeEach(async () => {
+        globaldb = {
+            set: vi.fn(),
+        };
+
+        ctx = {
+            data: {
+                globaldb,
+                logger: {
+                    debug: vi.fn(),
+                    warn: vi.fn(),
+                },
+            },
+            getObjectUri: vi.fn((klass, data) => {
+                return new URL(
+                    `https://ghost.example/.ghost/activitypub/${klass.name.toLowerCase()}/${data.id}`,
+                );
+            }),
+            getDocumentLoader: vi.fn().mockResolvedValue({}),
+            sendActivity: vi.fn(),
+        } as unknown as FedifyContext;
+
+        accountService = {
+            getAccountByApId: vi.fn(),
+            getAccountById: vi.fn(),
+            ensureByApId: vi.fn(),
+            getInternalFollowersOfAccount: vi.fn(),
+            checkIfAccountIsFollowing: vi.fn(),
+            saveAccount: vi.fn(),
+        };
+
+        moderationService = {
+            canFollowAccount: vi.fn().mockResolvedValue(true),
+        };
+
+        handler = new MoveHandler(
+            accountService as unknown as AccountService,
+            moderationService as unknown as ModerationService,
+        );
+
+        followerAccount = await createTestInternalAccount(1, {
+            host: new URL('https://ghost.example'),
+            username: 'index',
+            name: 'Ghost',
+            bio: null,
+            url: null,
+            avatarUrl: null,
+            bannerImageUrl: null,
+            customFields: null,
+        });
+
+        sourceAccount = await createTestExternalAccount(2, {
+            username: 'old',
+            name: 'Old account',
+            bio: null,
+            url: null,
+            avatarUrl: null,
+            bannerImageUrl: null,
+            customFields: null,
+            apId: new URL('https://mastodon.example/users/old'),
+            apFollowers: null,
+            apInbox: new URL('https://mastodon.example/users/old/inbox'),
+        });
+
+        targetAccount = await createTestExternalAccount(3, {
+            username: 'new',
+            name: 'New account',
+            bio: null,
+            url: null,
+            avatarUrl: null,
+            bannerImageUrl: null,
+            customFields: null,
+            apId: new URL('https://mastodon.example/users/new'),
+            apFollowers: null,
+            apInbox: new URL('https://mastodon.example/users/new/inbox'),
+        });
+
+        sourceActor = new Person({
+            id: sourceAccount.apId,
+            inbox: sourceAccount.apInbox,
+            preferredUsername: sourceAccount.username,
+        });
+
+        targetActor = new Person({
+            id: targetAccount.apId,
+            inbox: targetAccount.apInbox,
+            preferredUsername: targetAccount.username,
+            aliases: [sourceAccount.apId],
+        });
+
+        vi.mocked(lookupObject).mockResolvedValue(targetActor);
+        accountService.getAccountByApId.mockResolvedValue({
+            id: sourceAccount.id,
+        });
+        accountService.getAccountById.mockResolvedValue(sourceAccount);
+        accountService.ensureByApId.mockResolvedValue(ok(targetAccount));
+        accountService.getInternalFollowersOfAccount.mockResolvedValue([
+            followerAccount,
+        ]);
+        accountService.checkIfAccountIsFollowing.mockResolvedValue(false);
+    });
+
+    function createMove(
+        overrides: Partial<ConstructorParameters<typeof Move>[0]> = {},
+    ) {
+        return new Move({
+            id: new URL('https://mastodon.example/users/old#moves/1'),
+            actor: sourceActor,
+            object: sourceActor,
+            target: targetActor,
+            ...overrides,
+        });
+    }
+
+    it('ignores Move activities with missing required ids', async () => {
+        for (const move of [
+            { id: null },
+            { id: createMove().id, actorId: null },
+            {
+                id: createMove().id,
+                actorId: sourceAccount.apId,
+                objectId: null,
+            },
+            {
+                id: createMove().id,
+                actorId: sourceAccount.apId,
+                objectId: sourceAccount.apId,
+                targetId: null,
+            },
+        ]) {
+            await handler.handle(ctx, move as unknown as Move);
+        }
+
+        expect(accountService.getAccountByApId).not.toHaveBeenCalled();
+        expect(ctx.sendActivity).not.toHaveBeenCalled();
+    });
+
+    it('ignores Move activities where actor and object differ', async () => {
+        await handler.handle(
+            ctx,
+            createMove({
+                object: new URL('https://mastodon.example/users/someone-else'),
+            }),
+        );
+
+        expect(accountService.getAccountByApId).not.toHaveBeenCalled();
+        expect(ctx.sendActivity).not.toHaveBeenCalled();
+    });
+
+    it('ignores Move activities when the source account is not known locally', async () => {
+        accountService.getAccountByApId.mockResolvedValue(null);
+
+        await handler.handle(ctx, createMove());
+
+        expect(accountService.ensureByApId).not.toHaveBeenCalled();
+        expect(ctx.sendActivity).not.toHaveBeenCalled();
+    });
+
+    it('ignores Move activities when the target lookup fails', async () => {
+        vi.mocked(lookupObject).mockRejectedValue(new Error('lookup failed'));
+
+        await handler.handle(ctx, createMove());
+
+        expect(accountService.ensureByApId).not.toHaveBeenCalled();
+        expect(ctx.sendActivity).not.toHaveBeenCalled();
+    });
+
+    it('ignores Move activities when the target account lookup fails', async () => {
+        accountService.ensureByApId.mockResolvedValue(error('network-failure'));
+
+        await handler.handle(ctx, createMove());
+
+        expect(
+            accountService.getInternalFollowersOfAccount,
+        ).not.toHaveBeenCalled();
+        expect(ctx.sendActivity).not.toHaveBeenCalled();
+    });
+
+    it('ignores Move activities when the target is not an actor', async () => {
+        vi.mocked(lookupObject).mockResolvedValue({
+            id: targetAccount.apId,
+        } as never);
+
+        await handler.handle(ctx, {
+            id: createMove().id,
+            actorId: sourceAccount.apId,
+            objectId: sourceAccount.apId,
+            targetId: targetAccount.apId,
+        } as unknown as Move);
+
+        expect(accountService.ensureByApId).not.toHaveBeenCalled();
+        expect(ctx.sendActivity).not.toHaveBeenCalled();
+    });
+
+    it('ignores Move activities when the target does not alias the source', async () => {
+        targetActor = new Person({
+            id: targetAccount.apId,
+            inbox: targetAccount.apInbox,
+            preferredUsername: targetAccount.username,
+        });
+        vi.mocked(lookupObject).mockResolvedValue(targetActor);
+
+        await handler.handle(ctx, createMove({ target: targetActor }));
+
+        expect(accountService.ensureByApId).not.toHaveBeenCalled();
+        expect(ctx.sendActivity).not.toHaveBeenCalled();
+    });
+
+    it('ignores Move activities when the target matches the source', async () => {
+        await handler.handle(
+            ctx,
+            createMove({
+                target: sourceActor,
+            }),
+        );
+
+        expect(accountService.getAccountByApId).not.toHaveBeenCalled();
+        expect(ctx.sendActivity).not.toHaveBeenCalled();
+    });
+
+    it('ignores Move activities when there are no internal followers', async () => {
+        accountService.getInternalFollowersOfAccount.mockResolvedValue([]);
+
+        await handler.handle(ctx, createMove());
+
+        expect(accountService.saveAccount).not.toHaveBeenCalled();
+        expect(ctx.sendActivity).not.toHaveBeenCalled();
+    });
+
+    it('ignores followers that cannot interact with the target account', async () => {
+        moderationService.canFollowAccount.mockResolvedValue(false);
+
+        await handler.handle(ctx, createMove());
+
+        expect(accountService.saveAccount).not.toHaveBeenCalled();
+        expect(ctx.sendActivity).not.toHaveBeenCalled();
+    });
+
+    it('unfollows the old account when already following the target', async () => {
+        accountService.checkIfAccountIsFollowing.mockResolvedValue(true);
+
+        await handler.handle(ctx, createMove());
+
+        expect(ctx.sendActivity).toHaveBeenCalledOnce();
+        expect(ctx.sendActivity).toHaveBeenCalledWith(
+            { username: followerAccount.username },
+            expect.objectContaining({ id: sourceAccount.apId }),
+            expect.any(Undo),
+        );
+
+        const savedAccount = accountService.saveAccount.mock.calls[0][0];
+        const events = AccountEntity.pullEvents(savedAccount);
+
+        expect(events).toEqual([
+            new AccountUnfollowedEvent(sourceAccount.id, followerAccount.id),
+        ]);
+    });
+
+    it('follows the target and unfollows the old account for a valid Move', async () => {
+        await handler.handle(ctx, createMove());
+
+        expect(ctx.sendActivity).toHaveBeenCalledTimes(2);
+        expect(ctx.sendActivity).toHaveBeenNthCalledWith(
+            1,
+            { username: followerAccount.username },
+            targetActor,
+            expect.any(Follow),
+        );
+        expect(ctx.sendActivity).toHaveBeenNthCalledWith(
+            2,
+            { username: followerAccount.username },
+            expect.objectContaining({ id: sourceAccount.apId }),
+            expect.any(Undo),
+        );
+
+        const savedAccount = accountService.saveAccount.mock.calls[0][0];
+        const events = AccountEntity.pullEvents(savedAccount);
+
+        expect(events).toEqual([
+            new AccountUnfollowedEvent(sourceAccount.id, followerAccount.id),
+            new AccountFollowedEvent(targetAccount.id, followerAccount.id),
+        ]);
+        expect(globaldb.set).toHaveBeenCalledWith(
+            [createMove().id!.href],
+            expect.any(Object),
+        );
+    });
+
+    it('keeps the old follow when sending the target Follow fails', async () => {
+        vi.mocked(ctx.sendActivity).mockRejectedValueOnce(
+            new Error('send failed'),
+        );
+
+        await handler.handle(ctx, createMove());
+
+        expect(accountService.saveAccount).not.toHaveBeenCalled();
+    });
+
+    it('continues migrating later followers when one follower fails', async () => {
+        const secondFollower = await createTestInternalAccount(4, {
+            host: new URL('https://second.example'),
+            username: 'index',
+            name: 'Second',
+            bio: null,
+            url: null,
+            avatarUrl: null,
+            bannerImageUrl: null,
+            customFields: null,
+        });
+
+        accountService.getInternalFollowersOfAccount.mockResolvedValue([
+            followerAccount,
+            secondFollower,
+        ]);
+        vi.mocked(ctx.sendActivity)
+            .mockRejectedValueOnce(new Error('send failed'))
+            .mockResolvedValue(undefined);
+
+        await handler.handle(ctx, createMove());
+
+        expect(accountService.saveAccount).toHaveBeenCalledOnce();
+        const savedAccount = accountService.saveAccount.mock.calls[0][0];
+        const events = AccountEntity.pullEvents(savedAccount);
+
+        expect(events).toEqual([
+            new AccountUnfollowedEvent(sourceAccount.id, secondFollower.id),
+            new AccountFollowedEvent(targetAccount.id, secondFollower.id),
+        ]);
+    });
+
+    it('ignores embedded target aliases when authoritative target does not alias the source', async () => {
+        const embeddedTarget = new Person({
+            id: targetAccount.apId,
+            inbox: targetAccount.apInbox,
+            preferredUsername: targetAccount.username,
+            aliases: [sourceAccount.apId],
+        });
+        const fetchedTarget = new Person({
+            id: targetAccount.apId,
+            inbox: targetAccount.apInbox,
+            preferredUsername: targetAccount.username,
+        });
+        vi.mocked(lookupObject).mockResolvedValue(fetchedTarget);
+
+        await handler.handle(ctx, createMove({ target: embeddedTarget }));
+
+        expect(accountService.ensureByApId).not.toHaveBeenCalled();
+        expect(accountService.saveAccount).not.toHaveBeenCalled();
+    });
+});

--- a/src/activity-handlers/move.handler.unit.test.ts
+++ b/src/activity-handlers/move.handler.unit.test.ts
@@ -30,8 +30,8 @@ describe('MoveHandler', () => {
         ensureByApId: ReturnType<typeof vi.fn>;
         getInternalFollowerAccounts: ReturnType<typeof vi.fn>;
         checkIfAccountIsFollowing: ReturnType<typeof vi.fn>;
-        followAccount: ReturnType<typeof vi.fn>;
         unfollowAccount: ReturnType<typeof vi.fn>;
+        migrateFollow: ReturnType<typeof vi.fn>;
     };
     let moderationService: {
         canFollowAccount: ReturnType<typeof vi.fn>;
@@ -74,8 +74,8 @@ describe('MoveHandler', () => {
             ensureByApId: vi.fn(),
             getInternalFollowerAccounts: vi.fn(),
             checkIfAccountIsFollowing: vi.fn(),
-            followAccount: vi.fn(),
             unfollowAccount: vi.fn(),
+            migrateFollow: vi.fn(),
         };
 
         moderationService = {
@@ -273,7 +273,7 @@ describe('MoveHandler', () => {
         await handler.handle(ctx, createMove());
 
         expect(accountService.unfollowAccount).not.toHaveBeenCalled();
-        expect(accountService.followAccount).not.toHaveBeenCalled();
+        expect(accountService.migrateFollow).not.toHaveBeenCalled();
         expect(ctx.sendActivity).not.toHaveBeenCalled();
     });
 
@@ -283,7 +283,7 @@ describe('MoveHandler', () => {
         await handler.handle(ctx, createMove());
 
         expect(accountService.unfollowAccount).not.toHaveBeenCalled();
-        expect(accountService.followAccount).not.toHaveBeenCalled();
+        expect(accountService.migrateFollow).not.toHaveBeenCalled();
         expect(ctx.sendActivity).not.toHaveBeenCalled();
     });
 
@@ -304,7 +304,7 @@ describe('MoveHandler', () => {
             followerAccount,
             sourceAccount,
         );
-        expect(accountService.followAccount).not.toHaveBeenCalled();
+        expect(accountService.migrateFollow).not.toHaveBeenCalled();
     });
 
     it('follows the target and unfollows the old account for a valid Move', async () => {
@@ -324,14 +324,13 @@ describe('MoveHandler', () => {
             expect.any(Undo),
         );
 
-        expect(accountService.unfollowAccount).toHaveBeenCalledWith(
+        expect(accountService.migrateFollow).toHaveBeenCalledOnce();
+        expect(accountService.migrateFollow).toHaveBeenCalledWith(
             followerAccount,
             sourceAccount,
-        );
-        expect(accountService.followAccount).toHaveBeenCalledWith(
-            followerAccount,
             targetAccount,
         );
+        expect(accountService.unfollowAccount).not.toHaveBeenCalled();
         expect(globaldb.set).toHaveBeenCalledWith(
             [createMove().id!.href],
             expect.any(Object),
@@ -346,7 +345,7 @@ describe('MoveHandler', () => {
         await handler.handle(ctx, createMove());
 
         expect(accountService.unfollowAccount).not.toHaveBeenCalled();
-        expect(accountService.followAccount).not.toHaveBeenCalled();
+        expect(accountService.migrateFollow).not.toHaveBeenCalled();
     });
 
     it('continues migrating later followers when one follower fails', async () => {
@@ -371,16 +370,13 @@ describe('MoveHandler', () => {
 
         await handler.handle(ctx, createMove());
 
-        expect(accountService.unfollowAccount).toHaveBeenCalledOnce();
-        expect(accountService.unfollowAccount).toHaveBeenCalledWith(
+        expect(accountService.migrateFollow).toHaveBeenCalledOnce();
+        expect(accountService.migrateFollow).toHaveBeenCalledWith(
             secondFollower,
             sourceAccount,
-        );
-        expect(accountService.followAccount).toHaveBeenCalledOnce();
-        expect(accountService.followAccount).toHaveBeenCalledWith(
-            secondFollower,
             targetAccount,
         );
+        expect(accountService.unfollowAccount).not.toHaveBeenCalled();
     });
 
     it('ignores embedded target aliases when authoritative target does not alias the source', async () => {
@@ -401,6 +397,6 @@ describe('MoveHandler', () => {
 
         expect(accountService.ensureByApId).not.toHaveBeenCalled();
         expect(accountService.unfollowAccount).not.toHaveBeenCalled();
-        expect(accountService.followAccount).not.toHaveBeenCalled();
+        expect(accountService.migrateFollow).not.toHaveBeenCalled();
     });
 });

--- a/src/activity-handlers/move.handler.unit.test.ts
+++ b/src/activity-handlers/move.handler.unit.test.ts
@@ -30,7 +30,7 @@ describe('MoveHandler', () => {
         getAccountByApId: ReturnType<typeof vi.fn>;
         getAccountById: ReturnType<typeof vi.fn>;
         ensureByApId: ReturnType<typeof vi.fn>;
-        getInternalFollowersOfAccount: ReturnType<typeof vi.fn>;
+        getInternalFollowerAccounts: ReturnType<typeof vi.fn>;
         checkIfAccountIsFollowing: ReturnType<typeof vi.fn>;
         saveAccount: ReturnType<typeof vi.fn>;
     };
@@ -73,7 +73,7 @@ describe('MoveHandler', () => {
             getAccountByApId: vi.fn(),
             getAccountById: vi.fn(),
             ensureByApId: vi.fn(),
-            getInternalFollowersOfAccount: vi.fn(),
+            getInternalFollowerAccounts: vi.fn(),
             checkIfAccountIsFollowing: vi.fn(),
             saveAccount: vi.fn(),
         };
@@ -143,7 +143,7 @@ describe('MoveHandler', () => {
         });
         accountService.getAccountById.mockResolvedValue(sourceAccount);
         accountService.ensureByApId.mockResolvedValue(ok(targetAccount));
-        accountService.getInternalFollowersOfAccount.mockResolvedValue([
+        accountService.getInternalFollowerAccounts.mockResolvedValue([
             followerAccount,
         ]);
         accountService.checkIfAccountIsFollowing.mockResolvedValue(false);
@@ -220,7 +220,7 @@ describe('MoveHandler', () => {
         await handler.handle(ctx, createMove());
 
         expect(
-            accountService.getInternalFollowersOfAccount,
+            accountService.getInternalFollowerAccounts,
         ).not.toHaveBeenCalled();
         expect(ctx.sendActivity).not.toHaveBeenCalled();
     });
@@ -268,7 +268,7 @@ describe('MoveHandler', () => {
     });
 
     it('ignores Move activities when there are no internal followers', async () => {
-        accountService.getInternalFollowersOfAccount.mockResolvedValue([]);
+        accountService.getInternalFollowerAccounts.mockResolvedValue([]);
 
         await handler.handle(ctx, createMove());
 
@@ -357,7 +357,7 @@ describe('MoveHandler', () => {
             customFields: null,
         });
 
-        accountService.getInternalFollowersOfAccount.mockResolvedValue([
+        accountService.getInternalFollowerAccounts.mockResolvedValue([
             followerAccount,
             secondFollower,
         ]);

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import {
     Follow,
     type KvStore,
     Like,
+    Move,
     Note,
     Reject,
     type RequestContext,
@@ -53,6 +54,7 @@ import { dispatchRejectActivity } from '@/activity-dispatchers/reject.dispatcher
 import type { CreateHandler } from '@/activity-handlers/create.handler';
 import type { DeleteHandler } from '@/activity-handlers/delete.handler';
 import type { FollowHandler } from '@/activity-handlers/follow.handler';
+import type { MoveHandler } from '@/activity-handlers/move.handler';
 import type { UpdateHandler } from '@/activity-handlers/update.handler';
 import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import type { FediverseBridge } from '@/activitypub/fediverse-bridge';
@@ -433,6 +435,17 @@ inboxListener
                         'undoHandler',
                     );
                 return undoHandler(ctx, activity);
+            }),
+        ),
+    )
+    .onError(inboxErrorHandler)
+    .on(
+        Move,
+        ensureCorrectContext(
+            spanWrapper((ctx: FedifyContext, activity: Move) => {
+                const moveHandler =
+                    container.resolve<MoveHandler>('moveHandler');
+                return moveHandler.handle(ctx, activity);
             }),
         ),
     )

--- a/src/configuration/registrations.ts
+++ b/src/configuration/registrations.ts
@@ -17,6 +17,7 @@ import { AccountService } from '@/account/account.service';
 import { CreateHandler } from '@/activity-handlers/create.handler';
 import { DeleteHandler } from '@/activity-handlers/delete.handler';
 import { FollowHandler } from '@/activity-handlers/follow.handler';
+import { MoveHandler } from '@/activity-handlers/move.handler';
 import { UpdateHandler } from '@/activity-handlers/update.handler';
 import { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import { FediverseBridge } from '@/activitypub/fediverse-bridge';
@@ -375,6 +376,7 @@ export function registerDependencies(
     container.register('createHandler', asClass(CreateHandler).singleton());
     container.register('deleteHandler', asClass(DeleteHandler).singleton());
     container.register('followHandler', asClass(FollowHandler).singleton());
+    container.register('moveHandler', asClass(MoveHandler).singleton());
     container.register('updateHandler', asClass(UpdateHandler).singleton());
     container.register(
         'deleteDispatcher',

--- a/src/moderation/moderation.service.integration.test.ts
+++ b/src/moderation/moderation.service.integration.test.ts
@@ -317,6 +317,40 @@ describe('ModerationService', () => {
         });
     });
 
+    describe('canFollowAccount', () => {
+        it('should prevent following when the follower has blocked the target', async () => {
+            const [[aliceAccount], [bobAccount]] = await Promise.all([
+                fixtureManager.createInternalAccount(),
+                fixtureManager.createInternalAccount(),
+            ]);
+
+            await fixtureManager.createBlock(aliceAccount, bobAccount);
+
+            const aliceCanFollowBob = await moderationService.canFollowAccount(
+                aliceAccount.id,
+                bobAccount.id,
+            );
+
+            expect(aliceCanFollowBob).toBe(false);
+        });
+
+        it('should prevent following when the target has blocked the follower', async () => {
+            const [[aliceAccount], [bobAccount]] = await Promise.all([
+                fixtureManager.createInternalAccount(),
+                fixtureManager.createInternalAccount(),
+            ]);
+
+            await fixtureManager.createBlock(bobAccount, aliceAccount);
+
+            const aliceCanFollowBob = await moderationService.canFollowAccount(
+                aliceAccount.id,
+                bobAccount.id,
+            );
+
+            expect(aliceCanFollowBob).toBe(false);
+        });
+    });
+
     describe('getBlockedDomains', () => {
         it('should return blocked domains for an account', async () => {
             const [[aliceAccount], bobAccount, charlieAccount] =

--- a/src/moderation/moderation.service.integration.test.ts
+++ b/src/moderation/moderation.service.integration.test.ts
@@ -318,6 +318,20 @@ describe('ModerationService', () => {
     });
 
     describe('canFollowAccount', () => {
+        it('should allow following when neither account has blocked the other', async () => {
+            const [[aliceAccount], [bobAccount]] = await Promise.all([
+                fixtureManager.createInternalAccount(),
+                fixtureManager.createInternalAccount(),
+            ]);
+
+            const aliceCanFollowBob = await moderationService.canFollowAccount(
+                aliceAccount.id,
+                bobAccount.id,
+            );
+
+            expect(aliceCanFollowBob).toBe(true);
+        });
+
         it('should prevent following when the follower has blocked the target', async () => {
             const [[aliceAccount], [bobAccount]] = await Promise.all([
                 fixtureManager.createInternalAccount(),

--- a/src/moderation/moderation.service.ts
+++ b/src/moderation/moderation.service.ts
@@ -119,6 +119,18 @@ export class ModerationService {
         return block[0].length === 0;
     }
 
+    async canFollowAccount(
+        followerAccountId: number,
+        targetAccountId: number,
+    ): Promise<boolean> {
+        const [targetAllowsFollower, followerAllowsTarget] = await Promise.all([
+            this.canInteractWithAccount(followerAccountId, targetAccountId),
+            this.canInteractWithAccount(targetAccountId, followerAccountId),
+        ]);
+
+        return targetAllowsFollower && followerAllowsTarget;
+    }
+
     async getBlockedDomains(accountId: number): Promise<Set<string>> {
         const blocks = await this.db('domain_blocks')
             .where('blocker_id', accountId)


### PR DESCRIPTION
## Summary

Adds inbound ActivityPub `Move` handling for the case where a Ghost account follows a remote actor that migrates to a new actor.

The handler validates the Move, dereferences the authoritative target actor, requires the target actor to alias the source actor via `alsoKnownAs`, sends a Follow to the new actor, and then updates local follow state from the old actor to the new actor.

## Details

- Registers a class-based `MoveHandler` with Fedify inbox listeners.
- Adds an internal-follower repository/service lookup for accounts following the moved source actor.
- Adds bidirectional follow moderation so Move migration will not auto-follow blocked accounts or domains.
- Uses existing account follow/unfollow domain events to update follow state.
- Sends `Undo(Follow)` to the old actor best-effort after the local move.

