### PR TITLE
Released `ghost_uuid` when previous host is an alias of the same install

### DIFF
--- a/docs/site-registration.md
+++ b/docs/site-registration.md
@@ -22,21 +22,38 @@ host registers with a `ghost_uuid` that already belongs to an existing
 site row, the service classifies the previous owner's current state by
 fetching `/ghost/api/admin/site/` on the previous host:
 
-| Previous host response                              | Classification         | Outcome                                |
-| --------------------------------------------------- | ---------------------- | -------------------------------------- |
-| 200 with the same `site_uuid`                       | `still-claims`         | Refuse the reassignment                |
-| 200 with a different / missing `site_uuid`          | `released`             | Allow reassignment                     |
-| 200 with non-JSON body                              | `released`             | Allow reassignment                     |
-| 3xx / 4xx                                           | `released`             | Allow reassignment                     |
-| DNS NXDOMAIN (ENOTFOUND)                            | `released`             | Allow reassignment                     |
-| Connection refused (ECONNREFUSED)                   | `released`             | Allow reassignment                     |
-| Transient DNS failure (EAI_AGAIN)                   | `unverifiable`         | Allow reassignment (fail-open), logged |
-| 5xx / timeout / other transport error               | `unverifiable`         | Allow reassignment (fail-open), logged |
+| Previous host response                                                 | Classification | Outcome                                |
+| ---------------------------------------------------------------------- | -------------- | -------------------------------------- |
+| 200 with the same `site_uuid` and a matching canonical `url`           | `still-claims` | Refuse the reassignment                |
+| 200 with the same `site_uuid` but a different canonical `url` (alias)  | `released`     | Allow reassignment                     |
+| 200 with a different / missing `site_uuid`                             | `released`     | Allow reassignment                     |
+| 200 with non-JSON body                                                 | `released`     | Allow reassignment                     |
+| 3xx / 4xx                                                              | `released`     | Allow reassignment                     |
+| DNS NXDOMAIN (ENOTFOUND)                                               | `released`     | Allow reassignment                     |
+| Connection refused (ECONNREFUSED)                                      | `released`     | Allow reassignment                     |
+| Transient DNS failure (EAI_AGAIN)                                      | `unverifiable` | Allow reassignment (fail-open), logged |
+| 5xx / timeout / other transport error                                  | `unverifiable` | Allow reassignment (fail-open), logged |
 
 When the reassignment proceeds (whether `released` or `unverifiable`),
 the previous row's `ghost_uuid` is set to `null` and the new row takes
 the UUID. The previous row's account data stays intact; only the UUID
 claim is released.
+
+### Aliased hosts
+
+Managed Ghost hosting providers typically give each install two valid
+hostnames: a provider-controlled backend hostname (e.g.
+`<pod>.provider.tld`, `<customer>.ghost.io`) and a customer's custom
+domain pointed at it. Both hostnames serve the same install and return
+the same `site_uuid`, so a naive "does the previous host still claim
+this UUID?" check would always say yes when the customer's custom
+domain registers after the backend hostname.
+
+Ghost reports a single canonical URL in its admin settings (`site.url`).
+If the previous host's response includes a `url` whose host is not the
+previous host itself, that install has effectively moved its public
+identity elsewhere, and we treat the previous host as having released
+the UUID.
 
 ### Fail-open on unverifiable
 

--- a/src/feed/feed.service.integration.test.ts
+++ b/src/feed/feed.service.integration.test.ts
@@ -176,6 +176,7 @@ describe('FeedService', () => {
                             icon: `https://${host}/favicon.ico`,
                             cover_image: `https://${host}/cover.png`,
                             site_uuid: crypto.randomUUID(),
+                            url: `https://${host}/`,
                         },
                     };
                 },

--- a/src/helpers/ghost.ts
+++ b/src/helpers/ghost.ts
@@ -7,6 +7,7 @@ export type SiteSettings = {
         title: string;
         cover_image: string | null;
         site_uuid: string | null;
+        url: string | null;
     };
 };
 
@@ -24,6 +25,7 @@ export async function getSiteSettings(host: string): Promise<SiteSettings> {
             icon: settings?.site?.icon || null,
             cover_image: settings?.site?.cover_image || null,
             site_uuid: settings?.site?.site_uuid ?? null,
+            url: settings?.site?.url ?? null,
         },
     };
 }

