### PR TITLE
Expand README testing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,16 @@ To enable auto-formatting on save, you'll need to set the [default formatter](ht
 
 ## Running Tests
 
-- Run `yarn test` to execute tests within a Docker Compose stack.
+Tests run within a Docker Compose stack. Common commands:
+
+- `yarn test` — run everything (types, unit, integration, and e2e); slow
+- `yarn test:unit` — unit tests only; fast
+- `yarn test:integration` — integration tests only
+- `yarn test:cucumber` — end-to-end (Cucumber) tests
+- `yarn test:single 'path/to/test'` — run a single unit or integration test
+- `yarn test:types` — type-check with `tsc`
+
+See [AGENTS.md](AGENTS.md) for the full list and testing conventions.
 
 ## Migrations
 


### PR DESCRIPTION
## What changed

**Expanded the "Running Tests" section** from a single `yarn test` line into the granular commands developers actually reach for (`test:unit`, `test:integration`, `test:cucumber`, `test:single`, `test:types`), with a link to `AGENTS.md` for the full list.

## Why

The README only documented `yarn test` (run everything, slow). Surfacing the faster, more targeted commands makes the common dev loop discoverable without digging into `package.json` or `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)