### PR TITLE
Fixed `ghost_uuid` ownership verification to allow legitimate domain changes

### DIFF
--- a/docs/site-registration.md
+++ b/docs/site-registration.md
@@ -1,6 +1,6 @@
 # Site Registration
 
-Site registration is the process by which a Ghost site connects to 
+Site registration is the process by which a Ghost site connects to
 the ActivityPub service
 
 ## Registration Flow
@@ -11,16 +11,48 @@ the ActivityPub service
    - If exists, returns existing site (idempotent)
    - If not, proceeds to create new site
 3. Service fetches site settings from Ghost to get `ghost_uuid` (called `site_uuid` in Ghost)
-4. Service handles `ghost_uuid` uniqueness:
-   - Checks if another site already has this `ghost_uuid`
-   - If found, nullifies the `ghost_uuid` on the old site
-   - This handles domain changes where the same Ghost instance registers with a new domain
+4. Service handles `ghost_uuid` uniqueness (see below)
 5. Service creates new site record with the `ghost_uuid`
 6. Service creates internal account for the site
 
 ## Duplicate ghost_uuid Handling
 
-The `ghost_uuid` uniquely identifies a Ghost site. When a Ghost site changes domains and re-registers:
+The `ghost_uuid` column on `sites` has a UNIQUE constraint. When a new
+host registers with a `ghost_uuid` that already belongs to an existing
+site row, the service classifies the previous owner's current state by
+fetching `/ghost/api/admin/site/` on the previous host:
 
-- **Old site** (`old-domain.com`): `ghost_uuid` is set to `null`, site remains active with all data intact
-- **New site** (`new-domain.com`): Gets the `ghost_uuid`, becomes the active registration for that Ghost instance
+| Previous host response                              | Classification         | Outcome                                |
+| --------------------------------------------------- | ---------------------- | -------------------------------------- |
+| 200 with the same `site_uuid`                       | `still-claims`         | Refuse the reassignment                |
+| 200 with a different / missing `site_uuid`          | `released`             | Allow reassignment                     |
+| 200 with non-JSON body                              | `released`             | Allow reassignment                     |
+| 3xx / 4xx                                           | `released`             | Allow reassignment                     |
+| DNS NXDOMAIN / EAI_AGAIN                            | `released`             | Allow reassignment                     |
+| Connection refused (ECONNREFUSED)                   | `released`             | Allow reassignment                     |
+| 5xx / timeout / other transport error               | `unverifiable`         | Allow reassignment (fail-open), logged |
+
+When the reassignment proceeds (whether `released` or `unverifiable`),
+the previous row's `ghost_uuid` is set to `null` and the new row takes
+the UUID. The previous row's account data stays intact; only the UUID
+claim is released.
+
+### Fail-open on unverifiable
+
+For genuinely ambiguous responses (5xx, timeout, TLS errors), the
+service allows the reassignment rather than refuse it. This prevents
+transient outages on the previous host from blocking legitimate domain
+changes. Reassignments classified as `unverifiable` are logged at warn
+level so the pattern is observable in logs.
+
+### Trust model
+
+This verification is best-effort against the previous host itself. It
+catches the case where a live, registered host actively serves a
+conflicting UUID. It does not authoritatively prove ownership and does
+not defend against:
+
+- A registration claiming a `ghost_uuid` that AP has never seen before
+  (no previous row to check against)
+- A host running a Ghost instance configured with a UUID that does not
+  belong to it

--- a/docs/site-registration.md
+++ b/docs/site-registration.md
@@ -28,8 +28,9 @@ fetching `/ghost/api/admin/site/` on the previous host:
 | 200 with a different / missing `site_uuid`          | `released`             | Allow reassignment                     |
 | 200 with non-JSON body                              | `released`             | Allow reassignment                     |
 | 3xx / 4xx                                           | `released`             | Allow reassignment                     |
-| DNS NXDOMAIN / EAI_AGAIN                            | `released`             | Allow reassignment                     |
+| DNS NXDOMAIN (ENOTFOUND)                            | `released`             | Allow reassignment                     |
 | Connection refused (ECONNREFUSED)                   | `released`             | Allow reassignment                     |
+| Transient DNS failure (EAI_AGAIN)                   | `unverifiable`         | Allow reassignment (fail-open), logged |
 | 5xx / timeout / other transport error               | `unverifiable`         | Allow reassignment (fail-open), logged |
 
 When the reassignment proceeds (whether `released` or `unverifiable`),