--- a/src/helpers/ghost.unit.test.ts
+++ b/src/helpers/ghost.unit.test.ts
@@ -17,6 +17,7 @@ describe('getSiteSettings', () => {
                 icon: 'https://example.com/baz.png',
                 cover_image: 'https://example.com/qux.png',
                 site_uuid: 'e604ed82-188c-4f55-a5ce-9ebfb4184970',
+                url: 'https://example.com/',
             },
         };
 
@@ -41,6 +42,7 @@ describe('getSiteSettings', () => {
                     icon: 'https://example.com/baz.png',
                     cover_image: 'https://example.com/qux.png',
                     site_uuid: 'e604ed82-188c-4f55-a5ce-9ebfb4184970',
+                    url: 'https://example.com/',
                 },
             }),
         } as ResponsePromise);
@@ -54,6 +56,7 @@ describe('getSiteSettings', () => {
                 icon: 'https://example.com/baz.png',
                 cover_image: 'https://example.com/qux.png',
                 site_uuid: 'e604ed82-188c-4f55-a5ce-9ebfb4184970',
+                url: 'https://example.com/',
             },
         });
     });
@@ -66,6 +69,7 @@ describe('getSiteSettings', () => {
                     title: 'bar',
                     cover_image: 'https://example.com/qux.png',
                     site_uuid: 'e604ed82-188c-4f55-a5ce-9ebfb4184970',
+                    url: 'https://example.com/',
                 },
             }),
         } as ResponsePromise);
@@ -79,6 +83,7 @@ describe('getSiteSettings', () => {
                 icon: null,
                 cover_image: 'https://example.com/qux.png',
                 site_uuid: 'e604ed82-188c-4f55-a5ce-9ebfb4184970',
+                url: 'https://example.com/',
             },
         });
     });
@@ -91,6 +96,7 @@ describe('getSiteSettings', () => {
                     icon: 'https://example.com/baz.png',
                     cover_image: 'https://example.com/qux.png',
                     site_uuid: 'e604ed82-188c-4f55-a5ce-9ebfb4184970',
+                    url: 'https://example.com/',
                 },
             }),
         } as ResponsePromise);
@@ -104,6 +110,7 @@ describe('getSiteSettings', () => {
                 icon: 'https://example.com/baz.png',
                 cover_image: 'https://example.com/qux.png',
                 site_uuid: 'e604ed82-188c-4f55-a5ce-9ebfb4184970',
+                url: 'https://example.com/',
             },
         });
     });
@@ -116,6 +123,7 @@ describe('getSiteSettings', () => {
                     title: 'bar',
                     icon: 'https://example.com/baz.png',
                     site_uuid: 'e604ed82-188c-4f55-a5ce-9ebfb4184970',
+                    url: 'https://example.com/',
                 },
             }),
         } as ResponsePromise);
@@ -129,6 +137,7 @@ describe('getSiteSettings', () => {
                 icon: 'https://example.com/baz.png',
                 cover_image: null,
                 site_uuid: 'e604ed82-188c-4f55-a5ce-9ebfb4184970',
+                url: 'https://example.com/',
             },
         });
     });
@@ -141,6 +150,7 @@ describe('getSiteSettings', () => {
                     title: 'bar',
                     icon: 'https://example.com/baz.png',
                     cover_image: 'https://example.com/qux.png',
+                    url: 'https://example.com/',
                 },
             }),
         } as ResponsePromise);
@@ -154,6 +164,34 @@ describe('getSiteSettings', () => {
                 icon: 'https://example.com/baz.png',
                 cover_image: 'https://example.com/qux.png',
                 site_uuid: null,
+                url: 'https://example.com/',
+            },
+        });
+    });
+
+    it('sets the site url to null if missing', async () => {
+        vi.mocked(ky.get).mockReturnValue({
+            json: async () => ({
+                site: {
+                    description: 'foo',
+                    title: 'bar',
+                    icon: 'https://example.com/baz.png',
+                    cover_image: 'https://example.com/qux.png',
+                    site_uuid: 'e604ed82-188c-4f55-a5ce-9ebfb4184970',
+                },
+            }),
+        } as ResponsePromise);
+
+        const result = await getSiteSettings(host);
+
+        expect(result).toEqual({
+            site: {
+                description: 'foo',
+                title: 'bar',
+                icon: 'https://example.com/baz.png',
+                cover_image: 'https://example.com/qux.png',
+                site_uuid: 'e604ed82-188c-4f55-a5ce-9ebfb4184970',
+                url: null,
             },
         });
     });

