### PR TITLE
Fixed WebFinger subject dropping www from the account host

### DIFF
--- a/src/http/api/webfinger.controller.ts
+++ b/src/http/api/webfinger.controller.ts
@@ -2,7 +2,7 @@ import type { Context as HonoContext, Next } from 'hono';
 
 import type { Account } from '@/account/account.entity';
 import type { KnexAccountRepository } from '@/account/account.repository.knex';
-import { getAccountHandleHost, normalizeWebfingerHost } from '@/account/utils';
+import { normalizeWebfingerHost } from '@/account/utils';
 import { Route } from '@/http/decorators/route.decorator';
 import type { SiteService } from '@/site/site.service';
 
@@ -61,7 +61,10 @@ export class WebFingerController {
             );
 
         if (customDomainAccount) {
-            return this.createWebfingerResponse(customDomainAccount);
+            return this.createWebfingerResponse(
+                customDomainAccount,
+                this.getSubjectHost(customDomainAccount, resourceHost),
+            );
         }
 
         const site =
@@ -82,7 +85,10 @@ export class WebFingerController {
                 });
             }
 
-            return this.createWebfingerResponse(account);
+            return this.createWebfingerResponse(
+                account,
+                this.getSubjectHost(account, resourceHost),
+            );
         }
 
         const requestHost = ctx.req.header('host')?.split(':')[0];
@@ -137,10 +143,29 @@ export class WebFingerController {
         }
     }
 
-    private createWebfingerResponse(
-        account: Account,
-        subjectHost = getAccountHandleHost(account).replace(/^www\./, ''),
-    ) {
+    /**
+     * Resolve the host to use in the webfinger subject
+     *
+     * The subject host is only canonicalized to the non-www version of the
+     * account host when the resource was queried via the non-www host — the
+     * www version of a host cannot be unconditionally canonicalized to the
+     * non-www version because the non-www version may be served by an
+     * unrelated service (i.e another Fediverse server), in which case clients
+     * verifying the subject would be directed to the wrong server
+     */
+    private getSubjectHost(account: Account, resourceHost: string) {
+        if (account.webfingerHost) {
+            return account.webfingerHost;
+        }
+
+        if (resourceHost.toLowerCase() === account.apId.host) {
+            return account.apId.host;
+        }
+
+        return account.apId.host.replace(/^www\./, '');
+    }
+
+    private createWebfingerResponse(account: Account, subjectHost: string) {
         const webfingerData = {
             subject: `acct:${account.username}@${subjectHost}`,
             aliases: [account.apId.toString()],

--- a/src/http/api/webfinger.unit.test.ts
+++ b/src/http/api/webfinger.unit.test.ts
@@ -401,7 +401,7 @@ describe('handleWebFinger', () => {
         expect(response?.status).toBe(200);
     });
 
-    it('should ensure the www is not included in the subject', async () => {
+    it('should keep the www in the subject when the resource was queried via the www host', async () => {
         const ctx = getCtx({ resource: 'acct:alice@www.example.com' });
         const next = vi.fn();
 
@@ -426,7 +426,7 @@ describe('handleWebFinger', () => {
 
         expect(response?.status).toBe(200);
         expect(await response?.json()).toEqual({
-            subject: 'acct:alice@example.com',
+            subject: 'acct:alice@www.example.com',
             aliases: ['https://www.example.com/users/alice'],
             links: [
                 {
@@ -443,5 +443,35 @@ describe('handleWebFinger', () => {
         expect(response?.headers.get('Content-Type')).toBe(
             'application/jrd+json',
         );
+    });
+
+    it('should not include the www in the subject when the site is hosted on the non-www host', async () => {
+        const ctx = getCtx({ resource: 'acct:alice@www.example.com' });
+        const next = vi.fn();
+
+        vi.mocked(siteService.getSiteByHost).mockImplementation((host) => {
+            if (host === 'example.com') {
+                return Promise.resolve({
+                    host: 'example.com',
+                } as Site);
+            }
+
+            return Promise.resolve(null);
+        });
+
+        vi.mocked(accountRepository.getBySite).mockResolvedValue({
+            username: 'alice',
+            url: 'https://example.com',
+            apId: new URL('https://example.com/users/alice'),
+            webfingerHost: null,
+        } as unknown as Account);
+
+        const response = await webFingerController.handleWebFinger(ctx, next);
+
+        expect(response?.status).toBe(200);
+        expect(await response?.json()).toMatchObject({
+            subject: 'acct:alice@example.com',
+            aliases: ['https://example.com/users/alice'],
+        });
     });
 });


### PR DESCRIPTION
closes https://github.com/TryGhost/ActivityPub/issues/1715

## The problem

The WebFinger subject unconditionally stripped the `www.` prefix from the account host, so a site living at `www.r3pek.org` returned `acct:index@r3pek.org` as its subject — asserting a handle on a domain the server may not control (all other fields in the response correctly used `www.`).

Fediverse clients treat a subject that differs from the queried resource as a redirect and re-verify it against the subject's domain. Mastodon does this both for handle searches and for actor verification (`verified_webfinger?` queries `acct:<username>@<actor-id-host>`). When the non-www domain is served by an unrelated service — in the reporter's case, a Mastodon instance on the apex — that verification is directed at the wrong server, so both handle-based lookups and inbound actor resolution (follows, etc.) fail.

## The fix

The subject host is now only canonicalized to the non-www version of the account host when the resource was actually queried via the non-www form — a client reaching us with the non-www resource proves that form routes WebFinger to this service (e.g. via an apex → www redirect), and since the subject then matches the queried resource, no re-verification hop occurs. When the resource is queried via the account's actual `www.` host, that host is echoed back instead of being rewritten to a domain we may not own.

Behavior is unchanged for:

- sites whose non-www domain redirects WebFinger to the site (queries via the non-www handle still return the non-www subject)
- accounts with an explicitly configured alternate WebFinger host, which still takes precedence in the subject since delegation is verified when it is set
- the alternate-domain validation flow, which continues to echo the candidate host