### PR TITLE
Granted CICD workflow the permissions its called workflows require

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -17,8 +17,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
-  id-token: write
 
 concurrency:
   group: cicd-${{ github.ref_name == 'main' && 'main' || github.ref_name }}
@@ -26,17 +24,27 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     uses: ./.github/workflows/build.yml
     secrets: inherit
 
   test:
     needs: build
+    permissions:
+      contents: read
     uses: ./.github/workflows/test.yml
     with:
       skip-tests: ${{ contains(github.event.pull_request.labels.*.name, 'skip-tests') }}
 
   push:
     needs: [build]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     uses: ./.github/workflows/push.yml
     with:
       activitypub-private-tags: ${{ needs.build.outputs.activitypub-private-tags }}
@@ -49,12 +57,18 @@ jobs:
   deploy-pr:
     needs: [push, test]
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/deploy-pr.yml
     secrets: inherit
 
   deploy:
     needs: [push, test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/deploy.yml
     secrets: inherit
     with:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,6 +15,11 @@ on:
     tags:
       - "v*.*.*" # Trigger on semantic version tags like v1.0.0
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
 concurrency:
   group: cicd-${{ github.ref_name == 'main' && 'main' || github.ref_name }}
   cancel-in-progress: ${{ github.ref_name != 'main' }}


### PR DESCRIPTION
The org-wide GitHub Actions policy was tightened to a restrictive default GITHUB_TOKEN (`packages: read, id-token: none`). The called workflows (`build.yml`, `push.yml`, deploy workflows) request `packages: write` (for ghcr.io pushes) and `id-token: write` (for GCP OIDC), so without an explicit grant from the caller every CICD run fails at startup with "workflow is requesting ... but is only allowed ...".

Add a workflow-level `permissions:` block on `cicd.yml` that grants the union of what the called workflows need.