--- a/src/post/post.repository.knex.integration.test.ts
+++ b/src/post/post.repository.knex.integration.test.ts
@@ -87,6 +87,7 @@ describe('KnexPostRepository', () => {
                             icon: `https://${host}/favicon.ico`,
                             cover_image: `https://${host}/cover.png`,
                             site_uuid: crypto.randomUUID(),
+                            url: `https://${host}/`,
                         },
                     };
                 },

--- a/src/site/ghost-uuid-ownership.ts
+++ b/src/site/ghost-uuid-ownership.ts
@@ -24,7 +24,8 @@ export type ReleaseReason =
     | 'connection-refused'
     | 'admin-api-gone'
     | 'non-ghost-response'
-    | 'different-uuid';
+    | 'different-uuid'
+    | 'aliased';
 
 export type UnverifiableReason =
     | 'network-error'
@@ -61,10 +62,44 @@ export async function classifyGhostUuidOwnership(
     }
 
     if (settings.site.site_uuid === expectedUuid) {
+        // The previous host still serves a matching UUID, but Ghost
+        // reports a different host as the install's canonical URL.
+        // This is the common pattern for managed Ghost hosting (e.g.
+        // a provider's backend hostname aliased to a customer's
+        // custom domain): both hostnames serve the same install, but
+        // the install considers the custom domain its public identity.
+        // Treat the previous host as having released the UUID so the
+        // new (canonical) host can take it.
+        if (canonicalUrlPointsElsewhere(settings.site.url, host)) {
+            return { type: 'released', reason: 'aliased' };
+        }
         return { type: 'still-claims' };
     }
 
     return { type: 'released', reason: 'different-uuid' };
