### PR TITLE
Make tryghost/activitypub-migrations Dockerfile multiplatform

### DIFF
--- a/migrate/Dockerfile
+++ b/migrate/Dockerfile
@@ -1,9 +1,10 @@
-FROM debian:bookworm-slim@sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb
+FROM docker.io/library/debian:bookworm-slim@sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb
+ARG TARGETARCH
 
 RUN apt-get update -y && \
     apt-get install -y curl && \
     rm -rf /var/lib/apt/lists/* && \
-    curl -L https://github.com/golang-migrate/migrate/releases/download/v4.17.1/migrate.linux-amd64.tar.gz | tar xvz && \
+    curl -L https://github.com/golang-migrate/migrate/releases/download/v4.17.1/migrate.linux-${TARGETARCH}.tar.gz | tar xvz && \
     mv migrate /usr/bin/
 
 COPY bin /usr/local/bin


### PR DESCRIPTION
- Pin sha256 of the image index, not the platform manifest digest. Use fully qualified container name.
- Use TARGETARCH to download the correct golang migrate binary