### PR TITLE
docs(adr): Fedify circuit breaker adoption — two proposals (0014, 0015)

### DIFF
--- a/adr/0014-fedify-outbound-circuit-breaker.md
+++ b/adr/0014-fedify-outbound-circuit-breaker.md
@@ -1,0 +1,285 @@
+# Adopt Fedify's Outbound Delivery Circuit Breaker
+
+## Status
+
+Proposed — **alternative to [ADR-0015](0015-replace-account-delivery-backoff-with-circuit-breaker.md)**
+
+ADR-0014 and ADR-0015 are competing proposals; the team should adopt **one**.
+ADR-0014 (this one) keeps `account_delivery_backoffs` and adds Fedify's circuit
+breaker **on top** (additive). ADR-0015 **removes** `account_delivery_backoffs`
+and makes the circuit breaker the **single** suppression mechanism. See
+ADR-0015's "How to choose" section for the decision guide.
+
+## Context
+
+Fedify 2.3.0 added an **outbound delivery circuit breaker** that is enabled by
+default whenever an outbox queue is configured. We currently **disable** it
+(`circuitBreaker: false` in `src/configuration/registrations.ts`) because, as
+shipped, it silently drops deliveries on our queue (see "Why it is disabled
+today" below). This ADR proposes how we could adopt it deliberately, **without
+losing any current functionality**, and documents what we would gain.
+
+### Our current delivery system (two distinct mechanisms)
+
+Today's outbound delivery is built from two cooperating but separate parts:
+
+**1. A retry *engine* — GCP Pub/Sub, driven by `GCloudPubSubPushMessageQueue`**
+(`src/mq/gcloud-pubsub-push/mq.ts`)
+
+- `nativeRetrial = true`: on a delivery failure Fedify simply `throw`s and
+  defers re-delivery to us.
+- Two-stage retry (`handleMessage`, `mq.ts:309`): main topic → on failure
+  republish to a **retry topic** (`isRetry=true`) → on the retry topic, `throw`
+  so GCP's push subscription applies **exponential backoff**, up to
+  `MQ_PUBSUB_MAX_DELIVERY_ATTEMPTS` (default `Infinity`).
+- Failure classification (`src/mq/gcloud-pubsub-push/error-utils.ts`,
+  `analyzeError`) decides `isRetryable` / `isReportable`:
+  - DNS (`ENOTFOUND`/`EAI_AGAIN`), upstream SSL/TLS, and non-standard status
+    codes → **not retryable, not reportable** (silent drop).
+  - Network connectivity (`ECONNREFUSED`, `ETIMEDOUT`, `ECONNRESET`, socket
+    hangups, …) → **retryable**, not reportable.
+  - Fedify/HTTP delivery errors → retryable unless the status is in the
+    permanent set `400, 401, 403, 404, 405, 410, 422, 501`.
+  - Anything unrecognised → retryable **and** reportable (an app bug → Sentry).
+- Multitenancy filter (`shouldDeliverActivity`, `mq.ts:153`): never deliver to
+  inboxes that resolve to **internal** accounts on this instance.
+
+**2. A per-destination gate — `account_delivery_backoffs`**
+(`src/account/account.service.ts:1074`)
+
+- This is, in effect, **our own circuit breaker**.
+- `recordDeliveryFailure` is called from `handlePermanentFailure`
+  (`mq.ts:429`) when a message hits a **permanent** failure (or exhausts
+  `MQ_PUBSUB_MAX_DELIVERY_ATTEMPTS` when that is finite). It sets an
+  **exponential backoff** window per **remote account/inbox**:
+  `60s × 2ⁿ`, no cap, persisted in MySQL.
+- While a backoff window is active, `getActiveDeliveryBackoff` causes
+  `_enqueue` to **drop new messages** to that inbox (`mq.ts:183`).
+- `clearDeliveryFailure` removes the window on the next successful delivery.
+
+### The gap in the current system
+
+The two mechanisms trip on **different failure classes**:
+
+| Failure class | Current handling |
+|---|---|
+| Permanent (4xx in the permanent set), DNS, SSL | `account_delivery_backoffs` window → new messages dropped per **account** |
+| Transient host outage (network errors, **5xx**) | Retried **per-message, per-account, forever** (default `Infinity`), with **no host-level coordination** |
+
+So when a popular remote **host** (e.g. `mastodon.social`) has a transient
+outage, every in-flight message and every one of our accounts targeting that
+host independently keeps retrying it. There is **no per-host backpressure** —
+the exact problem a circuit breaker exists to solve, and the one thing our
+current design lacks.
+
+### Why Fedify's circuit breaker is disabled today
+
+Fedify's breaker, when a host's circuit opens, "holds" a message by
+**re-enqueuing it with a delay**
+(`enqueueHeldOutboxMessage` → `outboxQueue.enqueue(msg, { delay })`,
+`middleware.ts:1268`). Our queue **drops any delayed message**
+(`mq.ts:117`, *"this is a retry and we want to ignore for now"*) and the hold
+path `return`s without throwing, so Pub/Sub acks and discards it. The breaker's
+"retry later" therefore becomes a **silent drop**, and the held branch
+pre-empts the `nativeRetrial` throw path (`middleware.ts:1633`). It is disabled
+until the queue can honour delayed re-enqueues.
+
+### Fedify circuit breaker — behaviour and defaults
+
+From `@fedify/fedify@2.3.x` (`packages/fedify/src/federation/circuit-breaker.ts`,
+`.../middleware.ts`):
+
+- **Granularity:** per **remote host** (`getRemoteHost(inbox)`), not per inbox.
+- **What opens it:** network/transport errors and **5xx** (`recordFailure`).
+  4xx and 429 are "reachable" failures (`recordReachableFailure`) and **do not**
+  open the circuit. 429 is excluded; `Retry-After` is honoured.
+- **Defaults:** `failureThreshold: 5`, `failureWindow: 10 min`,
+  `recoveryDelay: 30 min`, `heldActivityTtl: 168 h (7 days)`,
+  `releaseInterval: 1 s`.
+- **State machine:** closed → open (hold) → half-open (probe on `recoveryDelay`)
+  → closed on a successful probe.
+- **Storage:** state lives in the configured `KvStore` (`get`/`set`/`delete`,
+  optional `cas`). Without `cas` it logs *"does not support CAS … updates may
+  race under concurrent workers"* (`middleware.ts:693`). **Neither** our
+  `RedisKvStore` nor `KnexKvStore` implements `cas` today.
+- **TTL expiry:** a held activity older than `heldActivityTtl` is dropped and
+  the `outboxPermanentFailureHandler` is called with `reason:
+  "circuit-breaker-ttl"`.
+- **Customisation:** `CircuitBreakerOptions` accepts `failureThreshold`,
+  `failureWindow`, `recoveryDelay`, `heldActivityTtl`, `releaseInterval`, a
+  custom `failure` predicate, and `onStateChange` / `onActivityDrop` callbacks.
+
+## Decision
+
+Adopt Fedify's circuit breaker as a **new, additive layer** that owns
+**transient host-level backpressure**, while **keeping every existing
+mechanism** that covers a different concern. The breaker replaces *nothing* we
+rely on today; it fills the host-outage gap.
+
+Target ownership after migration:
+
+| Concern | Owner (after) | Owner (today) |
+|---|---|---|
+| Re-delivery of transient failures | GCP retry engine (**unchanged**) | GCP retry engine |
+| Error taxonomy / Sentry reporting | `error-utils.ts` (**unchanged**) | `error-utils.ts` |
+| Internal-account filtering | `shouldDeliverActivity` (**unchanged**) | `shouldDeliverActivity` |
+| Permanent per-destination failures (4xx/DNS/SSL) | `account_delivery_backoffs` (**unchanged**) | `account_delivery_backoffs` |
+| **Transient host outage (network/5xx) backpressure** | **Fedify circuit breaker (new)** | *(none)* |
+
+### Prerequisites (the actual work)
+
+These are blockers; the breaker must not be enabled until they are done.
+
+**P1 — Make the queue honour delayed re-enqueue for circuit-held messages.**
+Held messages carry `circuitHeld: true` and `circuitHeldSince`. `_enqueue`
+must stop dropping them and instead deliver them *after* the requested delay.
+Without this, a held message either drops (today) or, if we naively re-publish,
+busy-loops every `releaseInterval` (1 s). Options:
+
+- **(Recommended) Route held messages through the existing retry topic.**
+  Detect `circuitHeld` in `_enqueue` and publish to the retry topic instead of
+  dropping. GCP's exponential backoff approximates the hold delay; the circuit
+  is re-evaluated on each redelivery via `beforeSend`. Reuses existing infra,
+  no new dependency. Raise `releaseInterval` (e.g. 30–60 s) so re-checks are not
+  excessively frequent. Ensure held re-enqueues are **not** counted as
+  `handleMessage` failures (they are publishes, not handler throws), so they do
+  not trip `account_delivery_backoffs`.
+- **(Higher fidelity) Cloud Tasks with `scheduleTime = now + delay`.** Honours
+  Fedify's exact delay, but adds a new infra dependency and delivery path.
+- **(DIY) A `held_deliveries` table + periodic sweeper** that re-publishes when
+  due — mirrors the `account_delivery_backoffs` pattern but is more code to own.
+
+**P2 — Decide on `cas` / accept racy counting.** We run multiple Cloud Run
+instances. Without `KvStore.cas`, concurrent workers can under-count failures
+(the circuit opens a little later than `failureThreshold` suggests). Options:
+add a `cas` method to `RedisKvStore`/`KnexKvStore` (Redis: `WATCH`/`MULTI` or a
+Lua script; MySQL: a conditional `UPDATE … WHERE`), or accept the imprecision —
+it is a threshold, and slightly late opening is not dangerous. Recommendation:
+ship accepting the race, add `cas` later if metrics show it matters.
+
+**P3 — Reconcile with `account_delivery_backoffs` when `MAX_DELIVERY_ATTEMPTS`
+is finite.** If that env is finite, transient exhaustion currently records an
+account backoff. To avoid double-gating transient failures, stop recording
+account backoff for *retryable* (transient) exhaustion and let the breaker own
+it; keep recording for *permanent* failures. If `MAX_DELIVERY_ATTEMPTS` stays
+`Infinity`, there is no overlap and no change is needed here.
+
+### Migration plan (phased)
+
+1. **Prereq build-out.** Implement P1 (held re-enqueue) behind a flag; unit +
+   integration tests for: held message is re-delivered after delay, not dropped,
+   not double-counted as a delivery failure, and dropped only at
+   `heldActivityTtl`.
+2. **Wire observability first.** Add an `outboxPermanentFailureHandler` that
+   handles `reason: "circuit-breaker-ttl"` (log + metric), and pass
+   `onStateChange` to emit a structured log/metric on every open/close. (We do
+   not pass `meterProvider`, so we wire our own logging rather than rely on
+   Fedify's OTel instruments — or pass `meterProvider` if we want the built-in
+   metrics.)
+3. **Enable in staging** with conservative options (see Configuration), behind
+   an env flag (e.g. `FEDIFY_CIRCUIT_BREAKER=true`) so it can be toggled without
+   a deploy. Drive a fake unreachable host (wiremock 5xx / connection refused)
+   in e2e and assert the circuit opens, holds, and recovers.
+4. **Reconcile P3** and remove transient-exhaustion account backoff if
+   `MAX_DELIVERY_ATTEMPTS` is finite in prod.
+5. **Enable in production**, monitor open/close rate and held/abandoned counts,
+   then make it the default and retire the env flag.
+
+### Configuration (proposed starting point)
+
+```ts
+createFederation<ContextData>({
+  // ...existing options...
+  circuitBreaker: {
+    failureThreshold: 5,        // default; tune from observed open-rate
+    failureWindow: { minutes: 10 },
+    recoveryDelay: { minutes: 30 },
+    heldActivityTtl: { hours: 24 }, // shorter than the 7-day default: we would
+                                    // rather abandon than hold a week of backlog
+    releaseInterval: { seconds: 60 }, // larger than 1s to avoid frequent re-checks
+                                      // given the retry-topic hold strategy (P1)
+    onStateChange: (host, prev, next) => logger.warn(
+      'Outbound circuit {host}: {prev} -> {next}', { host, prev, next },
+    ),
+  },
+})
+```
+
+## Consequences
+
+### What we keep (no functionality lost)
+
+- **Retry engine, intact.** Transient re-delivery still flows through the GCP
+  main→retry-topic→backoff path; `nativeRetrial` stays `true`. The breaker only
+  decides *whether* to attempt, never replaces re-attempts.
+- **Error taxonomy + Sentry reporting, intact.** `error-utils.ts` still
+  classifies DNS/SSL/network/permanent and still distinguishes remote failures
+  from reportable app bugs.
+- **Internal-account filtering, intact.** `shouldDeliverActivity` still runs in
+  `_enqueue`.
+- **Permanent per-destination backoff, intact.** `account_delivery_backoffs`
+  still gates 4xx/DNS/SSL — the class Fedify's breaker deliberately ignores
+  (reachable failures).
+
+### What we gain (on top of current logic)
+
+1. **Host-level backpressure for transient outages — a capability we do not
+   have today.** After 5 failures in 10 min, *all* traffic to a down host is
+   gated at once, instead of every message and every account independently
+   hammering it. This directly cuts wasted delivery attempts, outbound
+   connection churn, and retry-topic volume during a remote outage — and
+   complements ADR-0001's goal of not wasting delivery resources.
+2. **A real recovery state machine.** Half-open probing re-tests the host and
+   closes only when it genuinely recovers, versus our `account_delivery_backoffs`
+   window that expires blindly on a timer regardless of host health — fewer
+   premature re-sends and faster, verified resumption.
+3. **Fewer lost activities.** Once P1 lands, held messages are **retried after
+   recovery** (up to `heldActivityTtl`) instead of being dropped. Both of
+   today's gates (`account_delivery_backoffs` drop-on-enqueue, and the breaker
+   on the current queue) are lossy; the proposed design is loss-free for
+   transient outages within the TTL.
+4. **Protocol-correct throttling.** 429 is not treated as a circuit failure and
+   `Retry-After` is honoured — politeness our current path does not implement.
+5. **Better observability of remote health.** Per-host open/close state via
+   `onStateChange` (and optional OTel circuit metrics if we pass
+   `meterProvider`) gives a direct signal of which hosts are unhealthy, which we
+   currently only infer from logs.
+
+### Negative / costs
+
+- **Real implementation work** (P1) before any benefit; done wrong it is worse
+  than today (drop or busy-loop).
+- **Per-host granularity** replaces per-inbox precision for the transient class:
+  one dead actor on an otherwise-healthy shared host will not open the circuit
+  (correct), but a flapping host gates all its inboxes together (usually
+  desirable, occasionally over-broad).
+- **Concurrency caveat** (P2): failure counting is racy across Cloud Run
+  instances until we add `cas`.
+- **Two backoff concepts to reason about** (`account_delivery_backoffs` for
+  permanent, breaker for transient) — mitigated by the clear ownership table and
+  the P3 reconciliation.
+- **Operational surface:** a new env flag, new metrics/alerts, and a new
+  permanent-failure `reason` to handle.
+
+## Alternatives considered
+
+- **Keep the breaker off (status quo).** Zero work, but the transient host-outage
+  gap remains and we keep paying for uncoordinated retries during outages.
+- **Build host-level backpressure into `account_delivery_backoffs` ourselves**
+  (add a per-host row and trip on transient 5xx/network). Avoids the queue-delay
+  problem, but re-implements a state machine Fedify already maintains and tests,
+  and forgoes `Retry-After`/429 handling and the upstream metrics.
+- **Replace the GCP retry engine with Fedify's `outboxRetryPolicy`** (turn off
+  `nativeRetrial`). Largest blast radius — also needs queue delay support, and
+  would discard our error taxonomy, internal-account filtering, and Sentry
+  classification. Rejected.
+
+## Open questions
+
+- Prod value of `MQ_PUBSUB_MAX_DELIVERY_ATTEMPTS` (drives P3).
+- Preferred P1 implementation: retry-topic reuse vs Cloud Tasks vs held table.
+- Do we want Fedify's OTel circuit metrics (pass `meterProvider`) or only our
+  own `onStateChange` logging?
+- Final `heldActivityTtl` — how much backlog is worth holding for a host that
+  may never return.
+```

--- a/adr/0015-replace-account-delivery-backoff-with-circuit-breaker.md
+++ b/adr/0015-replace-account-delivery-backoff-with-circuit-breaker.md
@@ -1,0 +1,196 @@
+# Replace `account_delivery_backoffs` with Fedify's Circuit Breaker
+
+## Status
+
+Proposed — **alternative to [ADR-0014](0014-fedify-outbound-circuit-breaker.md)**
+
+ADR-0014 and ADR-0015 are competing proposals; the team should adopt **one**.
+ADR-0014 keeps `account_delivery_backoffs` and adds Fedify's circuit breaker
+**on top** (additive). ADR-0015 (this one) **removes** `account_delivery_backoffs`
+and makes Fedify's circuit breaker the **single** delivery-suppression
+mechanism, to reduce the amount of bespoke code we maintain.
+
+## Context
+
+See ADR-0014 for the full description of our current delivery system. In short,
+outbound delivery has three independent pieces:
+
+1. **Retry engine** — GCP Pub/Sub main→retry-topic→backoff
+   (`src/mq/gcloud-pubsub-push/mq.ts`).
+2. **Error taxonomy** — `src/mq/gcloud-pubsub-push/error-utils.ts`.
+3. **Per-destination suppression gate** — `account_delivery_backoffs`
+   (`src/account/account.service.ts:1074`), our own hand-rolled circuit breaker:
+   exponential `60s × 2ⁿ` window **per remote inbox**, recorded on permanent /
+   non-retryable failures, enforced by dropping new sends at `_enqueue`, cleared
+   on success.
+
+This ADR concerns **only piece 3**. Pieces 1 and 2 are kept in both proposals.
+
+The motivation for replacing is maintenance cost: `account_delivery_backoffs`
+is a bespoke table + migration, three `AccountService` methods, and an
+enqueue-time check that we own and test ourselves. Fedify 2.3.0 now ships a
+maintained circuit breaker, so the appeal is "delete our version, use theirs."
+
+### The structural fact that shapes this decision
+
+Fedify's circuit breaker only opens on **transient host failures** (network /
+transport errors and **5xx**, via `recordFailure`). Everything else —
+**4xx, 429, and Fedify's "permanent" failures** — is routed through
+`recordReachableFailure`, which is literally:
+
+```ts
+async recordReachableFailure(remoteHost) {
+  return await this.recordSuccess(remoteHost);   // circuit-breaker.ts:327-331
+}
+```
+
+i.e. a permanent rejection is treated as **the host being healthy**. The
+configurable `failure` predicate (`CircuitBreakerOptions.failure`) is consulted
+**only inside `recordFailure`** (the 5xx/transport path); 4xx never reach it.
+
+**Consequence:** Fedify's circuit breaker *cannot be configured* to suppress a
+destination that returns permanent 4xx (`404`, `410 Gone`, `403`, `422`, …) —
+the exact case `account_delivery_backoffs` exists to handle. Making it do so
+would require forking Fedify or intercepting before we hand the failure to it.
+
+## Decision
+
+Remove `account_delivery_backoffs` entirely and rely on Fedify's circuit breaker
+as the sole per-destination/host suppression mechanism. Keep the retry engine,
+error taxonomy, and `shouldDeliverActivity` internal-account filter.
+
+Concretely:
+
+- Delete `recordDeliveryFailure`, `clearDeliveryFailure`,
+  `getActiveDeliveryBackoff`, the `account_delivery_backoffs` table + migration,
+  the `handlePermanentFailure` → backoff wiring, and the `_enqueue` backoff drop.
+- Enable Fedify's circuit breaker (`circuitBreaker: { … }`), after the same
+  prerequisites as ADR-0014.
+- **Explicitly accept** that permanently-dead destinations are no longer
+  suppressed per-inbox (see "What we lose").
+
+### Prerequisites
+
+Same blockers as ADR-0014 — they do **not** go away by replacing:
+
+- **P1 — queue must honour delayed re-enqueue** for circuit-held messages, or
+  "hold" becomes a silent drop / busy-loop. (See ADR-0014 P1 for options.)
+- **P2 — `cas` on the `KvStore`** or accept racy failure counting across Cloud
+  Run instances.
+
+### Migration plan (phased)
+
+1. Implement P1 (held re-enqueue) and P2 decision, as in ADR-0014.
+2. Enable the breaker in staging behind an env flag; verify open/hold/recover
+   against a wiremock host returning 5xx / refusing connections.
+3. **Stop writing** to `account_delivery_backoffs` (remove
+   `recordDeliveryFailure` calls) while leaving reads in place; observe that
+   transient backpressure is now handled by the breaker.
+4. Remove the reads (`getActiveDeliveryBackoff` enqueue check) and the
+   `AccountService` methods.
+5. Drop the `account_delivery_backoffs` table in a follow-up migration once
+   confident (keep it one release for rollback).
+6. Remove the env flag and make the breaker the default.
+
+## Consequences
+
+### What we keep
+
+- Retry engine (GCP), error taxonomy (`error-utils.ts`), and internal-account
+  filtering (`shouldDeliverActivity`) — all unchanged, identical to ADR-0014.
+
+### What we lose (the tradeoffs)
+
+1. **Per-inbox suppression of permanently-dead destinations — removed, and
+   not recoverable via configuration.** Because Fedify treats 4xx/410/permanent
+   as success (see "structural fact" above), a follower whose inbox is
+   `410 Gone` / `404` / `403` will be **re-attempted on every future activity**,
+   indefinitely. Each attempt fails permanently and is abandoned for that
+   message, but there is no memory across messages, so a popular local account
+   fanning out to many dead followers pays a repeated, futile delivery cost —
+   precisely the kind of waste ADR-0001 sought to avoid. Today
+   `account_delivery_backoffs` dampens this after the first permanent failure.
+   *Severity: grows with scale / account age (dead remote actors accumulate).*
+
+2. **Granularity downgrade: per-host instead of per-inbox.** Even for the
+   transient failures it does handle, the breaker gates a whole host. One broken
+   actor on an otherwise-healthy shared host (e.g. a single expired-cert actor on
+   a big instance) will not, on its own, cross the per-host `failureThreshold`,
+   so it may **never** be suppressed — whereas `account_delivery_backoffs`
+   suppresses that one inbox immediately. Conversely a flapping host gates all
+   its inboxes together (usually fine, occasionally over-broad).
+
+3. **DNS / SSL / `501` per-actor errors stop being suppressed promptly.** Today
+   these are non-retryable → immediate per-inbox backoff. Under the breaker they
+   count toward the per-host threshold (5 in 10 min) and otherwise keep being
+   retried; a persistent single-actor TLS/DNS misconfiguration on a busy host may
+   never trip a host-level circuit. Loss of fast, targeted suppression for these.
+
+4. **Recovery semantics change for dead destinations.**
+   `account_delivery_backoffs` backs off **exponentially without bound**
+   (`60s, 120s, 240s, …`), so a truly-dead destination is probed less and less
+   over time. The breaker uses a **fixed 30-min `recoveryDelay`** with half-open
+   probing — excellent for transient outages, but for a destination that is
+   permanently gone (if it were gated at all) it would re-probe **every 30 min
+   forever**. The breaker is tuned for "temporarily down," not "gone."
+
+5. **Still lossy unless P1 is done well, and racy unless P2 is** — identical to
+   ADR-0014, but here there is no `account_delivery_backoffs` fallback if the
+   breaker misbehaves.
+
+### What we gain (over ADR-0014)
+
+1. **Less bespoke code to own.** Delete a table + migration, three service
+   methods, and the enqueue-time check; one suppression mechanism and one mental
+   model instead of two.
+2. **No overlap to reconcile.** ADR-0014 has a small double-trip on
+   DNS/SSL/`501` (both mechanisms fire); removing ours eliminates that entirely.
+3. Everything ADR-0014 gains over today (host-level transient backpressure,
+   half-open recovery, `Retry-After`/429 correctness, per-host health
+   observability) — see ADR-0014 "What we gain".
+
+### Net trade
+
+This proposal trades **per-inbox suppression of permanent/dead destinations**
+(which the breaker structurally cannot replace) for **a smaller, single
+codebase**. It is the right choice **only if** the team judges that repeated
+futile delivery attempts to permanently-dead inboxes are acceptable (or better
+addressed by a separate dead-follower-pruning mechanism), and that per-host
+granularity is sufficient.
+
+## How to choose between ADR-0014 and ADR-0015
+
+Pick **ADR-0014 (keep both)** if:
+- Suppressing delivery to permanently-dead / `410 Gone` inboxes matters at our
+  scale, and per-inbox precision is valued.
+- We want the safety of a fallback while bedding in the breaker.
+
+Pick **ADR-0015 (replace)** if:
+- Minimising maintained code outweighs the loss above.
+- We plan to (or already) handle dead destinations another way — e.g. pruning
+  stale follows / actors — making per-inbox permanent-failure suppression
+  redundant.
+- Per-host granularity is deemed sufficient.
+
+A reasonable middle path (not a third ADR, just a note): adopt **ADR-0014 now**,
+and revisit **ADR-0015** once a dead-follower-pruning mechanism exists, at which
+point `account_delivery_backoffs` may become genuinely redundant and safe to
+delete.
+
+## Alternatives considered
+
+- **Custom `failure` predicate to make the breaker open on 4xx.** Does not work:
+  4xx are routed through `recordReachableFailure` and never reach the predicate.
+  Would require forking/wrapping Fedify — more code than we delete. Rejected.
+- **Replace per-inbox suppression with dead-follower pruning instead.** A better
+  long-term answer to the permanent-destination problem, but it is a separate
+  feature, not a circuit-breaker concern. Noted as the unblocker for this ADR.
+
+## Open questions
+
+- How many permanently-dead remote inboxes do we actually accumulate, and what
+  is the measured cost of un-suppressed re-attempts? (Quantifies tradeoff #1.)
+- Do we have, or want, a dead-follower / stale-actor pruning mechanism that would
+  make per-inbox permanent suppression redundant?
+- Same P1/P2 open questions as ADR-0014.
+```