+}
+
+/**
+ * Returns true when the Ghost-reported canonical URL's host does not
+ * match the host we queried. A null/malformed `url` returns false
+ * (we conservatively keep treating the response as authoritative).
+ */
+function canonicalUrlPointsElsewhere(
+    canonicalUrl: string | null,
+    queriedHost: string,
+): boolean {
+    if (!canonicalUrl) {
+        return false;
+    }
+
+    let canonicalHost: string;
+    try {
+        canonicalHost = new URL(canonicalUrl).host;
+    } catch {
+        return false;
+    }
+
+    return canonicalHost !== queriedHost;
 }
 
 function classifyError(err: unknown): OwnershipCheckResult {

--- a/src/site/ghost-uuid-ownership.unit.test.ts
+++ b/src/site/ghost-uuid-ownership.unit.test.ts
@@ -8,7 +8,10 @@ import { classifyGhostUuidOwnership } from '@/site/ghost-uuid-ownership';
 const HOST = 'previous-owner.tld';
 const UUID = '3955fb96-837a-44b2-bb58-e20c082bc992';
 
-function settingsWithUuid(uuid: string | null): SiteSettings {
+function settingsWithUuid(
+    uuid: string | null,
+    url: string | null = `https://${HOST}/`,
+): SiteSettings {
     return {
         site: {
             description: null,
@@ -16,6 +19,7 @@ function settingsWithUuid(uuid: string | null): SiteSettings {
             title: 'Previous owner',
             cover_image: null,
             site_uuid: uuid,
+            url,
         },
     };
 }
@@ -78,6 +82,72 @@ describe('classifyGhostUuidOwnership', () => {
             expect(result).toEqual({
                 type: 'released',
                 reason: 'different-uuid',
+            });
+        });
+    });
+
+    describe('aliased hosts', () => {
+        it('returns released when the host serves a matching uuid but reports a different canonical url', async () => {
+            // The previous host is e.g. a managed-Ghost provider's
+            // backend hostname; the install's canonical url has been
+            // moved to a customer's custom domain.
+            const result = await classifyGhostUuidOwnership(
+                HOST,
+                UUID,
+                async () =>
+                    settingsWithUuid(UUID, 'https://customer-domain.tld/'),
+            );
+
+            expect(result).toEqual({
+                type: 'released',
+                reason: 'aliased',
+            });
+        });
+
+        it('returns still-claims when the canonical url matches the queried host', async () => {
+            const result = await classifyGhostUuidOwnership(
+                HOST,
+                UUID,
+                async () => settingsWithUuid(UUID, `https://${HOST}/`),
+            );
+
+            expect(result).toEqual({ type: 'still-claims' });
+        });
+
+        it('returns still-claims when the canonical url is missing', async () => {
+            const result = await classifyGhostUuidOwnership(
+                HOST,
+                UUID,
+                async () => settingsWithUuid(UUID, null),
+            );
+
+            expect(result).toEqual({ type: 'still-claims' });
+        });
+
+        it('returns still-claims when the canonical url is malformed', async () => {
+            const result = await classifyGhostUuidOwnership(
+                HOST,
+                UUID,
+                async () => settingsWithUuid(UUID, 'not a url'),
+            );
+
+            expect(result).toEqual({ type: 'still-claims' });
+        });
+
+        it('ignores port differences when comparing hosts', async () => {
+            // `new URL(...).host` includes the port if present, so a
+            // url with an explicit port on a different domain is still
+            // treated as a different host.
+            const result = await classifyGhostUuidOwnership(
+                HOST,
+                UUID,
+                async () =>
+                    settingsWithUuid(UUID, 'https://customer-domain.tld:8080/'),
+            );
+
+            expect(result).toEqual({
+                type: 'released',
+                reason: 'aliased',
             });
         });
     });

--- a/src/site/site.service.integration.test.ts
+++ b/src/site/site.service.integration.test.ts
@@ -55,7 +55,7 @@ describe('SiteService', () => {
             generateTestCryptoKeyPair,
         );
         ghostService = {
-            async getSiteSettings(_host: string) {
+            async getSiteSettings(host: string) {
                 return {
                     site: {
                         icon: '',
@@ -63,6 +63,7 @@ describe('SiteService', () => {
                         description: 'Default Description',
                         cover_image: 'https://testing.com/cover.png',
                         site_uuid: 'e604ed82-188c-4f55-a5ce-9ebfb4184970',
+                        url: `https://${host}/`,
                     },
                 };
             },
@@ -426,5 +427,55 @@ describe('SiteService', () => {
             .where({ host: 'site-a.tld' })
             .first();
         expect(siteARow.ghost_uuid).toBeNull();
+    });
+
+    it('Allows ghost_uuid reassignment when the previous host is an alias of the same install', async () => {
+        // A managed-Ghost provider's backend hostname is registered
+        // first; the install's canonical URL then moves to the customer's
+        // custom domain. Both hostnames still serve the same UUID, but
+        // Ghost reports the custom domain as the canonical URL.
+        const ghostUUID = 'aliased-ghost-uuid';
+        const backendHost = 'pod-a.provider.tld';
+        const customDomain = 'custom-domain.tld';
+
+        ghostService.getSiteSettings = vi.fn().mockResolvedValue({
+            site: {
+                icon: null,
+                title: 'Aliased site',
+                description: null,
+                cover_image: null,
+                site_uuid: ghostUUID,
+                url: `https://${backendHost}/`,
+            },
+        });
+
+        await service.initialiseSiteForHost(backendHost);
+
+        // Both hosts now serve the same install, with the custom
+        // domain reported as the canonical URL.
+        ghostService.getSiteSettings = vi.fn().mockResolvedValue({
+            site: {
+                icon: null,
+                title: 'Aliased site',
+                description: null,
+                cover_image: null,
+                site_uuid: ghostUUID,
+                url: `https://${customDomain}/`,
+            },
+        });
+
+        const customSite = await service.initialiseSiteForHost(customDomain);
+
+        expect(customSite.ghost_uuid).toBe(ghostUUID);
+
+        const backendRow = await db('sites')
+            .where({ host: backendHost })
+            .first();
+        expect(backendRow.ghost_uuid).toBeNull();
+
+        const customRow = await db('sites')
+            .where({ host: customDomain })
+            .first();
+        expect(customRow.ghost_uuid).toBe(ghostUUID);
     });
 });

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -320,6 +320,7 @@ export function createFixtureManager(
                     icon: `https://${host}/avatar/c4863565-3533-43fa-9991-19c5160a4da2.jpg`,
                     cover_image: `https://${host}/cover/cd93c035-7326-4043-aed1-9150fe91b59.jpg`,
                     site_uuid: crypto.randomUUID(),
+                    url: `https://${host}/`,
                 },
             }),
         },


### PR DESCRIPTION
Customers on managed Ghost hosting (Pikapod, Ghost(Pro), etc.) typically get two valid hostnames for the same install: a provider-controlled backend hostname (`<pod>.pikapod.net`, `<customer>.ghost.io`) and a customer's custom domain pointed at it. Both hostnames serve the same `site_uuid`, which causes the previous-host verification to refuse the customer's custom domain when it later registers with AP (the backend hostname returns a matching UUID, looks like "still claimed").

Ghost reports a single canonical URL (`site.url`) in its admin settings. When the previous host's canonical URL points at a different host, the install has effectively moved its public identity, and we now treat that as a release of the UUID on the previous host.

The new branch in the classifier is `released/aliased`. Other classifications are unchanged.