### PR TITLE
Added support for single redis instances

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -67,6 +67,9 @@ Only required if `FEDIFY_KV_STORE_TYPE` is set to `redis`
 
 - `REDIS_HOST` - Redis server host
 - `REDIS_PORT` - Redis server port
+- `REDIS_MODE` - Redis connection mode: `cluster` (default) or `standalone`
+  - Set to `standalone` to connect to a single-node Redis server, e.g. a plain `redis:alpine` container
+  - Default: `cluster`
 - `REDIS_TLS_CERT` - TLS certificate for Redis connection
   - Only required if Redis is configured to use TLS
 

--- a/src/configuration/registrations.ts
+++ b/src/configuration/registrations.ts
@@ -108,6 +108,24 @@ function getRedisMode(): RedisMode {
     return mode;
 }
 
+function getRedisPort(): number {
+    const rawPort = process.env.REDIS_PORT;
+
+    if (!rawPort) {
+        return 6379;
+    }
+
+    const port = Number(rawPort);
+
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+        throw new Error(
+            `Invalid REDIS_PORT "${rawPort}". Expected a port number between 1 and 65535.`,
+        );
+    }
+
+    return port;
+}
+
 /**
  * Create a Redis connection for use as Fedify's KvStore.
  *
@@ -119,7 +137,7 @@ export function createRedisConnection(logging: Logger): Redis | Cluster {
     const mode = getRedisMode();
 
     const host = process.env.REDIS_HOST || 'localhost';
-    const port = Number(process.env.REDIS_PORT) || 6379;
+    const port = getRedisPort();
     const tls = process.env.REDIS_TLS_CERT
         ? { ca: process.env.REDIS_TLS_CERT }
         : undefined;

--- a/src/configuration/registrations.ts
+++ b/src/configuration/registrations.ts
@@ -9,7 +9,7 @@ import {
     asFunction,
     asValue,
 } from 'awilix';
-import Redis from 'ioredis';
+import Redis, { type Cluster } from 'ioredis';
 import type { Knex } from 'knex';
 
 import { KnexAccountRepository } from '@/account/account.repository.knex';
@@ -94,6 +94,71 @@ import { LocalStorageAdapter } from '@/storage/adapters/local-storage-adapter';
 import { ImageProcessor } from '@/storage/image-processor';
 import { ImageStorageService } from '@/storage/image-storage.service';
 
+type RedisMode = 'cluster' | 'standalone';
+
+function getRedisMode(): RedisMode {
+    const mode = process.env.REDIS_MODE ?? 'cluster';
+
+    if (mode !== 'cluster' && mode !== 'standalone') {
+        throw new Error(
+            `Invalid REDIS_MODE "${mode}". Expected "cluster" or "standalone".`,
+        );
+    }
+
+    return mode;
+}
+
+/**
+ * Create a Redis connection for use as Fedify's KvStore.
+ *
+ * Defaults to a Redis Cluster connection (the historical behaviour). Set
+ * `REDIS_MODE=standalone` to connect to a single-node Redis server, e.g. a
+ * plain `redis:alpine` container.
+ */
+export function createRedisConnection(logging: Logger): Redis | Cluster {
+    const mode = getRedisMode();
+
+    const host = process.env.REDIS_HOST || 'localhost';
+    const port = Number(process.env.REDIS_PORT) || 6379;
+    const tls = process.env.REDIS_TLS_CERT
+        ? { ca: process.env.REDIS_TLS_CERT }
+        : undefined;
+
+    const retryStrategy = (times: number) => {
+        const delay = Math.min(times * 50, 2000);
+        logging.warn(
+            `Redis connection retry attempt ${times}, delay ${delay}ms`,
+        );
+        return delay;
+    };
+
+    if (mode === 'standalone') {
+        logging.info('Connecting to Redis in standalone mode');
+
+        return new Redis({
+            host,
+            port,
+            retryStrategy,
+            enableOfflineQueue: true,
+            maxRetriesPerRequest: 3,
+            enableReadyCheck: true,
+            tls,
+        });
+    }
+
+    logging.info('Connecting to Redis in cluster mode');
+
+    return new Redis.Cluster([{ host, port }], {
+        clusterRetryStrategy: retryStrategy,
+        enableOfflineQueue: true,
+        redisOptions: {
+            maxRetriesPerRequest: 3,
+            enableReadyCheck: true,
+            tls,
+        },
+    });
+}
+
 export function registerDependencies(
     container: AwilixContainer,
     deps: {
@@ -116,38 +181,8 @@ export function registerDependencies(
 
             if (kvStoreType === 'redis') {
                 logging.info('Using Redis KvStore for Fedify');
-                const host = process.env.REDIS_HOST || 'localhost';
-                const port = Number(process.env.REDIS_PORT) || 6379;
 
-                const redis = new Redis.Cluster(
-                    [
-                        {
-                            host,
-                            port,
-                        },
-                    ],
-                    {
-                        clusterRetryStrategy: (times: number) => {
-                            const delay = Math.min(times * 50, 2000);
-                            logging.warn(
-                                `Redis connection retry attempt ${times}, delay ${delay}ms`,
-                            );
-                            return delay;
-                        },
-                        enableOfflineQueue: true,
-                        redisOptions: {
-                            maxRetriesPerRequest: 3,
-                            enableReadyCheck: true,
-                            tls: process.env.REDIS_TLS_CERT
-                                ? {
-                                      ca: process.env.REDIS_TLS_CERT,
-                                  }
-                                : undefined,
-                        },
-                    },
-                );
-
-                return new RedisKvStore(redis);
+                return new RedisKvStore(createRedisConnection(logging));
             }
 
             logging.info('Using MySQL KvStore for Fedify');

--- a/src/configuration/registrations.ts
+++ b/src/configuration/registrations.ts
@@ -97,7 +97,7 @@ import { ImageStorageService } from '@/storage/image-storage.service';
 type RedisMode = 'cluster' | 'standalone';
 
 function getRedisMode(): RedisMode {
-    const mode = process.env.REDIS_MODE ?? 'cluster';
+    const mode = process.env.REDIS_MODE || 'cluster';
 
     if (mode !== 'cluster' && mode !== 'standalone') {
         throw new Error(

--- a/src/configuration/registrations.unit.test.ts
+++ b/src/configuration/registrations.unit.test.ts
@@ -66,6 +66,15 @@ describe('createRedisConnection', () => {
         expect(options.port).toBe(6380);
     });
 
+    it('connects in cluster mode when REDIS_MODE is set but empty', () => {
+        process.env.REDIS_MODE = '';
+
+        createRedisConnection(logging);
+
+        expect(clusterConstructor).toHaveBeenCalledTimes(1);
+        expect(redisConstructor).not.toHaveBeenCalled();
+    });
+
     it('throws on an unrecognised REDIS_MODE', () => {
         process.env.REDIS_MODE = 'sentinel';
 

--- a/src/configuration/registrations.unit.test.ts
+++ b/src/configuration/registrations.unit.test.ts
@@ -95,6 +95,22 @@ describe('createRedisConnection', () => {
         expect(options.port).toBe(6379);
     });
 
+    it('throws on a non-numeric REDIS_PORT', () => {
+        process.env.REDIS_PORT = 'not-a-port';
+
+        expect(() => createRedisConnection(logging)).toThrow(
+            /Invalid REDIS_PORT/,
+        );
+    });
+
+    it('throws on an out-of-range REDIS_PORT', () => {
+        process.env.REDIS_PORT = '65536';
+
+        expect(() => createRedisConnection(logging)).toThrow(
+            /Invalid REDIS_PORT/,
+        );
+    });
+
     it('passes the TLS certificate through when configured', () => {
         process.env.REDIS_MODE = 'standalone';
         process.env.REDIS_TLS_CERT = 'a-cert';

--- a/src/configuration/registrations.unit.test.ts
+++ b/src/configuration/registrations.unit.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Logger } from '@logtape/logtape';
+
+const clusterConstructor = vi.fn();
+const redisConstructor = vi.fn();
+
+vi.mock('ioredis', () => {
+    class Cluster {
+        constructor(...args: unknown[]) {
+            clusterConstructor(...args);
+        }
+    }
+    class Redis {
+        static Cluster = Cluster;
+        constructor(...args: unknown[]) {
+            redisConstructor(...args);
+        }
+    }
+    return { default: Redis, Cluster };
+});
+
+import { createRedisConnection } from './registrations';
+
+describe('createRedisConnection', () => {
+    const logging = {
+        info: vi.fn(),
+        warn: vi.fn(),
+    } as unknown as Logger;
+
+    const originalEnv = { ...process.env };
+
+    beforeEach(() => {
+        clusterConstructor.mockClear();
+        redisConstructor.mockClear();
+        process.env.REDIS_HOST = 'redis-host';
+        process.env.REDIS_PORT = '6380';
+        delete process.env.REDIS_MODE;
+        delete process.env.REDIS_TLS_CERT;
+    });
+
+    afterEach(() => {
+        process.env = { ...originalEnv };
+    });
+
+    it('connects in cluster mode by default', () => {
+        createRedisConnection(logging);
+
+        expect(clusterConstructor).toHaveBeenCalledTimes(1);
+        expect(redisConstructor).not.toHaveBeenCalled();
+
+        const nodes = clusterConstructor.mock.calls[0][0];
+        expect(nodes).toEqual([{ host: 'redis-host', port: 6380 }]);
+    });
+
+    it('connects in standalone mode when REDIS_MODE is "standalone"', () => {
+        process.env.REDIS_MODE = 'standalone';
+
+        createRedisConnection(logging);
+
+        expect(redisConstructor).toHaveBeenCalledTimes(1);
+        expect(clusterConstructor).not.toHaveBeenCalled();
+
+        const options = redisConstructor.mock.calls[0][0];
+        expect(options.host).toBe('redis-host');
+        expect(options.port).toBe(6380);
+    });
+
+    it('throws on an unrecognised REDIS_MODE', () => {
+        process.env.REDIS_MODE = 'sentinel';
+
+        expect(() => createRedisConnection(logging)).toThrow(
+            /Invalid REDIS_MODE/,
+        );
+    });
+
+    it('defaults to localhost:6379 when host/port are unset', () => {
+        process.env.REDIS_MODE = 'standalone';
+        delete process.env.REDIS_HOST;
+        delete process.env.REDIS_PORT;
+
+        createRedisConnection(logging);
+
+        const options = redisConstructor.mock.calls[0][0];
+        expect(options.host).toBe('localhost');
+        expect(options.port).toBe(6379);
+    });
+
+    it('passes the TLS certificate through when configured', () => {
+        process.env.REDIS_MODE = 'standalone';
+        process.env.REDIS_TLS_CERT = 'a-cert';
+
+        createRedisConnection(logging);
+
+        const options = redisConstructor.mock.calls[0][0];
+        expect(options.tls).toEqual({ ca: 'a-cert' });
+    });
+});


### PR DESCRIPTION
closes https://github.com/TryGhost/ActivityPub/issues/1868

## Summary

Adds support for connecting to a single-node Redis server, in addition to the existing Redis Cluster support, when Redis is used as Fedify's KvStore.

Previously the Redis connection was always created via `Redis.Cluster`, which fails against a standalone Redis instance (e.g. a plain `redis:alpine` container in local/dev environments or smaller deployments).

## Changes

- Added a `REDIS_MODE` environment variable: `cluster` (default) or `standalone`. An unrecognised value throws at startup with a clear error; an unset or empty value falls back to `cluster`.
- Extracted the inline Redis Cluster construction from `registerDependencies` into a new `createRedisConnection` factory that returns either a `Redis` or `Cluster` client based on `REDIS_MODE`. Connection behaviour (retry strategy, offline queue, ready check, TLS via `REDIS_TLS_CERT`) is preserved in both modes.
- `REDIS_PORT` is now validated at startup: a non-numeric or out-of-range value throws a descriptive error instead of silently falling back to `6379` (which could connect to the wrong Redis instance). Unset or empty still defaults to `6379`.
- Documented the new variable in `docs/env-vars.md`.
- Added unit tests covering mode selection, the default cluster behaviour, host/port defaults, port validation, TLS pass-through, and rejection of invalid modes.

## How to test

1. Start a standalone Redis instance, e.g. `docker run -p 6379:6379 redis:alpine`
2. Set `FEDIFY_KV_STORE_TYPE=redis`, `REDIS_MODE=standalone`, and `REDIS_HOST`/`REDIS_PORT` accordingly
3. Boot the app — it should log "Connecting to Redis in standalone mode" and use Redis as the KvStore without cluster-negotiation errors

Existing deployments are unaffected: with `REDIS_MODE` unset, behaviour is identical to before (cluster mode). The one intentional behaviour change is that a malformed `REDIS_PORT` now fails fast at boot instead of silently using the default port.
