### PR TITLE
Added custom domain validation endpoint

### DIFF
--- a/src/http/api/account.controller.ts
+++ b/src/http/api/account.controller.ts
@@ -568,15 +568,7 @@ export class AccountController {
         }
 
         if (data.domain === null) {
-            return new Response(
-                JSON.stringify(this.accountDomainResponse(account)),
-                {
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
-                    status: 200,
-                },
-            );
+            return this.jsonResponse(this.accountDomainResponse(account));
         }
 
         const normalizedHost = normalizeWebfingerHost(data.domain);
@@ -588,7 +580,8 @@ export class AccountController {
             });
         }
 
-        const fallbackHost = account.apId.host.replace(/^www\./, '');
+        const fallbackHost =
+            normalizeWebfingerHost(account.apId.host) ?? account.apId.host;
 
         if (normalizedHost === fallbackHost) {
             return this.jsonResponse(

--- a/src/http/api/account.controller.ts
+++ b/src/http/api/account.controller.ts
@@ -2,8 +2,15 @@ import { z } from 'zod';
 
 import type { Account } from '@/account/account.entity';
 import type { KnexAccountRepository } from '@/account/account.repository.knex';
-import type { AccountService } from '@/account/account.service';
-import { getAccountHandle, getAccountHandleHost } from '@/account/utils';
+import type {
+    AccountService,
+    WebfingerHostError,
+} from '@/account/account.service';
+import {
+    getAccountHandle,
+    getAccountHandleHost,
+    normalizeWebfingerHost,
+} from '@/account/utils';
 import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import type { AppContext } from '@/app';
 import { exhaustiveCheck, getError, getValue, isError } from '@/core/result';
@@ -88,6 +95,44 @@ export class AccountController {
             ),
             actorUrl: account.apId.href,
         };
+    }
+
+    private accountDomainPreviewResponse(
+        account: Account,
+        webfingerHost: string | null,
+    ) {
+        return {
+            domain: webfingerHost,
+            handle: getAccountHandle(
+                webfingerHost || account.apId.host,
+                account.username,
+            ),
+            actorUrl: account.apId.href,
+        };
+    }
+
+    private jsonResponse(body: unknown, status = 200) {
+        return new Response(JSON.stringify(body), {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            status,
+        });
+    }
+
+    private domainErrorResponse(accountError: WebfingerHostError) {
+        switch (accountError.type) {
+            case 'invalid-domain':
+            case 'invalid-webfinger':
+                return this.jsonResponse({ code: accountError.type }, 400);
+            case 'conflict':
+                return this.jsonResponse({ code: accountError.type }, 409);
+            case 'not-reachable':
+            case 'wrong-actor':
+                return this.jsonResponse({ code: accountError.type }, 422);
+            default:
+                return exhaustiveCheck(accountError);
+        }
     }
 
     /**
@@ -489,44 +534,7 @@ export class AccountController {
         );
 
         if (isError(result)) {
-            const accountError = getError(result);
-
-            switch (accountError.type) {
-                case 'invalid-domain':
-                case 'invalid-webfinger':
-                    return new Response(
-                        JSON.stringify({ code: accountError.type }),
-                        {
-                            headers: {
-                                'Content-Type': 'application/json',
-                            },
-                            status: 400,
-                        },
-                    );
-                case 'conflict':
-                    return new Response(
-                        JSON.stringify({ code: accountError.type }),
-                        {
-                            headers: {
-                                'Content-Type': 'application/json',
-                            },
-                            status: 409,
-                        },
-                    );
-                case 'not-reachable':
-                case 'wrong-actor':
-                    return new Response(
-                        JSON.stringify({ code: accountError.type }),
-                        {
-                            headers: {
-                                'Content-Type': 'application/json',
-                            },
-                            status: 422,
-                        },
-                    );
-                default:
-                    return exhaustiveCheck(accountError);
-            }
+            return this.domainErrorResponse(getError(result));
         }
 
         return new Response(
@@ -537,6 +545,68 @@ export class AccountController {
                 },
                 status: 200,
             },
+        );
+    }
+
+    @APIRoute('POST', 'domain/validate')
+    @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
+    async handleValidateAccountDomain(ctx: AppContext) {
+        const account = await this.accountService.getAccountForSite(
+            ctx.get('site'),
+        );
+
+        if (!account) {
+            return new Response(null, { status: 404 });
+        }
+
+        let data: z.infer<typeof UpdateDomainSchema>;
+
+        try {
+            data = UpdateDomainSchema.parse((await ctx.req.json()) as unknown);
+        } catch (_err) {
+            return new Response(null, { status: 400 });
+        }
+
+        if (data.domain === null) {
+            return new Response(
+                JSON.stringify(this.accountDomainResponse(account)),
+                {
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    status: 200,
+                },
+            );
+        }
+
+        const normalizedHost = normalizeWebfingerHost(data.domain);
+
+        if (!normalizedHost) {
+            return this.domainErrorResponse({
+                type: 'invalid-domain',
+                host: data.domain,
+            });
+        }
+
+        const fallbackHost = account.apId.host.replace(/^www\./, '');
+
+        if (normalizedHost === fallbackHost) {
+            return this.jsonResponse(
+                this.accountDomainPreviewResponse(account, null),
+            );
+        }
+
+        const result = await this.accountService.validateWebfingerHost(
+            account,
+            normalizedHost,
+        );
+
+        if (isError(result)) {
+            return this.domainErrorResponse(getError(result));
+        }
+
+        return this.jsonResponse(
+            this.accountDomainPreviewResponse(account, normalizedHost),
         );
     }
 

--- a/src/http/api/account.controller.ts
+++ b/src/http/api/account.controller.ts
@@ -16,6 +16,12 @@ import type { AppContext } from '@/app';
 import { exhaustiveCheck, getError, getValue, isError } from '@/core/result';
 import { isHandle } from '@/helpers/activitypub/actor';
 import { requireParam } from '@/http/api/helpers/request';
+import {
+    BadRequest,
+    Conflict,
+    Ok,
+    UnprocessableEntity,
+} from '@/http/api/helpers/response';
 import type { AccountDTO } from '@/http/api/types';
 import type {
     AccountFollows,
@@ -111,25 +117,27 @@ export class AccountController {
         };
     }
 
-    private jsonResponse(body: unknown, status = 200) {
-        return new Response(JSON.stringify(body), {
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            status,
-        });
-    }
-
     private domainErrorResponse(accountError: WebfingerHostError) {
         switch (accountError.type) {
             case 'invalid-domain':
+                return BadRequest('Invalid domain', accountError.type);
             case 'invalid-webfinger':
-                return this.jsonResponse({ code: accountError.type }, 400);
+                return BadRequest(
+                    'Could not resolve domain via WebFinger',
+                    accountError.type,
+                );
             case 'conflict':
-                return this.jsonResponse({ code: accountError.type }, 409);
+                return Conflict('Domain is already in use', accountError.type);
             case 'not-reachable':
+                return UnprocessableEntity(
+                    'Domain is not reachable',
+                    accountError.type,
+                );
             case 'wrong-actor':
-                return this.jsonResponse({ code: accountError.type }, 422);
+                return UnprocessableEntity(
+                    'Domain does not resolve to this account',
+                    accountError.type,
+                );
             default:
                 return exhaustiveCheck(accountError);
         }
@@ -568,7 +576,7 @@ export class AccountController {
         }
 
         if (data.domain === null) {
-            return this.jsonResponse(this.accountDomainResponse(account));
+            return Ok(this.accountDomainResponse(account));
         }
 
         const normalizedHost = normalizeWebfingerHost(data.domain);
@@ -584,9 +592,7 @@ export class AccountController {
             normalizeWebfingerHost(account.apId.host) ?? account.apId.host;
 
         if (normalizedHost === fallbackHost) {
-            return this.jsonResponse(
-                this.accountDomainPreviewResponse(account, null),
-            );
+            return Ok(this.accountDomainPreviewResponse(account, null));
         }
 
         const result = await this.accountService.validateWebfingerHost(
@@ -598,9 +604,7 @@ export class AccountController {
             return this.domainErrorResponse(getError(result));
         }
 
-        return this.jsonResponse(
-            this.accountDomainPreviewResponse(account, normalizedHost),
-        );
+        return Ok(this.accountDomainPreviewResponse(account, normalizedHost));
     }
 
     @APIRoute('POST', 'aliases')

--- a/src/http/api/account.controller.ts
+++ b/src/http/api/account.controller.ts
@@ -19,7 +19,7 @@ import { requireParam } from '@/http/api/helpers/request';
 import {
     BadRequest,
     Conflict,
-    Ok,
+    ok,
     UnprocessableEntity,
 } from '@/http/api/helpers/response';
 import type { AccountDTO } from '@/http/api/types';
@@ -110,7 +110,7 @@ export class AccountController {
         return {
             domain: webfingerHost,
             handle: getAccountHandle(
-                webfingerHost || account.apId.host,
+                webfingerHost || getAccountHandleHost(account),
                 account.username,
             ),
             actorUrl: account.apId.href,
@@ -576,7 +576,7 @@ export class AccountController {
         }
 
         if (data.domain === null) {
-            return Ok(this.accountDomainResponse(account));
+            return ok(this.accountDomainResponse(account));
         }
 
         const normalizedHost = normalizeWebfingerHost(data.domain);
@@ -592,7 +592,7 @@ export class AccountController {
             normalizeWebfingerHost(account.apId.host) ?? account.apId.host;
 
         if (normalizedHost === fallbackHost) {
-            return Ok(this.accountDomainPreviewResponse(account, null));
+            return ok(this.accountDomainPreviewResponse(account, null));
         }
 
         const result = await this.accountService.validateWebfingerHost(
@@ -604,7 +604,7 @@ export class AccountController {
             return this.domainErrorResponse(getError(result));
         }
 
-        return Ok(this.accountDomainPreviewResponse(account, normalizedHost));
+        return ok(this.accountDomainPreviewResponse(account, normalizedHost));
     }
 
     @APIRoute('POST', 'aliases')

--- a/src/http/api/account.controller.unit.test.ts
+++ b/src/http/api/account.controller.unit.test.ts
@@ -64,6 +64,7 @@ describe('AccountController aliases', () => {
             addAlias: vi.fn(),
             removeAlias: vi.fn(),
             setWebfingerHost: vi.fn(),
+            validateWebfingerHost: vi.fn(),
         } as unknown as AccountService;
         controller = new AccountController(
             {} as AccountView,
@@ -108,6 +109,11 @@ describe('AccountController aliases', () => {
                     path: '/.ghost/activitypub/:version/domain',
                     methodName: 'handleUpdateAccountDomain',
                 }),
+                expect.objectContaining({
+                    method: 'POST',
+                    path: '/.ghost/activitypub/:version/domain/validate',
+                    methodName: 'handleValidateAccountDomain',
+                }),
             ]),
         );
 
@@ -117,6 +123,7 @@ describe('AccountController aliases', () => {
             'handleRemoveAccountAlias',
             'handleGetAccountDomain',
             'handleUpdateAccountDomain',
+            'handleValidateAccountDomain',
         ]) {
             expect(
                 Reflect.getMetadata(
@@ -327,6 +334,72 @@ describe('AccountController aliases', () => {
 
         expect(response.status).toBe(400);
         expect(await response.json()).toEqual({ code: 'invalid-domain' });
+    });
+
+    it('validates an account domain without saving it', async () => {
+        vi.mocked(accountService.validateWebfingerHost).mockResolvedValue(
+            ok(true),
+        );
+
+        const response = await controller.handleValidateAccountDomain(
+            createContext({ domain: 'WWW.Site.COM' }),
+        );
+
+        expect(response.status).toBe(200);
+        expect(accountService.validateWebfingerHost).toHaveBeenCalledWith(
+            account,
+            'site.com',
+        );
+        expect(accountService.setWebfingerHost).not.toHaveBeenCalled();
+        expect(await response.json()).toEqual({
+            domain: 'site.com',
+            handle: '@index@site.com',
+            actorUrl: 'https://example.com/.ghost/activitypub/users/index',
+        });
+    });
+
+    it('returns default domain state when validating the fallback account host', async () => {
+        const response = await controller.handleValidateAccountDomain(
+            createContext({ domain: 'example.com' }),
+        );
+
+        expect(response.status).toBe(200);
+        expect(accountService.validateWebfingerHost).not.toHaveBeenCalled();
+        expect(accountService.setWebfingerHost).not.toHaveBeenCalled();
+        expect(await response.json()).toEqual({
+            domain: null,
+            handle: '@index@example.com',
+            actorUrl: 'https://example.com/.ghost/activitypub/users/index',
+        });
+    });
+
+    it('returns bad request when validating an invalid account domain', async () => {
+        const response = await controller.handleValidateAccountDomain(
+            createContext({ domain: 'https://site.com' }),
+        );
+
+        expect(response.status).toBe(400);
+        expect(accountService.validateWebfingerHost).not.toHaveBeenCalled();
+        expect(await response.json()).toEqual({ code: 'invalid-domain' });
+    });
+
+    it('maps account domain validation errors to their status codes', async () => {
+        vi.mocked(accountService.validateWebfingerHost).mockResolvedValue(
+            error({
+                type: 'wrong-actor',
+                host: 'site.com',
+                expectedActorUrl:
+                    'https://example.com/.ghost/activitypub/users/index',
+                actualActorUrl: 'https://site.com/users/index',
+            }),
+        );
+
+        const response = await controller.handleValidateAccountDomain(
+            createContext({ domain: 'site.com' }),
+        );
+
+        expect(response.status).toBe(422);
+        expect(await response.json()).toEqual({ code: 'wrong-actor' });
     });
 
     it('adds an alias and returns the updated alias list', async () => {

--- a/src/http/api/account.controller.unit.test.ts
+++ b/src/http/api/account.controller.unit.test.ts
@@ -373,6 +373,21 @@ describe('AccountController aliases', () => {
         });
     });
 
+    it('returns the current domain state when validating a null account domain', async () => {
+        const response = await controller.handleValidateAccountDomain(
+            createContext({ domain: null }),
+        );
+
+        expect(response.status).toBe(200);
+        expect(accountService.validateWebfingerHost).not.toHaveBeenCalled();
+        expect(accountService.setWebfingerHost).not.toHaveBeenCalled();
+        expect(await response.json()).toEqual({
+            domain: null,
+            handle: '@index@example.com',
+            actorUrl: 'https://example.com/.ghost/activitypub/users/index',
+        });
+    });
+
     it('returns bad request when validating an invalid account domain', async () => {
         const response = await controller.handleValidateAccountDomain(
             createContext({ domain: 'https://site.com' }),

--- a/src/http/api/account.controller.unit.test.ts
+++ b/src/http/api/account.controller.unit.test.ts
@@ -320,7 +320,10 @@ describe('AccountController aliases', () => {
         );
 
         expect(response.status).toBe(409);
-        expect(await response.json()).toEqual({ code: 'conflict' });
+        expect(await response.json()).toEqual({
+            message: 'Domain is already in use',
+            code: 'conflict',
+        });
     });
 
     it('returns bad request when an account domain is invalid', async () => {
@@ -333,7 +336,10 @@ describe('AccountController aliases', () => {
         );
 
         expect(response.status).toBe(400);
-        expect(await response.json()).toEqual({ code: 'invalid-domain' });
+        expect(await response.json()).toEqual({
+            message: 'Invalid domain',
+            code: 'invalid-domain',
+        });
     });
 
     it('validates an account domain without saving it', async () => {
@@ -395,7 +401,10 @@ describe('AccountController aliases', () => {
 
         expect(response.status).toBe(400);
         expect(accountService.validateWebfingerHost).not.toHaveBeenCalled();
-        expect(await response.json()).toEqual({ code: 'invalid-domain' });
+        expect(await response.json()).toEqual({
+            message: 'Invalid domain',
+            code: 'invalid-domain',
+        });
     });
 
     it('maps account domain validation errors to their status codes', async () => {
@@ -414,7 +423,10 @@ describe('AccountController aliases', () => {
         );
 
         expect(response.status).toBe(422);
-        expect(await response.json()).toEqual({ code: 'wrong-actor' });
+        expect(await response.json()).toEqual({
+            message: 'Domain does not resolve to this account',
+            code: 'wrong-actor',
+        });
     });
 
     it('adds an alias and returns the updated alias list', async () => {

--- a/src/http/api/helpers/response.ts
+++ b/src/http/api/helpers/response.ts
@@ -1,5 +1,7 @@
-function jsonResponse(message: string, status: number) {
-    const body = message ? JSON.stringify({ message }) : null;
+function jsonResponse(message: string, status: number, code?: string) {
+    const body = message
+        ? JSON.stringify({ message, ...(code ? { code } : {}) })
+        : null;
 
     return new Response(body, {
         headers: {
@@ -9,9 +11,23 @@ function jsonResponse(message: string, status: number) {
     });
 }
 
-export const BadRequest = (message: string) => jsonResponse(message, 400);
-export const Forbidden = (message: string) => jsonResponse(message, 403);
-export const NotFound = (message: string) => jsonResponse(message, 404);
-export const Conflict = (message: string) => jsonResponse(message, 409);
-export const InternalServerError = (message: string) =>
-    jsonResponse(message, 500);
+export const Ok = (body: unknown) =>
+    new Response(JSON.stringify(body), {
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        status: 200,
+    });
+
+export const BadRequest = (message: string, code?: string) =>
+    jsonResponse(message, 400, code);
+export const Forbidden = (message: string, code?: string) =>
+    jsonResponse(message, 403, code);
+export const NotFound = (message: string, code?: string) =>
+    jsonResponse(message, 404, code);
+export const Conflict = (message: string, code?: string) =>
+    jsonResponse(message, 409, code);
+export const UnprocessableEntity = (message: string, code?: string) =>
+    jsonResponse(message, 422, code);
+export const InternalServerError = (message: string, code?: string) =>
+    jsonResponse(message, 500, code);

--- a/src/http/api/helpers/response.ts
+++ b/src/http/api/helpers/response.ts
@@ -11,7 +11,7 @@ function jsonResponse(message: string, status: number, code?: string) {
     });
 }
 
-export const Ok = (body: unknown) =>
+export const ok = (body: unknown) =>
     new Response(JSON.stringify(body), {
         headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary

This PR adds a validate-only API path for custom Social Web domain setup.

The admin UI needs to let a user enter a custom Social Web domain, show the required WebFinger redirect instructions, validate that the redirect resolves to the current actor, and only persist the domain after the user explicitly clicks Save. The existing `PUT /v1/domain` endpoint validates and persists in one operation, which made it unsuitable for a two-step Validate/Save UI because clicking Validate would already activate the domain.

## What changed

- Added `POST /v1/domain/validate` for Owner/Administrator requests.
- Reused the existing `AccountService.validateWebfingerHost()` logic so validation behavior stays consistent with the save path.
- Kept `PUT /v1/domain` as the persistence endpoint for saving or clearing the custom WebFinger host.
- Extracted shared domain error response handling so validation and persistence return the same status/code shape for invalid domains, conflicts, unreachable WebFinger responses, invalid WebFinger payloads, and wrong-actor responses.

## Decisions

- The new endpoint does not mutate account state. It only confirms whether the submitted domain can be used.
- `domain: null` on the validation endpoint returns the current domain response rather than clearing anything. Clearing remains the responsibility of `PUT /v1/domain`.
- The validation response mirrors the domain response shape used by the admin client: `domain`, `handle`, and `actorUrl`.
- The existing persistence endpoint still performs validation before saving, so callers cannot bypass validation by calling Save directly.

## Validation

- Ran `yarn test:types` in `TryGhost/ActivityPub`.
- Ran `yarn lint` in `TryGhost/ActivityPub`; it completed with existing optional-chain warnings only.
