### PR TITLE
Removed redundant single-column indexes from the feeds table

### DIFF
--- a/migrate/migrations/000082_remove-redundant-feeds-indexes.down.sql
+++ b/migrate/migrations/000082_remove-redundant-feeds-indexes.down.sql
@@ -1,0 +1,4 @@
+CREATE INDEX idx_feeds_user_id ON feeds (user_id);
+CREATE INDEX idx_feeds_post_type ON feeds (post_type);
+CREATE INDEX idx_feeds_audience ON feeds (audience);
+CREATE INDEX idx_published_at ON feeds (published_at);

--- a/migrate/migrations/000082_remove-redundant-feeds-indexes.up.sql
+++ b/migrate/migrations/000082_remove-redundant-feeds-indexes.up.sql
@@ -1,0 +1,20 @@
+-- Drop single-column indexes on feeds that are no longer used.
+--
+-- The composite index idx_feeds_user_id_post_type covers
+-- (user_id, post_type, published_at DESC). Every feeds query pins user_id (and
+-- usually post_type) first and only then ranges/orders on published_at, so it
+-- can use the composite's leading columns. No query filters or orders on
+-- published_at, post_type, or user_id on its own, so the single-column
+-- idx_feeds_user_id, idx_feeds_post_type, and idx_published_at (all of which
+-- predate the composite) are redundant.
+--
+-- idx_feeds_audience covers a column that is written on insert but never read,
+-- filtered, or ordered by.
+--
+-- Removing them reduces write/storage overhead and prevents the optimizer from
+-- combining the user_id and post_type indexes into an index-merge plan, which
+-- scans far more rows than the composite index.
+DROP INDEX idx_feeds_user_id ON feeds;
+DROP INDEX idx_feeds_post_type ON feeds;
+DROP INDEX idx_feeds_audience ON feeds;
+DROP INDEX idx_published_at ON feeds;


### PR DESCRIPTION
no ref

The feeds table carries four single-column indexes that are no longer needed:
- idx_feeds_user_id (user_id), idx_feeds_post_type (post_type) and idx_published_at (published_at) were added when the feed query was first written and ran against those columns individually. They were later superseded by the composite idx_feeds_user_id_post_type (user_id, post_type, published_at DESC), which serves the feed query in a single seek. Every feeds query pins user_id (and usually post_type) first and only then ranges/orders on published_at, so it uses the composite's leading columns; nothing filters or orders on those columns standalone.
- idx_feeds_audience (audience) has never been used by any query. The audience column is written on insert but never read, filtered, or ordered by.

Beyond the write and storage overhead of maintaining unused indexes, keeping idx_feeds_user_id and idx_feeds_post_type lets the optimizer combine them into an index-merge intersection on the feed query. At the current size of the feeds table this plan scans every Note row (tens of millions) instead of using the composite index, taking the notes/reader feed endpoint from ~15ms to several seconds. Dropping the redundant indexes removes that plan as an option.

A FORCE INDEX hint on the feed query (added separately) currently pins it to the composite index and will be removed in a follow-up once the un-forced query is confirmed to pick the composite in production.