### PR TITLE
Fix profile posts for accounts without a readable outbox

### DIFF
--- a/src/http/api/views/account.posts.view.integration.test.ts
+++ b/src/http/api/views/account.posts.view.integration.test.ts
@@ -6,7 +6,7 @@ import type { Knex } from 'knex';
 import type { Account } from '@/account/account.entity';
 import { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import { AsyncEvents } from '@/core/events';
-import { getError, getValue, isError } from '@/core/result';
+import { error, getError, getValue, isError } from '@/core/result';
 import type { AccountPosts } from '@/http/api/views/account.posts.view';
 import { AccountPostsView } from '@/http/api/views/account.posts.view';
 import { Audience, Post, PostType } from '@/post/post.entity';
@@ -175,6 +175,156 @@ describe('AccountPostsView', () => {
 
             expect(value2.results).toHaveLength(1);
             expect(value2.nextCursor).toBeNull();
+        });
+    });
+
+    describe('getLocallyStoredPosts', () => {
+        let account: Account;
+        let contextAccount: Account;
+
+        beforeEach(async () => {
+            account = await fixtureManager.createExternalAccount();
+            [contextAccount] = await fixtureManager.createInternalAccount();
+        });
+
+        it('returns posts in descending published order, excluding replies', async () => {
+            const post1 = await fixtureManager.createPost(account);
+            const post2 = await fixtureManager.createPost(account);
+            await fixtureManager.createReply(account, post1);
+
+            const accountPosts = await viewer.getLocallyStoredPosts(
+                account,
+                contextAccount.id,
+                10,
+                null,
+            );
+
+            expect(accountPosts.results).toHaveLength(2);
+            expect(accountPosts.results[0].id).toBe(post2.apId.href);
+            expect(accountPosts.results[1].id).toBe(post1.apId.href);
+            expect(accountPosts.results[0].repostedBy).toBeNull();
+        });
+
+        it('sets followedByMe on the author', async () => {
+            await fixtureManager.createPost(account);
+            await fixtureManager.createFollow(contextAccount, account);
+
+            const accountPosts = await viewer.getLocallyStoredPosts(
+                account,
+                contextAccount.id,
+                10,
+                null,
+            );
+
+            expect(accountPosts.results).toHaveLength(1);
+            expect(accountPosts.results[0].author.followedByMe).toBe(true);
+        });
+
+        it('paginates results and returns correct nextCursor', async () => {
+            const post1 = await fixtureManager.createPost(account);
+            const post2 = await fixtureManager.createPost(account);
+
+            await db('posts')
+                .where('id', post1.id)
+                .update('published_at', new Date('2023-01-01'));
+            await db('posts')
+                .where('id', post2.id)
+                .update('published_at', new Date('2023-01-02'));
+
+            const page1 = await viewer.getLocallyStoredPosts(
+                account,
+                contextAccount.id,
+                1,
+                null,
+            );
+
+            expect(page1.results).toHaveLength(1);
+            expect(page1.results[0].id).toBe(post2.apId.href);
+            expect(page1.nextCursor).toBeTruthy();
+
+            const page2 = await viewer.getLocallyStoredPosts(
+                account,
+                contextAccount.id,
+                1,
+                page1.nextCursor,
+            );
+
+            expect(page2.results).toHaveLength(1);
+            expect(page2.results[0].id).toBe(post1.apId.href);
+            expect(page2.nextCursor).toBeNull();
+        });
+    });
+
+    describe('getPostsByApId for external accounts', () => {
+        let account: Account;
+        let contextAccount: Account;
+
+        beforeEach(async () => {
+            account = await fixtureManager.createExternalAccount();
+            [contextAccount] = await fixtureManager.createInternalAccount();
+        });
+
+        it('falls back to locally stored posts when the remote outbox cannot be read', async () => {
+            const post = await fixtureManager.createPost(account);
+
+            vi.spyOn(viewer, 'getPostsByRemoteLookUp').mockResolvedValue(
+                error('error-getting-outbox'),
+            );
+
+            const result = await viewer.getPostsByApId(
+                account.apId,
+                account,
+                contextAccount,
+                10,
+                null,
+            );
+
+            expect(isError(result)).toBe(false);
+            if (!isError(result)) {
+                const accountPosts = getValue(result);
+                expect(accountPosts.results).toHaveLength(1);
+                expect(accountPosts.results[0].id).toBe(post.apId.href);
+            }
+        });
+
+        it('does not fall back when the account is not known locally', async () => {
+            vi.spyOn(viewer, 'getPostsByRemoteLookUp').mockResolvedValue(
+                error('error-getting-outbox'),
+            );
+
+            const result = await viewer.getPostsByApId(
+                new URL('https://unknown.example.com/users/foo'),
+                null,
+                contextAccount,
+                10,
+                null,
+            );
+
+            expect(isError(result)).toBe(true);
+            if (isError(result)) {
+                expect(getError(result)).toBe('error-getting-outbox');
+            }
+        });
+
+        it('does not fall back for errors unrelated to the outbox', async () => {
+            await fixtureManager.createPost(account);
+
+            vi.spyOn(viewer, 'getPostsByRemoteLookUp').mockResolvedValue(
+                error('not-an-actor'),
+            );
+
+            const result = await viewer.getPostsByApId(
+                account.apId,
+                account,
+                contextAccount,
+                10,
+                null,
+            );
+
+            expect(isError(result)).toBe(true);
+            if (isError(result)) {
+                expect(getError(result)).toBe('not-an-actor');
+            }
         });
     });
 

