### PR TITLE
Fixed KnexKvStore returning null for missing keys

### DIFF
--- a/src/knex.kvstore.integration.test.ts
+++ b/src/knex.kvstore.integration.test.ts
@@ -18,10 +18,11 @@ describe('KnexKvStore', () => {
         const store = KnexKvStore.create(client, table, logger);
 
         // checkReadingUnsetKey
+        // Fedify's KvStore contract requires undefined (not null) for missing
+        // keys - null means a stored negative entry (see checkNullValue)
         {
             const actual = await store.get(['unsetkey']);
-            const expected = null;
-            expect(actual).toEqual(expected);
+            expect(actual).toBeUndefined();
         }
 
         // checkReadingSetKey
@@ -46,8 +47,15 @@ describe('KnexKvStore', () => {
             await store.set(['deleted'], { initial: 'value' });
             await store.delete(['deleted']);
             const actual = await store.get(['deleted']);
-            const expected = null;
-            expect(actual).toEqual(expected);
+            expect(actual).toBeUndefined();
+        }
+
+        // checkNullValue - Fedify's KvKeyCache stores null to mark a key
+        // lookup as failed, and must read it back as null (not undefined)
+        {
+            await store.set(['nullvalue'], null);
+            const actual = await store.get(['nullvalue']);
+            expect(actual).toBeNull();
         }
     });
 
@@ -131,7 +139,7 @@ describe('KnexKvStore', () => {
 
         const result = await store.get(['expired-key']);
 
-        expect(result).toBeNull();
+        expect(result).toBeUndefined();
     });
 
     it('Deletes expired entries from the database on read', async () => {

--- a/src/knex.kvstore.ts
+++ b/src/knex.kvstore.ts
@@ -58,7 +58,12 @@ export class KnexKvStore implements KvStore {
                 `KnexKvStore: Deleting expired key ${key}`,
                 keyInfo,
             );
-            await this.knex(this.table).where(query).del();
+            // Only delete if still expired - a concurrent set() may have
+            // refreshed the row between our read and this delete
+            await this.knex(this.table)
+                .where(query)
+                .where('expires', '<=', new Date())
+                .del();
             return undefined;
         }
         if (row.value === null) {

--- a/src/knex.kvstore.ts
+++ b/src/knex.kvstore.ts
@@ -53,7 +53,8 @@ export class KnexKvStore implements KvStore {
         if (!row) {
             return undefined;
         }
-        if (row.expires !== null && row.expires <= new Date()) {
+        const now = new Date();
+        if (row.expires !== null && row.expires <= now) {
             this.logging.debug(
                 `KnexKvStore: Deleting expired key ${key}`,
                 keyInfo,
@@ -62,7 +63,7 @@ export class KnexKvStore implements KvStore {
             // refreshed the row between our read and this delete
             await this.knex(this.table)
                 .where(query)
-                .where('expires', '<=', new Date())
+                .where('expires', '<=', now)
                 .del();
             return undefined;
         }

--- a/src/knex.kvstore.ts
+++ b/src/knex.kvstore.ts
@@ -46,8 +46,12 @@ export class KnexKvStore implements KvStore {
             key: this.keyToString(key),
         };
         const row = await this.knex(this.table).where(query).first();
+        // Fedify distinguishes a missing key (undefined) from a stored null:
+        // its KvKeyCache treats null as a cached "key is unavailable" marker
+        // and skips fetching the key entirely, so returning null for missing
+        // keys breaks HTTP signature verification for never-seen senders.
         if (!row) {
-            return null;
+            return undefined;
         }
         if (row.expires !== null && row.expires <= new Date()) {
             this.logging.debug(
@@ -55,6 +59,9 @@ export class KnexKvStore implements KvStore {
                 keyInfo,
             );
             await this.knex(this.table).where(query).del();
+            return undefined;
+        }
+        if (row.value === null) {
             return null;
         }
         if (Object.hasOwn(row.value, '@@BOOLEAN@@')) {


### PR DESCRIPTION
## Summary

Fixes #1961 — follows between self-hosted instances failing with `401 Failed to verify the request signature`.

`KnexKvStore.get()` returned `null` for missing keys, but Fedify's `KvStore` contract requires `undefined` when a key does not exist — `null` is a legitimate stored value. Since Fedify introduced persistent negative key caching (v2.1+), its `KvKeyCache` strictly distinguishes the two:

- `undefined` → cache miss → fetch the sender's key and verify
- `null` → "this key is known to be unavailable" → **skip fetching for 10 minutes**

Because our MySQL-backed store reported every missing key as `null`, every signing key that had never been cached was treated as a cached negative entry, so Fedify never fetched the sender's key and inbound HTTP signature verification failed with 401 for any new peer. This matches the reporter's logs exactly — on a freshly truncated `key_value` table, Fedify logs `Entry ... found in cache, but it is unavailable`, which is only possible if the store misreports misses as negatives:

```
DBG fedify·sig·key: Entry '...#main-key' found in cache, but it is unavailable.
DBG fedify·sig·key: Entry '...#main-key' found in cache, but no fetch failure details are available.
DBG fedify·sig·http: Failed to fetch key: '...'
WRN fedify·federation·http: 'POST' '/.ghost/activitypub/inbox/index': 401
```

("no fetch failure details are available" because there never was a fetch.)

### Verification

Running Fedify's actual `KvKeyCache` against both store behaviours:

```
old KnexKvStore (missing -> null):      treated as cached NEGATIVE -> Fedify never fetches, verification 401s
fixed KnexKvStore (missing -> undefined): cache MISS -> Fedify fetches the key (correct)
```

### Also fixed

Reading back a stored JSON `null` (Fedify persists `null` to mark failed key lookups, with a TTL) previously threw `TypeError` in `Object.hasOwn(row.value, ...)`. It now correctly round-trips as `null`.
