### PR TITLE
Fixed malformed headers emitting junk trace IDs

### DIFF
--- a/src/helpers/context-header.ts
+++ b/src/helpers/context-header.ts
@@ -9,7 +9,20 @@ export function getTraceContext(traceContext: string | undefined) {
         return { traceId: null, spanId: null, sampled: null };
     }
 
-    const [_version, traceId, spanId, flags] = parts;
+    const [version, traceId, spanId, flags] = parts;
+
+    const isValidTraceContext =
+        /^[0-9a-f]{2}$/.test(version) &&
+        /^[0-9a-f]{32}$/.test(traceId) &&
+        traceId !== '00000000000000000000000000000000' &&
+        /^[0-9a-f]{16}$/.test(spanId) &&
+        spanId !== '0000000000000000' &&
+        /^[0-9a-f]{2}$/.test(flags);
+
+    if (!isValidTraceContext) {
+        return { traceId: null, spanId: null, sampled: null };
+    }
+
     const sampled = (Number.parseInt(flags, 16) & 0x1) === 1;
     return { traceId, spanId, sampled };
 }

--- a/src/helpers/context-header.ts
+++ b/src/helpers/context-header.ts
@@ -1,32 +1,23 @@
+import { TraceFlags } from '@opentelemetry/api';
+import { parseTraceParent } from '@opentelemetry/core';
+
 export function getTraceContext(traceContext: string | undefined) {
     if (!traceContext) {
         return { traceId: null, spanId: null, sampled: null };
     }
 
-    const parts = traceContext.split('-');
-
-    if (parts.length !== 4) {
-        return { traceId: null, spanId: null, sampled: null };
-    }
-
-    const [version, traceId, spanId, flags] = parts;
-
     // Reject malformed/spoofed traceparent so we don't emit junk trace IDs
-    // to Cloud Logging. Version 'ff' and all-zero trace/span IDs are invalid
-    // per the W3C Trace Context spec.
-    const isValidTraceContext =
-        /^[0-9a-f]{2}$/.test(version) &&
-        version !== 'ff' &&
-        /^[0-9a-f]{32}$/.test(traceId) &&
-        !/^0+$/.test(traceId) &&
-        /^[0-9a-f]{16}$/.test(spanId) &&
-        !/^0+$/.test(spanId) &&
-        /^[0-9a-f]{2}$/.test(flags);
+    // to Cloud Logging. parseTraceParent enforces the W3C Trace Context
+    // rules (hex format, reserved version 'ff', all-zero trace/span IDs).
+    const spanContext = parseTraceParent(traceContext);
 
-    if (!isValidTraceContext) {
+    if (!spanContext) {
         return { traceId: null, spanId: null, sampled: null };
     }
 
-    const sampled = (Number.parseInt(flags, 16) & 0x1) === 1;
-    return { traceId, spanId, sampled };
+    return {
+        traceId: spanContext.traceId,
+        spanId: spanContext.spanId,
+        sampled: (spanContext.traceFlags & TraceFlags.SAMPLED) !== 0,
+    };
 }

--- a/src/helpers/context-header.ts
+++ b/src/helpers/context-header.ts
@@ -11,12 +11,16 @@ export function getTraceContext(traceContext: string | undefined) {
 
     const [version, traceId, spanId, flags] = parts;
 
+    // Reject malformed/spoofed traceparent so we don't emit junk trace IDs
+    // to Cloud Logging. Version 'ff' and all-zero trace/span IDs are invalid
+    // per the W3C Trace Context spec.
     const isValidTraceContext =
         /^[0-9a-f]{2}$/.test(version) &&
+        version !== 'ff' &&
         /^[0-9a-f]{32}$/.test(traceId) &&
-        traceId !== '00000000000000000000000000000000' &&
+        !/^0+$/.test(traceId) &&
         /^[0-9a-f]{16}$/.test(spanId) &&
-        spanId !== '0000000000000000' &&
+        !/^0+$/.test(spanId) &&
         /^[0-9a-f]{2}$/.test(flags);
 
     if (!isValidTraceContext) {

--- a/src/helpers/context-header.unit.test.ts
+++ b/src/helpers/context-header.unit.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { getTraceContext } from '@/helpers/context-header';
+
+describe('getTraceContext', () => {
+    const nullTraceContext = {
+        traceId: null,
+        spanId: null,
+        sampled: null,
+    };
+
+    it('returns null fields when traceparent is missing', () => {
+        expect(getTraceContext(undefined)).toEqual(nullTraceContext);
+    });
+
+    it('parses a valid sampled traceparent header', () => {
+        expect(
+            getTraceContext(
+                '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+            ),
+        ).toEqual({
+            traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+            spanId: '00f067aa0ba902b7',
+            sampled: true,
+        });
+    });
+
+    it('parses a valid unsampled traceparent header', () => {
+        expect(
+            getTraceContext(
+                '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00',
+            ),
+        ).toEqual({
+            traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+            spanId: '00f067aa0ba902b7',
+            sampled: false,
+        });
+    });
+
+    it.each([
+        '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7',
+        '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-extra',
+        'zz-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+        '00-xyz-00f067aa0ba902b7-01',
+        '00-00000000000000000000000000000000-00f067aa0ba902b7-01',
+        '00-4bf92f3577b34da6a3ce929d0e0e4736-xyz-01',
+        '00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01',
+        '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-zz',
+    ])('returns null fields for invalid traceparent %s', (traceparent) => {
+        expect(getTraceContext(traceparent)).toEqual(nullTraceContext);
+    });
+});

--- a/src/helpers/context-header.unit.test.ts
+++ b/src/helpers/context-header.unit.test.ts
@@ -40,6 +40,7 @@ describe('getTraceContext', () => {
     it.each([
         '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7',
         '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-extra',
+        'ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
         'zz-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
         '00-xyz-00f067aa0ba902b7-01',
         '00-00000000000000000000000000000000-00f067aa0ba902b7-01',

--- a/src/helpers/context-header.unit.test.ts
+++ b/src/helpers/context-header.unit.test.ts
@@ -37,6 +37,18 @@ describe('getTraceContext', () => {
         });
     });
 
+    it('parses a future-version traceparent header with extra fields', () => {
+        expect(
+            getTraceContext(
+                '01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-extra',
+            ),
+        ).toEqual({
+            traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+            spanId: '00f067aa0ba902b7',
+            sampled: true,
+        });
+    });
+
     it.each([
         '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7',
         '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-extra',


### PR DESCRIPTION
- Validate the W3C `traceparent` header before returning Cloud Logging trace context, so malformed or spoofed headers no longer emit junk trace IDs.
- Parsing is delegated to `parseTraceParent` from `@opentelemetry/core` (already a direct dependency) rather than a hand-rolled parser. This enforces the spec rules — hex format, reserved version `ff`, all-zero trace/span IDs, no extra fields on version `00` — and correctly parses future-version headers that carry extra fields (the spec says receivers should read the first four fields).
- `getTraceContext` is now a thin mapping: null-object shape on missing/invalid input, and `traceFlags & TraceFlags.SAMPLED` → `sampled`.
- Add unit coverage: valid sampled/unsampled headers, a future-version forward-compat case, and a matrix of malformed headers (bad hex, wrong lengths, all-zero IDs, reserved version `ff`, wrong field count).