--- a/src/http/api/views/account.posts.view.integration.test.ts
+++ b/src/http/api/views/account.posts.view.integration.test.ts
@@ -205,6 +205,31 @@ describe('AccountPostsView', () => {
             expect(accountPosts.results[0].repostedBy).toBeNull();
         });
 
+        it('includes reposts by the account with reposter fields', async () => {
+            const originalAuthor = await fixtureManager.createExternalAccount();
+            const originalPost =
+                await fixtureManager.createPost(originalAuthor);
+
+            originalPost.addRepost(account);
+            await postRepository.save(originalPost);
+
+            const accountPosts = await viewer.getLocallyStoredPosts(
+                account,
+                contextAccount.id,
+                10,
+                null,
+            );
+
+            expect(accountPosts.results).toHaveLength(1);
+            expect(accountPosts.results[0].id).toBe(originalPost.apId.href);
+            expect(accountPosts.results[0].author.id).toBe(
+                String(originalAuthor.id),
+            );
+            expect(accountPosts.results[0].repostedBy).toMatchObject({
+                id: account.id.toString(),
+            });
+        });
+
         it('sets followedByMe on the author', async () => {
             await fixtureManager.createPost(account);
             await fixtureManager.createFollow(contextAccount, account);

--- a/src/http/api/views/account.posts.view.ts
+++ b/src/http/api/views/account.posts.view.ts
@@ -4,11 +4,24 @@ import type { Knex } from 'knex';
 import type { Account } from '@/account/account.entity';
 import { getAccountHandle } from '@/account/utils';
 import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
-import { error, getValue, isError, ok, type Result } from '@/core/result';
+import {
+    error,
+    getError,
+    getValue,
+    isError,
+    ok,
+    type Result,
+} from '@/core/result';
 import { normalizePlainText, sanitizeHtml } from '@/helpers/html';
+import { isUri } from '@/helpers/uri';
 import type { PostDTO } from '@/http/api/types';
 import { ContentPreparer } from '@/post/content';
-import { type Mention, OutboxType, PostType } from '@/post/post.entity';
+import {
+    Audience,
+    type Mention,
+    OutboxType,
+    PostType,
+} from '@/post/post.entity';
 
 export type GetPostsError =
     | 'invalid-next-parameter'
@@ -113,13 +126,38 @@ export class AccountPostsView {
         }
 
         //Otherwise, do a remote lookup to fetch the posts
-        return this.getPostsByRemoteLookUp(
+        const remoteResult = await this.getPostsByRemoteLookUp(
             currentContextAccount.id,
             currentContextAccount.apId,
             apId,
             cursor,
             account,
         );
+
+        // Some servers (e.g. Threads) do not expose a readable outbox. If we
+        // know the account, fall back to the posts we have stored locally
+        // from previously received activities. Cursors from a remote lookup
+        // are URLs and cannot be used to paginate the locally stored posts
+        // (which are paginated by timestamp)
+        if (isError(remoteResult) && account && !(cursor && isUri(cursor))) {
+            const remoteError = getError(remoteResult);
+
+            if (
+                remoteError === 'error-getting-outbox' ||
+                remoteError === 'no-page-found'
+            ) {
+                return ok(
+                    await this.getLocallyStoredPosts(
+                        account,
+                        currentContextAccount.id,
+                        limit,
+                        cursor,
+                    ),
+                );
+            }
+        }
+
+        return remoteResult;
     }
 
     async getPostsFromOutbox(
@@ -266,6 +304,128 @@ export class AccountPostsView {
             nextCursor:
                 hasMore && lastResult ? lastResult.outbox_published_at : null,
         });
+    }
+
+    /**
+     * Get the posts that are stored locally for an account
+     *
+     * We may have posts for an external account stored locally as a result of
+     * previously received activities, which is useful as a fallback when the
+     * account's posts cannot be retrieved remotely
+     */
+    async getLocallyStoredPosts(
+        account: Account,
+        contextAccountId: number,
+        limit: number,
+        cursor: string | null,
+    ): Promise<AccountPosts> {
+        const query = this.db('posts')
+            .select(
+                // Post fields
+                'posts.id as post_id',
+                'posts.type as post_type',
+                'posts.title as post_title',
+                'posts.excerpt as post_excerpt',
+                'posts.summary as post_summary',
+                'posts.content as post_content',
+                'posts.url as post_url',
+                'posts.image_url as post_image_url',
+                'posts.published_at as post_published_at',
+                'posts.like_count as post_like_count',
+                this.db.raw(`
+                    CASE
+                        WHEN likes.account_id IS NOT NULL THEN 1
+                        ELSE 0
+                    END AS post_liked_by_current_user
+                `),
+                'posts.reply_count as post_reply_count',
+                'posts.reading_time_minutes as post_reading_time_minutes',
+                'posts.attachments as post_attachments',
+                'posts.repost_count as post_repost_count',
+                this.db.raw(`
+                    CASE
+                        WHEN reposts.account_id IS NOT NULL THEN 1
+                        ELSE 0
+                    END AS post_reposted_by_current_user
+                `),
+                'posts.ap_id as post_ap_id',
+                // Author fields
+                'author_account.id as author_id',
+                'author_account.name as author_name',
+                'author_account.username as author_username',
+                'author_account.url as author_url',
+                'author_account.webfinger_host as author_webfinger_host',
+                'author_account.avatar_url as author_avatar_url',
+                this.db.raw(`
+                    CASE
+                        WHEN follows_author.following_id IS NOT NULL THEN 1
+                        ELSE 0
+                    END AS author_followed_by_current_user
+                `),
+                // Reposter fields - always empty as we only include posts
+                // authored by the account
+                this.db.raw('NULL as reposter_id'),
+                this.db.raw('NULL as reposter_name'),
+                this.db.raw('NULL as reposter_username'),
+                this.db.raw('NULL as reposter_url'),
+                this.db.raw('NULL as reposter_webfinger_host'),
+                this.db.raw('NULL as reposter_avatar_url'),
+                this.db.raw('0 as reposter_followed_by_current_user'),
+            )
+            .innerJoin(
+                'accounts as author_account',
+                'author_account.id',
+                'posts.author_id',
+            )
+            .leftJoin('follows as follows_author', function () {
+                this.on(
+                    'follows_author.following_id',
+                    'author_account.id',
+                ).andOnVal(
+                    'follows_author.follower_id',
+                    '=',
+                    contextAccountId.toString(),
+                );
+            })
+            .leftJoin('likes', function () {
+                this.on('likes.post_id', 'posts.id').andOnVal(
+                    'likes.account_id',
+                    '=',
+                    contextAccountId.toString(),
+                );
+            })
+            .leftJoin('reposts', function () {
+                this.on('reposts.post_id', 'posts.id').andOnVal(
+                    'reposts.account_id',
+                    '=',
+                    contextAccountId.toString(),
+                );
+            })
+            .where('posts.author_id', account.id)
+            .where('posts.audience', Audience.Public)
+            .whereNull('posts.in_reply_to')
+            .whereNull('posts.deleted_at')
+            .modify((query) => {
+                if (cursor) {
+                    query.where('posts.published_at', '<', cursor);
+                }
+            })
+            .orderBy('posts.published_at', 'desc')
+            .limit(limit + 1);
+
+        const results = await query;
+
+        const hasMore = results.length > limit;
+        const paginatedResults = results.slice(0, limit);
+        const lastResult = paginatedResults[paginatedResults.length - 1];
+
+        return {
+            results: paginatedResults.map((result: GetProfileDataResultRow) =>
+                this.mapToPostDTO(result, contextAccountId),
+            ),
+            nextCursor:
+                hasMore && lastResult ? lastResult.post_published_at : null,
+        };
     }
 
     async getPostsByRemoteLookUp(

--- a/src/http/api/views/account.posts.view.ts
+++ b/src/http/api/views/account.posts.view.ts
@@ -309,9 +309,9 @@ export class AccountPostsView {
     /**
      * Get the posts that are stored locally for an account
      *
-     * We may have posts for an external account stored locally as a result of
-     * previously received activities, which is useful as a fallback when the
-     * account's posts cannot be retrieved remotely
+     * We may have posts and reposts for an external account stored locally as
+     * a result of previously received activities, which is useful as a
+     * fallback when the account's posts cannot be retrieved remotely
      */
     async getLocallyStoredPosts(
         account: Account,
@@ -319,7 +319,28 @@ export class AccountPostsView {
         limit: number,
         cursor: string | null,
     ): Promise<AccountPosts> {
-        const query = this.db('posts')
+        // External accounts have no rows in the outboxes table, so we build
+        // an equivalent timeline from the posts they authored and the posts
+        // they reposted
+        const timeline = this.db('posts')
+            .select(
+                'id as post_id',
+                this.db.raw('NULL as reposter_id'),
+                'published_at as timeline_published_at',
+            )
+            .where('author_id', account.id)
+            .unionAll([
+                this.db('reposts')
+                    .select(
+                        'post_id',
+                        'account_id as reposter_id',
+                        'created_at as timeline_published_at',
+                    )
+                    .where('account_id', account.id),
+            ]);
+
+        const query = this.db
+            .from(timeline.as('timeline'))
             .select(
                 // Post fields
                 'posts.id as post_id',
@@ -362,20 +383,32 @@ export class AccountPostsView {
                         ELSE 0
                     END AS author_followed_by_current_user
                 `),
-                // Reposter fields - always empty as we only include posts
-                // authored by the account
-                this.db.raw('NULL as reposter_id'),
-                this.db.raw('NULL as reposter_name'),
-                this.db.raw('NULL as reposter_username'),
-                this.db.raw('NULL as reposter_url'),
-                this.db.raw('NULL as reposter_webfinger_host'),
-                this.db.raw('NULL as reposter_avatar_url'),
-                this.db.raw('0 as reposter_followed_by_current_user'),
+                // Reposter fields
+                'reposter_account.id as reposter_id',
+                'reposter_account.name as reposter_name',
+                'reposter_account.username as reposter_username',
+                'reposter_account.url as reposter_url',
+                'reposter_account.webfinger_host as reposter_webfinger_host',
+                'reposter_account.avatar_url as reposter_avatar_url',
+                this.db.raw(`
+                    CASE
+                        WHEN follows_reposter.following_id IS NOT NULL THEN 1
+                        ELSE 0
+                    END AS reposter_followed_by_current_user
+                `),
+                // Timeline fields
+                'timeline.timeline_published_at as timeline_published_at',
             )
+            .innerJoin('posts', 'posts.id', 'timeline.post_id')
             .innerJoin(
                 'accounts as author_account',
                 'author_account.id',
                 'posts.author_id',
+            )
+            .leftJoin(
+                'accounts as reposter_account',
+                'reposter_account.id',
+                'timeline.reposter_id',
             )
             .leftJoin('follows as follows_author', function () {
                 this.on(
@@ -383,6 +416,16 @@ export class AccountPostsView {
                     'author_account.id',
                 ).andOnVal(
                     'follows_author.follower_id',
+                    '=',
+                    contextAccountId.toString(),
+                );
+            })
+            .leftJoin('follows as follows_reposter', function () {
+                this.on(
+                    'follows_reposter.following_id',
+                    'reposter_account.id',
+                ).andOnVal(
+                    'follows_reposter.follower_id',
                     '=',
                     contextAccountId.toString(),
                 );
@@ -401,16 +444,15 @@ export class AccountPostsView {
                     contextAccountId.toString(),
                 );
             })
-            .where('posts.author_id', account.id)
             .where('posts.audience', Audience.Public)
             .whereNull('posts.in_reply_to')
             .whereNull('posts.deleted_at')
             .modify((query) => {
                 if (cursor) {
-                    query.where('posts.published_at', '<', cursor);
+                    query.where('timeline.timeline_published_at', '<', cursor);
                 }
             })
-            .orderBy('posts.published_at', 'desc')
+            .orderBy('timeline.timeline_published_at', 'desc')
             .limit(limit + 1);
 
         const results = await query;
@@ -424,7 +466,7 @@ export class AccountPostsView {
                 this.mapToPostDTO(result, contextAccountId),
             ),
             nextCursor:
-                hasMore && lastResult ? lastResult.post_published_at : null,
+                hasMore && lastResult ? lastResult.timeline_published_at : null,
         };
     }
 


### PR DESCRIPTION
## What

Fixes profiles showing "hasn't posted anything yet" for accounts on servers that don't expose a readable outbox — most notably Threads (#981).

When the remote outbox lookup fails (`error-getting-outbox` / `no-page-found`) for an account we already know about, `AccountPostsView.getPostsByApId` now falls back to the posts we have stored locally from previously received activities: a timeline of the public, non-reply, non-deleted posts the account authored plus the reposts we have stored for it, mirroring the `outboxes` table shape and paginated by timestamp like the internal outbox flow.

## Why

Triage of #981:

- Threads requires signed fetches; unsigned requests get exactly the `{"success":false,"error":"Not found"}` response from the issue report. Our outbox fetches *are* signed — Fedify propagates the authenticated document loader from `lookupObject` into `actor.getOutbox()` — and the actor plus followers/following collections resolve fine, which is why the profile header and counts load in the issue's screenshot.
- Threads' outbox has never exposed post contents (it only ever returned `totalItems`) and now 404s outright, so the remote lookup can never produce posts for Threads accounts. That part is on Threads and can't be fixed here.
- However, for followed accounts we already hold their posts in the `posts` table — they were delivered to our inbox and shown in the Notes feed — but the profile view never looked there. Posts visible in the feed while the profile claims the account "hasn't posted anything yet" is the inconsistency this PR fixes, and it applies to any server whose outbox is unreadable or temporarily failing, not just Threads.

The other symptom mentioned in the issue — *new* Threads posts not arriving in the timeline — is delivery-side (Threads deciding what to push to whom) and isn't addressable in this codebase.

Implementation note on cursors: remote pagination cursors are URLs while local ones are timestamps, so the fallback is skipped when the request carries a remote (URL) cursor rather than comparing a URL against a datetime column.

## Tests

- Integration tests for `getLocallyStoredPosts` (ordering, reply exclusion, repost inclusion with reposter fields, `followedByMe`, pagination)
- Integration tests for the fallback wiring in `getPostsByApId` (falls back on outbox errors, doesn't fall back for unknown accounts or unrelated errors)
