### PR TITLE
Stopped inbox handlers throwing when a remote actor cannot be resolved

### DIFF
--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -102,43 +102,10 @@ export class AccountService {
     ) {}
 
     /**
-     * @deprecated use `ensureByApId`
      * Get an Account by the ActivityPub ID
      * If it is not found locally in our database it will be
      * remotely fetched and stored
      */
-    async getByApId(id: URL): Promise<Account | null> {
-        const account = await this.accountRepository.getByApId(id);
-        if (account) {
-            return account;
-        }
-
-        const context = this.fedifyContextFactory.getFedifyContext();
-
-        const documentLoader = await context.getDocumentLoader({
-            identifier: 'index',
-        });
-        const potentialActor = await lookupFedifyObject(id, { documentLoader });
-
-        // If potentialActor is null - we could not find anything for this URL
-        // Error because could be upstream server issues and we want a retry
-        if (potentialActor === null) {
-            throw new Error(`Could not find Actor ${id}`);
-        }
-
-        // If we do find an Object, and it's not an Actor - we return null because
-        // it's invalid, we don't expect this to be a temporary error
-        if (!isActor(potentialActor)) {
-            return null;
-        }
-
-        const data = await mapActorToExternalAccountData(potentialActor);
-
-        await this.createExternalAccount(data);
-
-        return this.accountRepository.getByApId(id);
-    }
-
     async ensureByApId(
         id: URL,
     ): Promise<Result<Account, RemoteAccountFetchError>> {

--- a/src/activity-handlers/delete.handler.ts
+++ b/src/activity-handlers/delete.handler.ts
@@ -1,9 +1,8 @@
 import type { Actor, Delete } from '@fedify/vocab';
 
-import type { Account } from '@/account/account.entity';
 import type { AccountService } from '@/account/account.service';
 import type { FedifyContext } from '@/app';
-import { exhaustiveCheck, getError, isError } from '@/core/result';
+import { exhaustiveCheck, getError, getValue, isError } from '@/core/result';
 import { getRelatedActivities } from '@/db';
 import type { PostService } from '@/post/post.service';
 
@@ -43,19 +42,19 @@ export class DeleteHandler {
             return;
         }
 
-        let senderAccount: Account | null = null;
+        const senderAccountResult = await this.accountService.ensureByApId(
+            sender.id,
+        );
 
-        try {
-            senderAccount = await this.accountService.getByApId(sender.id);
-        } catch (error) {
-            ctx.data.logger.error('Error fetching sender account', { error });
+        if (isError(senderAccountResult)) {
+            ctx.data.logger.debug('Sender account not found, exit early', {
+                senderId: sender.id.href,
+                error: getError(senderAccountResult),
+            });
             return;
         }
 
-        if (senderAccount === null) {
-            ctx.data.logger.debug('Sender account not found, exit early');
-            return;
-        }
+        const senderAccount = getValue(senderAccountResult);
 
         const deleteResult = await this.postService.deleteByApId(
             deleteActivity.objectId,

--- a/src/dispatchers.ts
+++ b/src/dispatchers.ts
@@ -548,8 +548,6 @@ export const createUndoHandler = (
                 );
                 return;
             }
-            const senderAccount = await accountService.getByApId(sender.id);
-
             if (object.objectId === null) {
                 ctx.data.logger.debug(
                     'Undo announce activity object id missing, exit early',
@@ -557,47 +555,61 @@ export const createUndoHandler = (
                 return;
             }
 
-            if (senderAccount !== null) {
-                const originalPostResult = await postService.getByApId(
-                    object.objectId,
-                );
+            const senderAccountResult = await accountService.ensureByApId(
+                sender.id,
+            );
 
-                if (isError(originalPostResult)) {
-                    const error = getError(originalPostResult);
-                    switch (error) {
-                        case 'upstream-error':
-                            ctx.data.logger.debug(
-                                'Upstream error fetching post for undoing announce',
-                                {
-                                    postId: object.objectId.href,
-                                },
-                            );
-                            break;
-                        case 'not-a-post':
-                            ctx.data.logger.debug(
-                                'Resource is not a post in undoing announce',
-                                {
-                                    postId: object.objectId.href,
-                                },
-                            );
-                            break;
-                        case 'missing-author':
-                            ctx.data.logger.debug(
-                                'Post has missing author in undoing announce',
-                                {
-                                    postId: object.objectId.href,
-                                },
-                            );
-                            break;
-                        default:
-                            return exhaustiveCheck(error);
-                    }
-                    return;
-                }
-                const originalPost = getValue(originalPostResult);
-                originalPost.removeRepost(senderAccount);
-                await postRepository.save(originalPost);
+            if (isError(senderAccountResult)) {
+                ctx.data.logger.debug(
+                    'Could not resolve undo announce sender account, exit early',
+                    {
+                        senderId: sender.id.href,
+                        error: getError(senderAccountResult),
+                    },
+                );
+                return;
             }
+            const senderAccount = getValue(senderAccountResult);
+
+            const originalPostResult = await postService.getByApId(
+                object.objectId,
+            );
+
+            if (isError(originalPostResult)) {
+                const error = getError(originalPostResult);
+                switch (error) {
+                    case 'upstream-error':
+                        ctx.data.logger.debug(
+                            'Upstream error fetching post for undoing announce',
+                            {
+                                postId: object.objectId.href,
+                            },
+                        );
+                        break;
+                    case 'not-a-post':
+                        ctx.data.logger.debug(
+                            'Resource is not a post in undoing announce',
+                            {
+                                postId: object.objectId.href,
+                            },
+                        );
+                        break;
+                    case 'missing-author':
+                        ctx.data.logger.debug(
+                            'Post has missing author in undoing announce',
+                            {
+                                postId: object.objectId.href,
+                            },
+                        );
+                        break;
+                    default:
+                        return exhaustiveCheck(error);
+                }
+                return;
+            }
+            const originalPost = getValue(originalPostResult);
+            originalPost.removeRepost(senderAccount);
+            await postRepository.save(originalPost);
         }
 
         return;
@@ -731,47 +743,59 @@ export function createAnnounceHandler(
         ctx.data.globaldb.set([announce.id.href], announceJson);
 
         // This will save the account if it doesn't already exist
-        const senderAccount = await accountService.getByApId(sender.id);
+        const senderAccountResult = await accountService.ensureByApId(
+            sender.id,
+        );
 
-        if (senderAccount !== null) {
-            // This will save the post if it doesn't already exist
-            const postResult = await postService.getByApId(announce.objectId);
+        if (isError(senderAccountResult)) {
+            ctx.data.logger.debug(
+                'Could not resolve announce sender account, exit early',
+                {
+                    senderId: sender.id.href,
+                    error: getError(senderAccountResult),
+                },
+            );
+            return;
+        }
+        const senderAccount = getValue(senderAccountResult);
 
-            if (isError(postResult)) {
-                const error = getError(postResult);
-                switch (error) {
-                    case 'upstream-error':
-                        ctx.data.logger.debug(
-                            'Upstream error fetching post for reposting',
-                            {
-                                postId: announce.objectId.href,
-                            },
-                        );
-                        break;
-                    case 'not-a-post':
-                        ctx.data.logger.debug(
-                            'Resource for reposting is not a post',
-                            {
-                                postId: announce.objectId.href,
-                            },
-                        );
-                        break;
-                    case 'missing-author':
-                        ctx.data.logger.debug(
-                            'Post for reposting has missing author',
-                            {
-                                postId: announce.objectId.href,
-                            },
-                        );
-                        break;
-                    default:
-                        return exhaustiveCheck(error);
-                }
-            } else {
-                const post = getValue(postResult);
-                post.addRepost(senderAccount);
-                await postRepository.save(post);
+        // This will save the post if it doesn't already exist
+        const postResult = await postService.getByApId(announce.objectId);
+
+        if (isError(postResult)) {
+            const error = getError(postResult);
+            switch (error) {
+                case 'upstream-error':
+                    ctx.data.logger.debug(
+                        'Upstream error fetching post for reposting',
+                        {
+                            postId: announce.objectId.href,
+                        },
+                    );
+                    break;
+                case 'not-a-post':
+                    ctx.data.logger.debug(
+                        'Resource for reposting is not a post',
+                        {
+                            postId: announce.objectId.href,
+                        },
+                    );
+                    break;
+                case 'missing-author':
+                    ctx.data.logger.debug(
+                        'Post for reposting has missing author',
+                        {
+                            postId: announce.objectId.href,
+                        },
+                    );
+                    break;
+                default:
+                    return exhaustiveCheck(error);
             }
+        } else {
+            const post = getValue(postResult);
+            post.addRepost(senderAccount);
+            await postRepository.save(post);
         }
     };
 }
@@ -800,12 +824,18 @@ export function createLikeHandler(
             return;
         }
 
-        const [account, sender] = await Promise.all([
-            accountService.getByApId(like.actorId),
+        const [accountResult, sender] = await Promise.all([
+            accountService.ensureByApId(like.actorId),
             like.getActor(ctx),
         ]);
 
-        if (account !== null) {
+        if (isError(accountResult)) {
+            ctx.data.logger.debug('Could not resolve like actor account', {
+                actorId: like.actorId.href,
+                error: getError(accountResult),
+            });
+        } else {
+            const account = getValue(accountResult);
             const postResult = await postService.getByApId(like.objectId);
 
             if (isError(postResult)) {

--- a/src/dispatchers.unit.test.ts
+++ b/src/dispatchers.unit.test.ts
@@ -1357,7 +1357,7 @@ describe('dispatchers', () => {
 
             mockAccountService = {
                 getAccountByApId: vi.fn(),
-                getByApId: vi.fn(),
+                ensureByApId: vi.fn(),
                 recordAccountUnfollow: vi.fn(),
             } as unknown as AccountService;
 
@@ -1445,8 +1445,8 @@ describe('dispatchers', () => {
         describe('Undo(Announce)', () => {
             it('removes reposted post', async () => {
                 const senderAccount = { id: 20 } as unknown as Account;
-                vi.mocked(mockAccountService.getByApId).mockResolvedValue(
-                    senderAccount,
+                vi.mocked(mockAccountService.ensureByApId).mockResolvedValue(
+                    ok(senderAccount),
                 );
 
                 const mockRepostedPost = { removeRepost: vi.fn() };
@@ -1499,7 +1499,34 @@ describe('dispatchers', () => {
                 );
                 await handler(undoCtx, undo);
 
-                expect(mockAccountService.getByApId).not.toHaveBeenCalled();
+                expect(mockAccountService.ensureByApId).not.toHaveBeenCalled();
+                expect(mockPostService.getByApId).not.toHaveBeenCalled();
+                expect(mockPostRepository.save).not.toHaveBeenCalled();
+            });
+
+            it('exits early when the sender account cannot be resolved', async () => {
+                vi.mocked(mockAccountService.ensureByApId).mockResolvedValue(
+                    error('not-found'),
+                );
+
+                const announce = new Announce({
+                    id: new URL('https://remote.example/announces/7'),
+                    actor: new Person({ id: bobUrl }),
+                    object: postUrl,
+                });
+                const undo = new Undo({
+                    id: new URL('https://remote.example/undo/2'),
+                    actor: bobUrl,
+                    object: announce,
+                });
+
+                const handler = createUndoHandler(
+                    mockAccountService,
+                    mockPostRepository,
+                    mockPostService,
+                );
+                await handler(undoCtx, undo);
+
                 expect(mockPostService.getByApId).not.toHaveBeenCalled();
                 expect(mockPostRepository.save).not.toHaveBeenCalled();
             });

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -203,13 +203,25 @@ export class PostService {
             return error('missing-author');
         }
 
-        const author = await this.accountService.getByApId(
+        const authorResult = await this.accountService.ensureByApId(
             foundObject.attributionId,
         );
 
-        if (author === null) {
-            return error('missing-author');
+        if (isError(authorResult)) {
+            const authorError = getError(authorResult);
+            switch (authorError) {
+                case 'network-failure':
+                    return error('upstream-error');
+                case 'not-found':
+                case 'invalid-type':
+                case 'invalid-data':
+                    return error('missing-author');
+                default:
+                    return exhaustiveCheck(authorError);
+            }
         }
+
+        const author = getValue(authorResult);
 
         let inReplyTo = null;
         if (foundObject.replyTargetId) {


### PR DESCRIPTION
closes https://github.com/TryGhost/ActivityPub/issues/1313

## Problem

`AccountService.getByApId` threw an exception when a remote actor lookup returned nothing:

```ts
if (potentialActor === null) {
    throw new Error(`Could not find Actor ${id}`);
}
```

Ordinary inbound activities (Announce, Like, Undo, Delete) from — or referencing — an actor that can no longer be resolved (deleted account, defederated or misconfigured server) escaped the inbox listeners as an exception. Fedify's `inboxErrorHandler` then captured it to Sentry, and because the Pub/Sub message was never acked, the queue redelivered it and the cycle repeated. A single unresolvable actor could generate thousands of error reports, as described in #1313.

The method was already marked `@deprecated use ensureByApId`, which returns a `Result` instead of throwing, but five call sites were never migrated. Notably, the author lookup inside `PostService.getByApId` let the exception leak out of an otherwise Result-based method — that's the exact stack trace in the issue.

## Solution

Migrated the remaining callers to `ensureByApId` and removed the deprecated method:

- **`PostService.getByApId`** — maps the author-lookup failure into the existing `GetByApIdError` values (`network-failure` → `upstream-error`, everything else → `missing-author`), which callers already handle gracefully.
- **Announce / Undo(Announce) / Like handlers** (`dispatchers.ts`) — log at debug level and exit early when the sender account can't be resolved, matching the surrounding handlers that already use `ensureByApId`.
- **`DeleteHandler`** — replaced the try/catch (which logged at error level, still noisy in Sentry) with the same debug-log-and-exit pattern.

Unresolvable actors are now handled as expected domain outcomes rather than infrastructure errors, so they no longer hit Sentry or trigger redelivery.

## Testing

- Updated the Undo(Announce) unit tests for the new signature and added a test asserting the handler exits gracefully when the sender account can't be resolved.
- `pnpm lint`, `pnpm test:types`, `pnpm test:unit` (944 passed) and the `post.service` integration tests all pass.