### PR TITLE
Removed FORCE INDEX hint from the feed query

### DIFF
--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -129,12 +129,6 @@ export class FeedService {
             .first();
 
         const results = await this.db('feeds')
-            // FORCE INDEX keeps the scan scoped to this user's feed; without it
-            // the planner scans every Note in the table and the query degrades
-            // as the table grows.
-            .from(
-                this.db.raw('feeds FORCE INDEX (idx_feeds_user_id_post_type)'),
-            )
             .select(
                 // Post fields
                 'posts.id as post_id',


### PR DESCRIPTION
no ref

The feed query in `getFeedData` was pinned to `idx_feeds_user_id_post_type` with a `FORCE INDEX` hint (#1891) to stop the optimizer from choosing an index-merge intersection that scanned every Note in the feeds table.

The redundant single-column indexes that made that plan possible have since been removed (#1895), so the optimizer now selects the composite index on its own. Verified in production: the un-forced query uses `idx_feeds_user_id_post_type` with no index-merge or filesort. The hint is no longer needed, so this reverts it and returns the query to plain Knex.