--- a/src/feed/feed.service.integration.test.ts
+++ b/src/feed/feed.service.integration.test.ts
@@ -152,6 +152,7 @@ describe('FeedService', () => {
         const logger = {
             info: vi.fn(),
             debug: vi.fn(),
+            warn: vi.fn(),
         } as unknown as Logger;
         events = new AsyncEvents();
         accountRepository = new KnexAccountRepository(client, events);
@@ -163,19 +164,24 @@ describe('FeedService', () => {
             fedifyContextFactory,
             generateTestCryptoKeyPair,
         );
-        siteService = new SiteService(client, accountService, {
-            async getSiteSettings(host: string) {
-                return {
-                    site: {
-                        title: `Site ${host} title`,
-                        description: `Site ${host} description`,
-                        icon: `https://${host}/favicon.ico`,
-                        cover_image: `https://${host}/cover.png`,
-                        site_uuid: crypto.randomUUID(),
-                    },
-                };
+        siteService = new SiteService(
+            client,
+            accountService,
+            {
+                async getSiteSettings(host: string) {
+                    return {
+                        site: {
+                            title: `Site ${host} title`,
+                            description: `Site ${host} description`,
+                            icon: `https://${host}/favicon.ico`,
+                            cover_image: `https://${host}/cover.png`,
+                            site_uuid: crypto.randomUUID(),
+                        },
+                    };
+                },
             },
-        });
+            logger,
+        );
         postRepository = new KnexPostRepository(client, events, logger);
         moderationService = new ModerationService(client);
         fixtureManager = createFixtureManager(client);

--- a/src/post/post.repository.knex.integration.test.ts
+++ b/src/post/post.repository.knex.integration.test.ts
@@ -70,23 +70,29 @@ describe('KnexPostRepository', () => {
             fedifyContextFactory,
             generateTestCryptoKeyPair,
         );
-        siteService = new SiteService(client, accountService, {
-            async getSiteSettings(host: string) {
-                return {
-                    site: {
-                        title: `Site ${host} title`,
-                        description: `Site ${host} description`,
-                        icon: `https://${host}/favicon.ico`,
-                        cover_image: `https://${host}/cover.png`,
-                        site_uuid: crypto.randomUUID(),
-                    },
-                };
-            },
-        });
         const logger = {
             info: vi.fn(),
             debug: vi.fn(),
+            warn: vi.fn(),
         } as unknown as Logger;
+        siteService = new SiteService(
+            client,
+            accountService,
+            {
+                async getSiteSettings(host: string) {
+                    return {
+                        site: {
+                            title: `Site ${host} title`,
+                            description: `Site ${host} description`,
+                            icon: `https://${host}/favicon.ico`,
+                            cover_image: `https://${host}/cover.png`,
+                            site_uuid: crypto.randomUUID(),
+                        },
+                    };
+                },
+            },
+            logger,
+        );
         postRepository = new KnexPostRepository(client, events, logger);
         const moderationService = new ModerationService(client);
         const feedService = new FeedService(client, moderationService);

--- a/src/site/ghost-uuid-ownership.ts
+++ b/src/site/ghost-uuid-ownership.ts
@@ -88,7 +88,10 @@ function classifyError(err: unknown): OwnershipCheckResult {
     // (e.g. ENOTFOUND, ECONNREFUSED) nested in the cause chain.
     if (err instanceof Error) {
         const code = getNetworkErrorCode(err);
-        if (code === 'ENOTFOUND' || code === 'EAI_AGAIN') {
+        // ENOTFOUND is a definitive "no DNS record exists" response.
+        // EAI_AGAIN is a transient resolver failure (e.g. upstream
+        // resolver timeout) and does not prove the host is gone.
+        if (code === 'ENOTFOUND') {
             return { type: 'released', reason: 'dns-not-found' };
         }
         if (code === 'ECONNREFUSED') {

--- a/src/site/ghost-uuid-ownership.ts
+++ b/src/site/ghost-uuid-ownership.ts
@@ -1,0 +1,148 @@
+import { HTTPError, TimeoutError } from 'ky';
+
+import type { SiteSettings } from '@/helpers/ghost';
+
+/**
+ * The outcome of asking a previously-registered host whether it still
+ * claims a given `ghost_uuid`.
+ *
+ * - `still-claims`: the host responded definitively that it still owns
+ *   the UUID. The new registration must be refused.
+ * - `released`: we have a definitive signal that the host has given up
+ *   the UUID (or never genuinely held it). The new registration may
+ *   proceed.
+ * - `unverifiable`: we cannot determine ownership from the response.
+ *   The policy layer decides what to do (currently: fail-open).
+ */
+export type OwnershipCheckResult =
+    | { type: 'still-claims' }
+    | { type: 'released'; reason: ReleaseReason }
+    | { type: 'unverifiable'; reason: UnverifiableReason };
+
+export type ReleaseReason =
+    | 'dns-not-found'
+    | 'connection-refused'
+    | 'admin-api-gone'
+    | 'non-ghost-response'
+    | 'different-uuid';
+
+export type UnverifiableReason =
+    | 'network-error'
+    | 'timeout'
+    | 'server-error'
+    | 'unknown';
+
+type SettingsFetcher = (host: string) => Promise<SiteSettings>;
+
+/**
+ * Classify whether a previously-registered host still claims a given
+ * `ghost_uuid`, by fetching its admin site settings and inspecting the
+ * outcome.
+ *
+ * This is best-effort verification against the host itself. It cannot
+ * authoritatively prove ownership — for that, we would need to check
+ * against Ghost(Pro)'s own records, which is tracked separately.
+ */
+export async function classifyGhostUuidOwnership(
+    host: string,
+    expectedUuid: string,
+    fetchSettings: SettingsFetcher,
+): Promise<OwnershipCheckResult> {
+    let settings: SiteSettings;
+
+    try {
+        settings = await fetchSettings(host);
+    } catch (err) {
+        return classifyError(err);
+    }
+
+    if (!settings?.site?.site_uuid) {
+        return { type: 'released', reason: 'different-uuid' };
+    }
+
+    if (settings.site.site_uuid === expectedUuid) {
+        return { type: 'still-claims' };
+    }
+
+    return { type: 'released', reason: 'different-uuid' };
+}
+
+function classifyError(err: unknown): OwnershipCheckResult {
+    if (err instanceof TimeoutError) {
+        return { type: 'unverifiable', reason: 'timeout' };
+    }
+
+    if (err instanceof HTTPError) {
+        return classifyHttpStatus(err);
+    }
+
+    // Parsing failures on a 2xx body (`ky.json()` throws `SyntaxError`)
+    // mean the host returned something that isn't a Ghost admin API
+    // response, so it is not actively claiming the UUID.
+    if (err instanceof SyntaxError) {
+        return { type: 'released', reason: 'non-ghost-response' };
+    }
+
+    // Network-layer failures from ky 1.x surface as the underlying
+    // `TypeError: fetch failed` from undici, with a system error code
+    // (e.g. ENOTFOUND, ECONNREFUSED) nested in the cause chain.
+    if (err instanceof Error) {
+        const code = getNetworkErrorCode(err);
+        if (code === 'ENOTFOUND' || code === 'EAI_AGAIN') {
+            return { type: 'released', reason: 'dns-not-found' };
+        }
+        if (code === 'ECONNREFUSED') {
+            return { type: 'released', reason: 'connection-refused' };
+        }
+        if (code !== undefined) {
+            return { type: 'unverifiable', reason: 'network-error' };
+        }
+    }
+
+    return { type: 'unverifiable', reason: 'unknown' };
+}
+
+function classifyHttpStatus(err: HTTPError): OwnershipCheckResult {
+    const status = err.response.status;
+
+    if (status >= 400 && status < 500) {
+        return { type: 'released', reason: 'admin-api-gone' };
+    }
+
+    if (status >= 500) {
+        return { type: 'unverifiable', reason: 'server-error' };
+    }
+
+    return { type: 'unverifiable', reason: 'unknown' };
+}
+
+/**
+ * Walk the `cause` chain looking for a system error code like
+ * `ENOTFOUND` or `ECONNREFUSED`. The error structure varies between
+ * Node versions and HTTP libraries: the code may be on the error
+ * itself, on `err.cause`, or nested deeper.
+ */
+function getNetworkErrorCode(err: Error): string | undefined {
+    let current: unknown = err;
+
+    for (let depth = 0; depth < 4 && current; depth++) {
+        if (
+            typeof current === 'object' &&
+            current !== null &&
+            'code' in current
+        ) {
+            const code = (current as { code?: unknown }).code;
+            if (typeof code === 'string') {
+                return code;
+            }
+        }
+        current =
+            typeof current === 'object' &&
+            current !== null &&
+            'cause' in current
+                ? (current as { cause?: unknown }).cause
+                : undefined;
+    }
+
+    return undefined;
+}

--- a/src/site/ghost-uuid-ownership.unit.test.ts
+++ b/src/site/ghost-uuid-ownership.unit.test.ts
@@ -98,7 +98,7 @@ describe('classifyGhostUuidOwnership', () => {
             });
         });
 
-        it('returns released on transient DNS failure (EAI_AGAIN)', async () => {
+        it('returns unverifiable on transient DNS failure (EAI_AGAIN)', async () => {
             const result = await classifyGhostUuidOwnership(
                 HOST,
                 UUID,
@@ -108,8 +108,8 @@ describe('classifyGhostUuidOwnership', () => {
             );
 
             expect(result).toEqual({
-                type: 'released',
-                reason: 'dns-not-found',
+                type: 'unverifiable',
+                reason: 'network-error',
             });
         });
 

--- a/src/site/ghost-uuid-ownership.unit.test.ts
+++ b/src/site/ghost-uuid-ownership.unit.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it } from 'vitest';
+
+import { HTTPError, TimeoutError } from 'ky';
+
+import type { SiteSettings } from '@/helpers/ghost';
+import { classifyGhostUuidOwnership } from '@/site/ghost-uuid-ownership';
+
+const HOST = 'previous-owner.tld';
+const UUID = '3955fb96-837a-44b2-bb58-e20c082bc992';
+
+function settingsWithUuid(uuid: string | null): SiteSettings {
+    return {
+        site: {
+            description: null,
+            icon: null,
+            title: 'Previous owner',
+            cover_image: null,
+            site_uuid: uuid,
+        },
+    };
+}
+
+function networkError(code: string | undefined): Error {
+    // Mirrors how undici / Node's fetch surfaces network errors: a
+    // top-level `TypeError: fetch failed` with the system error nested
+    // in `cause`.
+    const cause = code
+        ? Object.assign(new Error('underlying network error'), { code })
+        : new Error('underlying network error');
+    return new TypeError('fetch failed', { cause });
+}
+
+function timeoutError(): TimeoutError {
+    const request = new Request(`https://${HOST}/ghost/api/admin/site/`);
+    return new TimeoutError(request);
+}
+
+function httpError(status: number): HTTPError {
+    const response = new Response('', { status });
+    const request = new Request(`https://${HOST}/ghost/api/admin/site/`);
+    // The options object is mostly internal to ky; an empty object is
+    // sufficient for the classifier, which only reads `response.status`.
+    return new HTTPError(response, request, {} as never);
+}
+
+describe('classifyGhostUuidOwnership', () => {
+    describe('definitive responses', () => {
+        it('returns still-claims when the host serves a matching site_uuid', async () => {
+            const result = await classifyGhostUuidOwnership(
+                HOST,
+                UUID,
+                async () => settingsWithUuid(UUID),
+            );
+
+            expect(result).toEqual({ type: 'still-claims' });
+        });
+
+        it('returns released when the host serves a different site_uuid', async () => {
+            const result = await classifyGhostUuidOwnership(
+                HOST,
+                UUID,
+                async () => settingsWithUuid('a-different-uuid'),
+            );
+
+            expect(result).toEqual({
+                type: 'released',
+                reason: 'different-uuid',
+            });
+        });
+
+        it('returns released when the host serves no site_uuid', async () => {
+            const result = await classifyGhostUuidOwnership(
+                HOST,
+                UUID,
+                async () => settingsWithUuid(null),
+            );
+
+            expect(result).toEqual({
+                type: 'released',
+                reason: 'different-uuid',
+            });
+        });
+    });
+
+    describe('network errors', () => {
+        it('returns released when DNS lookup fails (ENOTFOUND)', async () => {
+            const result = await classifyGhostUuidOwnership(
+                HOST,
+                UUID,
+                async () => {
+                    throw networkError('ENOTFOUND');
+                },
+            );
+
+            expect(result).toEqual({
+                type: 'released',
+                reason: 'dns-not-found',
+            });
+        });
+
+        it('returns released on transient DNS failure (EAI_AGAIN)', async () => {
+            const result = await classifyGhostUuidOwnership(
+                HOST,
+                UUID,
+                async () => {
+                    throw networkError('EAI_AGAIN');
+                },
+            );
+
+            expect(result).toEqual({
+                type: 'released',
+                reason: 'dns-not-found',
+            });
+        });
+
+        it('returns released when the connection is refused (ECONNREFUSED)', async () => {
+            const result = await classifyGhostUuidOwnership(
+                HOST,
+                UUID,
+                async () => {
+                    throw networkError('ECONNREFUSED');
+                },
+            );
+
+            expect(result).toEqual({
+                type: 'released',
+                reason: 'connection-refused',
+            });
+        });
+
+        it('returns unverifiable for other network errors', async () => {
+            const result = await classifyGhostUuidOwnership(
+                HOST,
+                UUID,
+                async () => {
+                    throw networkError('ECONNRESET');
+                },
+            );
+
+            expect(result).toEqual({
+                type: 'unverifiable',
+                reason: 'network-error',
+            });
+        });
+
+        it('reads the system error code from a deeply nested cause chain', async () => {
+            const inner = Object.assign(new Error('underlying'), {
+                code: 'ENOTFOUND',
+            });
+            const middle = new Error('intermediate', { cause: inner });
+            const err = new TypeError('fetch failed', { cause: middle });
+
+            const result = await classifyGhostUuidOwnership(
+                HOST,
+                UUID,
+                async () => {
+                    throw err;
+                },
+            );
+
+            expect(result).toEqual({
+                type: 'released',
+                reason: 'dns-not-found',
+            });
+        });
+    });
+
+    describe('timeouts', () => {
+        it('returns unverifiable on timeout', async () => {
+            const result = await classifyGhostUuidOwnership(
+                HOST,
+                UUID,
+                async () => {
+                    throw timeoutError();
+                },
+            );
+
+            expect(result).toEqual({
+                type: 'unverifiable',
+                reason: 'timeout',
+            });
+        });
+    });
+
+    describe('HTTP status errors', () => {
+        it('returns released on 404', async () => {
+            const result = await classifyGhostUuidOwnership(
+                HOST,
+                UUID,
+                async () => {
+                    throw httpError(404);
+                },
+            );
+
+            expect(result).toEqual({
+                type: 'released',
+                reason: 'admin-api-gone',
+            });
+        });
+
+        it('returns released on 403', async () => {
+            const result = await classifyGhostUuidOwnership(
+                HOST,
+                UUID,
+                async () => {
+                    throw httpError(403);
+                },
+            );
+
+            expect(result).toEqual({
+                type: 'released',
+                reason: 'admin-api-gone',
+            });
+        });
+
+        it('returns unverifiable on 500', async () => {
+            const result = await classifyGhostUuidOwnership(
+                HOST,
+                UUID,
+                async () => {
+                    throw httpError(500);
+                },
+            );
+
+            expect(result).toEqual({
+                type: 'unverifiable',
+                reason: 'server-error',
+            });
+        });
+
+        it('returns unverifiable on 503', async () => {
+            const result = await classifyGhostUuidOwnership(
+                HOST,
+                UUID,
+                async () => {
+                    throw httpError(503);
+                },
+            );
+
+            expect(result).toEqual({
+                type: 'unverifiable',
+                reason: 'server-error',
+            });
+        });
+    });
+
+    describe('parse errors', () => {
+        it('returns released when the response body is not valid JSON', async () => {
+            const result = await classifyGhostUuidOwnership(
+                HOST,
+                UUID,
+                async () => {
+                    throw new SyntaxError(
+                        'Unexpected token < in JSON at position 0',
+                    );
+                },
+            );
+
+            expect(result).toEqual({
+                type: 'released',
+                reason: 'non-ghost-response',
+            });
+        });
+    });
+
+    describe('unknown errors', () => {
+        it('returns unverifiable for arbitrary errors', async () => {
+            const result = await classifyGhostUuidOwnership(
+                HOST,
+                UUID,
+                async () => {
+                    throw new Error('something unexpected');
+                },
+            );
+
+            expect(result).toEqual({
+                type: 'unverifiable',
+                reason: 'unknown',
+            });
+        });
+    });
+});

--- a/src/site/site.service.integration.test.ts
+++ b/src/site/site.service.integration.test.ts
@@ -1,6 +1,8 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { getLogger } from '@logtape/logtape';
 import type { Knex } from 'knex';
+import { HTTPError } from 'ky';
 
 import { KnexAccountRepository } from '@/account/account.repository.knex';
 import { AccountService } from '@/account/account.service';
@@ -66,7 +68,12 @@ describe('SiteService', () => {
             },
         };
         // Create the service
-        service = new SiteService(db, accountService, ghostService);
+        service = new SiteService(
+            db,
+            accountService,
+            ghostService,
+            getLogger(['test', 'site-service']),
+        );
     });
 
     it('Can initialise a site multiple times and retrieve it', async () => {
@@ -369,7 +376,7 @@ describe('SiteService', () => {
         expect(oldRow.ghost_uuid).toBeNull();
     });
 
-    it('Blocks ghost_uuid reassignment when the old host returns a transient HTTP error', async () => {
+    it('Allows ghost_uuid reassignment when the old host returns a transient 5xx (fail-open)', async () => {
         const ghostUUID = 'transient-error-uuid';
 
         ghostService.getSiteSettings = vi.fn().mockResolvedValue({
@@ -384,10 +391,13 @@ describe('SiteService', () => {
 
         await service.initialiseSiteForHost('site-a.tld');
 
-        // Old host returns an HTTP error (has a response property)
-        const httpError = Object.assign(
-            new Error('Request failed with status code 500'),
-            { response: { status: 500 } },
+        // Old host returns a 500 (genuinely unverifiable). Policy is to
+        // fail-open: allow reassignment rather than block legitimate
+        // domain changes during transient outages.
+        const httpError = new HTTPError(
+            new Response('', { status: 500 }),
+            new Request('https://site-a.tld/ghost/api/admin/site/'),
+            {} as never,
         );
 
         ghostService.getSiteSettings = vi
@@ -407,24 +417,14 @@ describe('SiteService', () => {
                 });
             });
 
-        await expect(
-            service.initialiseSiteForHost('site-b.tld'),
-        ).rejects.toThrow(
-            'Unable to verify ghost_uuid ownership: site-a.tld returned an error',
-        );
+        const siteB = await service.initialiseSiteForHost('site-b.tld');
 
-        // Verify existing site is untouched
+        expect(siteB.ghost_uuid).toBe(ghostUUID);
+
+        // Old site's ghost_uuid should be released
         const siteARow = await db('sites')
             .where({ host: 'site-a.tld' })
             .first();
-
-        expect(siteARow.ghost_uuid).toBe(ghostUUID);
-
-        // Verify new site was not created
-        const siteBRow = await db('sites')
-            .where({ host: 'site-b.tld' })
-            .first();
-
-        expect(siteBRow).toBeUndefined();
+        expect(siteARow.ghost_uuid).toBeNull();
     });
 });

--- a/src/site/site.service.ts
+++ b/src/site/site.service.ts
@@ -1,10 +1,12 @@
 import crypto from 'node:crypto';
 
+import type { Logger } from '@logtape/logtape';
 import type { Knex } from 'knex';
 
 import type { AccountService } from '@/account/account.service';
 import type { InternalAccountData } from '@/account/types';
 import type { getSiteSettings, SiteSettings } from '@/helpers/ghost';
+import { classifyGhostUuidOwnership } from '@/site/ghost-uuid-ownership';
 
 export type Site = {
     id: number;
@@ -22,6 +24,7 @@ export class SiteService {
         private client: Knex,
         private accountService: AccountService,
         private ghostService: IGhostService,
+        private logger: Logger,
     ) {}
 
     private async createSite(
@@ -48,7 +51,11 @@ export class SiteService {
                 .first();
 
             if (currentOwner) {
-                await this.verifyUUIDReleased(currentOwner.host, ghostUuid);
+                await this.verifyUUIDReleased(
+                    currentOwner.host,
+                    host,
+                    ghostUuid,
+                );
 
                 verifiedOwnerHost = currentOwner.host;
             }
@@ -156,25 +163,45 @@ export class SiteService {
     }
 
     private async verifyUUIDReleased(
-        host: string,
+        previousHost: string,
+        newHost: string,
         ghostUuid: string,
     ): Promise<void> {
-        let settings: SiteSettings | undefined;
+        const result = await classifyGhostUuidOwnership(
+            previousHost,
+            ghostUuid,
+            (host) => this.ghostService.getSiteSettings(host),
+        );
 
-        try {
-            settings = await this.ghostService.getSiteSettings(host);
-        } catch (err) {
-            if (this.isHostReachableError(err)) {
-                throw new Error(
-                    `Unable to verify ghost_uuid ownership: ${host} returned an error`,
-                );
-            }
+        if (result.type === 'still-claims') {
+            throw new Error('ghost_uuid is still claimed by another host');
+        }
+
+        if (result.type === 'unverifiable') {
+            // Fail-open: a transient or ambiguous response from the
+            // previous host should not block legitimate domain changes.
+            // The trade-off is accepted; see docs/site-registration.md.
+            this.logger.warn(
+                'Reassigning ghost_uuid despite unverifiable response from previous host {previousHost} (reason: {reason}); transferring to {newHost}',
+                {
+                    previousHost,
+                    newHost,
+                    ghostUuid,
+                    reason: result.reason,
+                },
+            );
             return;
         }
 
-        if (settings?.site?.site_uuid === ghostUuid) {
-            throw new Error('ghost_uuid is still claimed by another host');
-        }
+        this.logger.info(
+            'Previous host {previousHost} has released ghost_uuid (reason: {reason}); transferring to {newHost}',
+            {
+                previousHost,
+                newHost,
+                ghostUuid,
+                reason: result.reason,
+            },
+        );
     }
 
     private async getSiteSettings(host: string): Promise<SiteSettings> {
@@ -185,13 +212,5 @@ export class SiteService {
         }
 
         return settings;
-    }
-
-    private isHostReachableError(err: unknown): boolean {
-        return (
-            err !== null &&
-            typeof err === 'object' &&
-            ('response' in err || 'request' in err)
-        );
     }
 }

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -305,20 +305,26 @@ export function createFixtureManager(
         fedifyContextFactory,
         generateTestCryptoKeyPair,
     );
-    const siteService = new SiteService(db, accountService, {
-        getSiteSettings: async (host) => ({
-            site: {
-                description: faker.lorem.sentence(),
-                title: faker.person.fullName(),
-                icon: `https://${host}/avatar/c4863565-3533-43fa-9991-19c5160a4da2.jpg`,
-                cover_image: `https://${host}/cover/cd93c035-7326-4043-aed1-9150fe91b59.jpg`,
-                site_uuid: crypto.randomUUID(),
-            },
-        }),
-    });
     const logger = {
         info: () => {},
+        warn: () => {},
     } as unknown as Logger;
+    const siteService = new SiteService(
+        db,
+        accountService,
+        {
+            getSiteSettings: async (host) => ({
+                site: {
+                    description: faker.lorem.sentence(),
+                    title: faker.person.fullName(),
+                    icon: `https://${host}/avatar/c4863565-3533-43fa-9991-19c5160a4da2.jpg`,
+                    cover_image: `https://${host}/cover/cd93c035-7326-4043-aed1-9150fe91b59.jpg`,
+                    site_uuid: crypto.randomUUID(),
+                },
+            }),
+        },
+        logger,
+    );
     const postRepository = new KnexPostRepository(db, events, logger);
 
     return new FixtureManager(


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1769

The verification added in #1661 treated any HTTP-layer error from the previous host as "unverifiable" and refused the registration. In practice this blocked the most common legitimate case (the previous hostname has been decommissioned, so DNS returns NXDOMAIN), since the classifier could not tell that apart from a transient outage.

This PR replaces `isHostReachableError` with a proper classifier that distinguishes:

- **Definitively released** (allow reassignment): NXDOMAIN / ECONNREFUSED / 4xx / non-JSON 2xx body / 2xx with different `site_uuid`.
- **Still claimed** (refuse reassignment): 2xx with matching `site_uuid`.
- **Unverifiable** (allow, fail-open, logged): 5xx / timeout / other transport errors.

Allowing on `unverifiable` matches the original intent of #1661 ("If the existing host is unreachable, the reassignment is allowed to support legitimate domain migrations"). Reassignments classified as unverifiable are logged at warn level so the pattern is observable in logs.

The classifier lives in its own module (`src/site/ghost-uuid-ownership.ts`) with dedicated unit tests for each branch.

Replaces #1836 (which proposed reverting the verification entirely).