### PR TITLE
Build arm64 image on native runner instead of QEMU emulation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
   build-main-images:
-    name: Build Docker Images
+    name: Build Docker Images (${{ matrix.platform }}, ${{ matrix.platform_slug }})
     runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,14 +58,16 @@ jobs:
 
   build-main-images:
     name: Build Docker Images
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:
         include:
           - platform: linux/amd64
             platform_slug: amd64
+            runs_on: ubuntu-latest
           - platform: linux/arm64
             platform_slug: arm64
+            runs_on: ubuntu-24.04-arm
     outputs:
       activitypub-private-tags: ${{ steps.activitypub-docker-metadata-private.outputs.tags }}
       activitypub-public-tags: ${{ steps.activitypub-docker-metadata-public.outputs.tags || '' }}
@@ -88,12 +90,6 @@ jobs:
       - name: Checkout
         if: steps.should-build.outputs.skip != 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-
-      - name: Set up QEMU
-        if: steps.should-build.outputs.skip != 'true'
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
-        with:
-          platforms: ${{ matrix.platform_slug }}
 
       - name: Set up Docker Buildx
         if: steps.should-build.outputs.skip != 'true'


### PR DESCRIPTION
## What

Build the multi-arch Docker images on native runners — `ubuntu-latest` for `linux/amd64`, `ubuntu-24.04-arm` for `linux/arm64` — and remove the QEMU emulation step, which is no longer needed now that each platform builds on its own architecture.

## Why

The arm64 build is failing on `main` (e.g. [this run](https://github.com/TryGhost/ActivityPub/actions/runs/27938425575/job/82665665552)) at the `yarn --ignore-scripts` layer:

```
qemu: uncaught target signal 4 (Illegal instruction) - core dumped
exit code: 132        # 128 + 4 = killed by SIGILL
```

The arm64 image was built on the x86_64 `ubuntu-latest` runner via QEMU user-mode emulation, so `yarn` ran an arm64 Node binary under QEMU. After the base image digest bump in #1892 (the `node:22.22.3-alpine` tag was repushed onto a newer Alpine base — gcc 15.2.0, python3 3.14.5, etc.), the Node binary emits arm64 instructions the runner's QEMU can't translate, killing the process with SIGILL. It's deterministic (not a cache/flake issue), and the `amd64` leg is unaffected because it runs natively.

Building arm64 on a real arm64 CPU runs those instructions natively — no translation, no `Illegal instruction` — and makes the pipeline resilient to this whole class of emulation breakage going forward. As a bonus, the native arm64 build is significantly faster than emulation.

## Changes

- `build-main-images.runs-on` is now `${{ matrix.runs_on }}`; each matrix leg carries its own `runs_on` label.
- Removed the `Set up QEMU` step (`docker/setup-qemu-action`).

## Reviewer notes

- GitHub's hosted `ubuntu-24.04-arm` runners are free for public repos, so no larger-runners plan is required. If the org enforces a runner-group label allowlist, `ubuntu-24.04-arm` may need to be permitted there.
- The arm64 leg only runs on `main` and `v*` tags (existing `should-build` gate is unchanged), so this PR's CI exercises the amd64 leg and YAML; the real arm64 build validates once merged to `main`.
- The GHA layer cache is arch-keyed, so the arm64 leg rebuilds cold on its first post-merge run, then caches normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)