### PR TITLE
Preserved site identity when a Ghost site changes URL

### DIFF
--- a/docs/site-registration.md
+++ b/docs/site-registration.md
@@ -11,9 +11,11 @@ the ActivityPub service
    - If exists, returns existing site (idempotent)
    - If not, proceeds to create new site
 3. Service fetches site settings from Ghost to get `ghost_uuid` (called `site_uuid` in Ghost)
-4. Service handles `ghost_uuid` uniqueness (see below)
+4. Service handles `ghost_uuid` uniqueness (see below) — this can resolve
+   to moving an existing site to the new host instead of creating a new one
 5. Service creates new site record with the `ghost_uuid`
-6. Service creates internal account for the site
+6. Service creates internal account for the site (unless the site already
+   has one, e.g. after a move)
 
 ## Duplicate ghost_uuid Handling
 
@@ -25,19 +27,29 @@ fetching `/ghost/api/admin/site/` on the previous host:
 | Previous host response                                                 | Classification | Outcome                                |
 | ---------------------------------------------------------------------- | -------------- | -------------------------------------- |
 | 200 with the same `site_uuid` and a matching canonical `url`           | `still-claims` | Refuse the reassignment                |
-| 200 with the same `site_uuid` but a different canonical `url` (alias)  | `released`     | Allow reassignment                     |
-| 200 with a different / missing `site_uuid`                             | `released`     | Allow reassignment                     |
-| 200 with non-JSON body                                                 | `released`     | Allow reassignment                     |
-| 3xx / 4xx                                                              | `released`     | Allow reassignment                     |
-| DNS NXDOMAIN (ENOTFOUND)                                               | `released`     | Allow reassignment                     |
-| Connection refused (ECONNREFUSED)                                      | `released`     | Allow reassignment                     |
-| Transient DNS failure (EAI_AGAIN)                                      | `unverifiable` | Allow reassignment (fail-open), logged |
-| 5xx / timeout / other transport error                                  | `unverifiable` | Allow reassignment (fail-open), logged |
+| 200 with the same `site_uuid` but a different canonical `url` (alias)  | `released`     | New site takes the UUID                |
+| 200 with a different / missing `site_uuid`                             | `released`     | Move the existing site to the new host |
+| 200 with non-JSON body                                                 | `released`     | Move the existing site to the new host |
+| 3xx / 4xx                                                              | `released`     | Move the existing site to the new host |
+| DNS NXDOMAIN (ENOTFOUND)                                               | `released`     | Move the existing site to the new host |
+| Connection refused (ECONNREFUSED)                                      | `released`     | Move the existing site to the new host |
+| Transient DNS failure (EAI_AGAIN)                                      | `unverifiable` | New site takes the UUID (fail-open), logged |
+| 5xx / timeout / other transport error                                  | `unverifiable` | New site takes the UUID (fail-open), logged |
 
-When the reassignment proceeds (whether `released` or `unverifiable`),
-the previous row's `ghost_uuid` is set to `null` and the new row takes
-the UUID. The previous row's account data stays intact; only the UUID
-claim is released.
+There are two ways a conflict can resolve in the new host's favour:
+
+- **Move the existing site to the new host.** When the previous host no
+  longer serves the install at all (DNS gone, connection refused, not a
+  Ghost site anymore, or serving a different `site_uuid`), the install's
+  URL has changed. The existing site row is updated to the new host,
+  keeping its id, `webhook_secret`, `ghost_uuid` and — crucially — its
+  account (followers, posts, keys). Actor URLs are not rewritten;
+  changing the federated identity is a separate actor migration concern.
+- **New site takes the UUID.** When the previous host still serves the
+  install (aliased hosts, below) or the outcome is unverifiable, the new
+  host registers as its own site: the previous row's `ghost_uuid` is set
+  to `null` and the new row takes the UUID. The previous row's account
+  data stays intact; only the UUID claim is released.
 
 ### Aliased hosts
 