### PR DESCRIPTION
## Summary

Two **competing** ADRs (Status: Proposed) for adopting Fedify 2.3.0's outbound delivery **circuit breaker**. The team should pick **one**. They are cross-linked.

Background: PR #1942 bumps Fedify to 2.3.0, which enables an outbound circuit breaker by default. We disabled it there (`circuitBreaker: false`) because, as shipped, it silently drops deliveries on our Pub/Sub queue (it "holds" by re-enqueuing with a delay, and our queue drops delayed messages). These ADRs propose how to adopt it deliberately.

## The two proposals

- **ADR-0014 — Keep both (additive).** Keep `account_delivery_backoffs` and add the breaker on top. The breaker owns **transient host outages** (network/5xx) — a gap we have today (we currently retry those per-message, per-account, forever, with no host-level backpressure). `account_delivery_backoffs` keeps owning **permanent per-inbox** failures (4xx/410/DNS/SSL).
- **ADR-0015 — Replace (consolidate).** Delete `account_delivery_backoffs` and make the breaker the single suppression mechanism. Less bespoke code, but we **lose per-inbox suppression of permanently-dead destinations**.

## The key fact for the decision

Fedify's breaker routes 4xx/429/permanent through `recordReachableFailure → recordSuccess` — it treats a permanent rejection as *the host being healthy* — and its configurable `failure` predicate is only consulted on the 5xx/transport path. So the breaker **structurally cannot** suppress a `410 Gone` / `404` / `403` destination. That capability only exists in `account_delivery_backoffs` today.

## What needs deciding

1. Does suppressing delivery to permanently-dead inboxes matter at our scale (and is per-inbox precision worth keeping)? → favours **0014**.
2. Is minimising maintained code the priority, with dead destinations handled separately (e.g. dead-follower pruning)? → favours **0015**.

See ADR-0015's "How to choose" section for the full decision guide (incl. the suggested middle path: adopt 0014 now, revisit 0015 once dead-follower pruning exists).

## Notes / not in scope

- These are **docs only** — no behavioural change. Adoption (either way) is gated on real prerequisite work documented in the ADRs: the queue must honour delayed re-enqueue (P1), and a `cas`/concurrency decision for the KV store (P2).
- Related: PR #1942 (the 2.3.0 bump with the breaker disabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)