### PR TITLE
Force notes feed query to use the user/post-type index

### DIFF
--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -129,6 +129,12 @@ export class FeedService {
             .first();
 
         const results = await this.db('feeds')
+            // FORCE INDEX keeps the scan scoped to this user's feed; without it
+            // the planner scans every Note in the table and the query degrades
+            // as the table grows.
+            .from(
+                this.db.raw('feeds FORCE INDEX (idx_feeds_user_id_post_type)'),
+            )
             .select(
                 // Post fields
                 'posts.id as post_id',


### PR DESCRIPTION
no ref

The notes feed query was degrading badly (up to ~10s in production) because the planner scanned every Note in the feeds table instead of scoping to the requesting user. Adding `FORCE INDEX` on `idx_feeds_user_id_post_type` pins the query to a per-user covering range scan, taking it from 7.5s to 16ms on production data. This also covers the reader/Inbox feed, which shares the same query