--- a/src/site/site.service.integration.test.ts
+++ b/src/site/site.service.integration.test.ts
@@ -200,7 +200,7 @@ describe('SiteService', () => {
         expect(account.name).toBe('Default Title');
     });
 
-    it('Handles duplicate ghost_uuid when a site changes domains', async () => {
+    it('Moves the site to the new host when the old host no longer serves its ghost_uuid', async () => {
         const ghostUUID = 'some-ghost-uuid';
 
         ghostService.getSiteSettings = vi.fn().mockResolvedValue({
@@ -212,6 +212,11 @@ describe('SiteService', () => {
                 site_uuid: ghostUUID,
             },
         });
+
+        const createInternalAccount = vi.spyOn(
+            accountService,
+            'createInternalAccount',
+        );
 
         const siteA = await service.initialiseSiteForHost('domain-a.tld');
 
@@ -247,22 +252,26 @@ describe('SiteService', () => {
 
         const siteB = await service.initialiseSiteForHost('domain-b.tld');
 
+        // The existing site moves to the new host, keeping its identity
+        expect(siteB.id).toBe(siteA.id);
         expect(siteB.host).toBe('domain-b.tld');
         expect(siteB.ghost_uuid).toBe(ghostUUID);
+        expect(siteB.webhook_secret).toBe(siteA.webhook_secret);
 
-        // Verify both sites exist
-        const allSites = await db('sites').select('*').orderBy('id', 'asc');
-        expect(allSites).toHaveLength(2);
+        const allSites = await db('sites').select('*');
+        expect(allSites).toHaveLength(1);
+        expect(allSites[0].host).toBe('domain-b.tld');
+        expect(allSites[0].ghost_uuid).toBe(ghostUUID);
 
-        // Verify old site has null ghost_uuid
-        const oldSite = allSites.find((s) => s.host === 'domain-a.tld');
-        expect(oldSite).toBeDefined();
-        expect(oldSite?.ghost_uuid).toBeNull();
+        // The existing account is preserved - no new account is created
+        expect(createInternalAccount.mock.calls).toHaveLength(1);
 
-        // Verify new site has the ghost_uuid
-        const newSite = allSites.find((s) => s.host === 'domain-b.tld');
-        expect(newSite).toBeDefined();
-        expect(newSite?.ghost_uuid).toBe(ghostUUID);
+        const accounts = await db('accounts')
+            .join('users', 'accounts.id', 'users.account_id')
+            .where('users.site_id', siteA.id)
+            .select('accounts.*');
+        expect(accounts).toHaveLength(1);
+        expect(accounts[0].name).toBe('Site A title');
     });
 
     it('Rejects ghost_uuid reassignment when the existing host still claims it', async () => {
@@ -327,7 +336,7 @@ describe('SiteService', () => {
         expect(siteBRow).toBeUndefined();
     });
 
-    it('Allows ghost_uuid reassignment when the old host is unreachable', async () => {
+    it('Moves the site to the new host when the old host is unreachable', async () => {
         const ghostUUID = 'migrating-ghost-uuid';
 
         ghostService.getSiteSettings = vi.fn().mockResolvedValue({
@@ -340,7 +349,8 @@ describe('SiteService', () => {
             },
         });
 
-        await service.initialiseSiteForHost('old-domain.tld');
+        const originalSite =
+            await service.initialiseSiteForHost('old-domain.tld');
 
         // Old host is unreachable (domain decommissioned)
         ghostService.getSiteSettings = vi
@@ -367,14 +377,20 @@ describe('SiteService', () => {
 
         const newSite = await service.initialiseSiteForHost('new-domain.tld');
 
+        // The existing site moves to the new host, keeping its identity
+        expect(newSite.id).toBe(originalSite.id);
+        expect(newSite.host).toBe('new-domain.tld');
         expect(newSite.ghost_uuid).toBe(ghostUUID);
+        expect(newSite.webhook_secret).toBe(originalSite.webhook_secret);
 
-        // Old site's ghost_uuid should be nullified
+        const allSites = await db('sites').select('*');
+        expect(allSites).toHaveLength(1);
+        expect(allSites[0].host).toBe('new-domain.tld');
+
         const oldRow = await db('sites')
             .where({ host: 'old-domain.tld' })
             .first();
-
-        expect(oldRow.ghost_uuid).toBeNull();
+        expect(oldRow).toBeUndefined();
     });
 
     it('Allows ghost_uuid reassignment when the old host returns a transient 5xx (fail-open)', async () => {

--- a/src/site/site.service.ts
+++ b/src/site/site.service.ts
@@ -46,16 +46,26 @@ export class SiteService {
 
         if (ghostUuid !== null) {
             const currentOwner = await this.client('sites')
-                .select('host')
+                .select('id', 'host', 'webhook_secret')
                 .where({ ghost_uuid: ghostUuid })
                 .first();
 
             if (currentOwner) {
-                await this.verifyUUIDReleased(
+                const resolution = await this.resolveUuidConflict(
                     currentOwner.host,
                     host,
                     ghostUuid,
                 );
+
+                if (resolution === 'move-site') {
+                    return await this.moveSiteToHost(
+                        currentOwner.id,
+                        host,
+                        isGhostPro,
+                        currentOwner.webhook_secret,
+                        ghostUuid,
+                    );
+                }
 
                 verifiedOwnerHost = currentOwner.host;
             }
@@ -128,13 +138,13 @@ export class SiteService {
             site = existingSite;
         }
 
+        // The site can already have an account even when the host lookup
+        // missed: createSite may have moved an existing site to this host
         const existingAccount =
-            (existingSite &&
-                (await this.client('accounts')
-                    .join('users', 'accounts.id', 'users.account_id')
-                    .where('users.site_id', site.id)
-                    .first())) ||
-            null;
+            (await this.client('accounts')
+                .join('users', 'accounts.id', 'users.account_id')
+                .where('users.site_id', site.id)
+                .first()) || null;
 
         if (existingAccount === null) {
             settings ??= await this.getSiteSettings(host);
@@ -162,11 +172,24 @@ export class SiteService {
         return result === 1;
     }
 
-    private async verifyUUIDReleased(
+    /**
+     * Decide what to do when a new host registers with a `ghost_uuid`
+     * that already belongs to an existing site.
+     *
+     * - `move-site`: the previous host no longer serves the install, so
+     *   this is the same site whose URL changed. The existing site row
+     *   (and with it the account, followers and webhook secret) moves to
+     *   the new host.
+     * - `release-uuid`: the new host registers as its own site and takes
+     *   the UUID from the previous row.
+     *
+     * See docs/site-registration.md for the full decision table.
+     */
+    private async resolveUuidConflict(
         previousHost: string,
         newHost: string,
         ghostUuid: string,
-    ): Promise<void> {
+    ): Promise<'move-site' | 'release-uuid'> {
         const result = await classifyGhostUuidOwnership(
             previousHost,
             ghostUuid,
@@ -190,11 +213,28 @@ export class SiteService {
                     reason: result.reason,
                 },
             );
-            return;
+            return 'release-uuid';
+        }
+
+        if (result.reason === 'aliased') {
+            // The previous host still serves the install (e.g. a managed
+            // hosting backend hostname behind a customer's custom
+            // domain), so the new canonical host registers as its own
+            // site rather than taking over the previous one.
+            this.logger.info(
+                'Previous host {previousHost} has released ghost_uuid (reason: {reason}); transferring to {newHost}',
+                {
+                    previousHost,
+                    newHost,
+                    ghostUuid,
+                    reason: result.reason,
+                },
+            );
+            return 'release-uuid';
         }
 
         this.logger.info(
-            'Previous host {previousHost} has released ghost_uuid (reason: {reason}); transferring to {newHost}',
+            'Previous host {previousHost} no longer serves ghost_uuid (reason: {reason}); moving site to {newHost}',
             {
                 previousHost,
                 newHost,
@@ -202,6 +242,34 @@ export class SiteService {
                 reason: result.reason,
             },
         );
+        return 'move-site';
+    }
+
+    /**
+     * Move an existing site to a new host after its Ghost URL changed.
+     * The site row keeps its id, webhook secret and `ghost_uuid`, so the
+     * account attached to it (followers, posts, keys) is preserved.
+     * Actor URLs are not rewritten; changing the federated identity is a
+     * separate actor migration concern.
+     */
+    private async moveSiteToHost(
+        siteId: number,
+        host: string,
+        isGhostPro: boolean,
+        webhookSecret: string,
+        ghostUuid: string,
+    ): Promise<Site> {
+        await this.client('sites').where({ id: siteId }).update({
+            host,
+            ghost_pro: isGhostPro,
+        });
+
+        return {
+            id: siteId,
+            host,
+            webhook_secret: webhookSecret,
+            ghost_uuid: ghostUuid,
+        };
     }
 
     private async getSiteSettings(host: string): Promise<SiteSettings> {


### PR DESCRIPTION
## The problem

Site context is resolved from the request `Host` header. When a Ghost site's configured URL changes:

1. Every authenticated admin API request fails with `403 SITE_MISSING` (`No site found for 'new.example.com'`), because `sites` has no row for the new host.
2. When Ghost re-registers via `GET /.ghost/activitypub/v1/site` (on boot / settings toggle), `createSite` released the `ghost_uuid` from the old row and created a **brand-new site and internal account** for the new host — silently orphaning the existing account: followers, posts, notifications and keys all remain attached to a row no request can reach anymore.

## Why not resolve requests by `ghost_uuid` directly

The issue suggests resolving authenticated admin requests by `ghost_uuid`, but no request carries it: the admin JWT contains only `sub` and `role`, and the only way to learn the install's UUID is to fetch `/ghost/api/admin/site/` from the requesting host — a network call we don't want in per-request middleware. Registration already does exactly that fetch, so registration is where the install identity can be keyed on `ghost_uuid`.

## The fix

When a new host registers with a `ghost_uuid` that already belongs to an existing site, the ownership classifier (#1837, #1842) now drives two outcomes instead of one:

- **Previous host no longer serves the install** (`released` via NXDOMAIN, connection refused, 4xx, non-Ghost response, or a different `site_uuid`): this is the same site whose URL changed. The existing site row is **moved to the new host**, keeping its id, `webhook_secret`, `ghost_uuid` and account. Host-based lookup then works for all subsequent admin, webhook and federation requests.
- **Previous host still serves the install** (`released/aliased`, i.e. managed-hosting backend hostnames) **or the outcome is unverifiable** (fail-open): behaviour is unchanged — the new host registers as its own site and takes the UUID.

`still-claims` continues to refuse the registration.

Actor URLs are deliberately not rewritten: the federated identity (`ap_id`, handle) stays on the old domain until actor/domain migration is handled as its own concern, per the issue's scoping. What this PR guarantees is that a URL change no longer destroys the link between the install and its existing account, and the admin UI keeps working against Ghost's new URL.

Also fixed alongside: `initialiseSiteForHost` only checked for an existing internal account when the host lookup had succeeded, so any path that returns a site with an account under a fresh host would have created a duplicate account. The check now always runs against the resolved site id.

Docs: updated the decision table and outcomes in `docs/site-registration.md`.

## Testing

- Updated the two integration tests that covered domain changes (`different-uuid` and unreachable-host cases) to assert the site moves: same id, same webhook secret, single row, no second internal account.
- The aliased-host, fail-open (5xx) and still-claims tests are unchanged and still pass.
- `pnpm lint`, `pnpm test:types` and `pnpm test:single 'src/site/site.service.integration.test.ts'` (11 tests) all pass.