### PR TITLE
Added endpoint to resolve a Ghost post to its ActivityPub object

### DIFF
--- a/features/ghost-post-resolution.feature
+++ b/features/ghost-post-resolution.feature
@@ -1,0 +1,12 @@
+Feature: Resolve a Ghost post to its ActivityPub object
+
+  Scenario: A Ghost post is resolved to its ActivityPub object by its UUID
+    Given a "post.published" webhook
+    When it is sent to the webhook endpoint
+    Then the request is accepted
+    When the ActivityPub object for the Ghost post is requested
+    Then we are redirected to an ActivityPub article
+
+  Scenario: An unknown Ghost post cannot be resolved
+    When the ActivityPub object for an unknown Ghost post is requested
+    Then the request is rejected with a 404

--- a/features/step_definitions/ghost_post_steps.js
+++ b/features/step_definitions/ghost_post_steps.js
@@ -1,0 +1,50 @@
+import { Then, When } from '@cucumber/cucumber';
+
+import assert from 'node:assert';
+
+import { v4 as uuidv4 } from 'uuid';
+
+import { fetchActivityPub } from '../support/request.js';
+
+When(
+    'the ActivityPub object for the Ghost post is requested',
+    async function () {
+        const uuid = this.webhookPayload.post.current.uuid;
+
+        this.response = await fetchActivityPub(
+            `https://self.test/.ghost/activitypub/ghost-post/${uuid}`,
+            { redirect: 'manual' },
+            false,
+        );
+    },
+);
+
+When(
+    'the ActivityPub object for an unknown Ghost post is requested',
+    async function () {
+        this.response = await fetchActivityPub(
+            `https://self.test/.ghost/activitypub/ghost-post/${uuidv4()}`,
+            { redirect: 'manual' },
+            false,
+        );
+    },
+);
+
+Then('we are redirected to an ActivityPub article', async function () {
+    assert.equal(this.response.status, 302);
+
+    const location = this.response.headers.get('Location');
+
+    const response = await fetchActivityPub(location, {
+        headers: {
+            Accept: 'application/activity+json',
+        },
+    });
+
+    assert.equal(response.status, 200);
+
+    const article = await response.json();
+
+    assert.equal(article.type, 'Article');
+    assert.equal(article.name, this.webhookPayload.post.current.title);
+});

--- a/features/step_definitions/webhook_steps.js
+++ b/features/step_definitions/webhook_steps.js
@@ -39,6 +39,7 @@ When('it is sent to the webhook endpoint', async function () {
     if (this.payloadData) {
         payload = merge(payload, this.payloadData);
     }
+    this.webhookPayload = payload;
     const body = JSON.stringify(payload);
     const timestamp = Date.now();
     const hmac = createHmac('sha256', getWebhookSecret())

--- a/src/app.ts
+++ b/src/app.ts
@@ -110,6 +110,7 @@ import { ClientConfigController } from '@/http/api/client-config.controller';
 import { ExploreController } from '@/http/api/explore.controller';
 import { FeedController } from '@/http/api/feed.controller';
 import { FollowController } from '@/http/api/follow.controller';
+import { GhostPostController } from '@/http/api/ghost-post.controller';
 import { MissingRequiredParamError } from '@/http/api/helpers/request';
 import { BadRequest } from '@/http/api/helpers/response';
 import { LikeController } from '@/http/api/like.controller';
@@ -968,6 +969,7 @@ app.post(
 );
 
 routeRegistry.registerController('followController', FollowController);
+routeRegistry.registerController('ghostPostController', GhostPostController);
 routeRegistry.registerController('likeController', LikeController);
 routeRegistry.registerController('postController', PostController);
 routeRegistry.registerController('searchController', SearchController);

--- a/src/configuration/registrations.ts
+++ b/src/configuration/registrations.ts
@@ -56,6 +56,7 @@ import { ClientConfigController } from '@/http/api/client-config.controller';
 import { ExploreController } from '@/http/api/explore.controller';
 import { FeedController } from '@/http/api/feed.controller';
 import { FollowController } from '@/http/api/follow.controller';
+import { GhostPostController } from '@/http/api/ghost-post.controller';
 import { LikeController } from '@/http/api/like.controller';
 import { MediaController } from '@/http/api/media.controller';
 import { NotificationController } from '@/http/api/notification.controller';
@@ -71,6 +72,7 @@ import { AccountSearchView } from '@/http/api/views/account.search.view';
 import { AccountView } from '@/http/api/views/account.view';
 import { BlocksView } from '@/http/api/views/blocks.view';
 import { ExploreView } from '@/http/api/views/explore.view';
+import { GhostPostView } from '@/http/api/views/ghost-post.view';
 import { RecommendationsView } from '@/http/api/views/recommendations.view';
 import { ReplyChainView } from '@/http/api/views/reply.chain.view';
 import { TopicView } from '@/http/api/views/topic.view';
@@ -377,9 +379,14 @@ export function registerDependencies(
         asClass(AccountSearchView).singleton(),
     );
     container.register('blocksView', asClass(BlocksView).singleton());
+    container.register('ghostPostView', asClass(GhostPostView).singleton());
     container.register('replyChainView', asClass(ReplyChainView).singleton());
 
     container.register('blockController', asClass(BlockController).singleton());
+    container.register(
+        'ghostPostController',
+        asClass(GhostPostController).singleton(),
+    );
     container.register(
         'followController',
         asClass(FollowController).singleton(),

--- a/src/http/api/ghost-post.controller.ts
+++ b/src/http/api/ghost-post.controller.ts
@@ -1,0 +1,40 @@
+import type { AppContext } from '@/app';
+import { requireParam } from '@/http/api/helpers/request';
+import { NotFound } from '@/http/api/helpers/response';
+import type { GhostPostView } from '@/http/api/views/ghost-post.view';
+import { Route } from '@/http/decorators/route.decorator';
+
+/**
+ * Controller for resolving Ghost posts to their ActivityPub objects
+ */
+export class GhostPostController {
+    constructor(private readonly ghostPostView: GhostPostView) {}
+
+    /**
+     * Handle a request to resolve a Ghost post, by its UUID, to the
+     * ActivityPub object that was created from it
+     *
+     * The UUID is the only identifier Ghost can derive for a post without
+     * knowledge of this service's data, so this URL is what Ghost (or anything
+     * else that knows the post's UUID) can advertise for ActivityPub
+     * discovery, e.g. via a <link rel="alternate"> tag on the post's page
+     *
+     * @see https://swicg.github.io/activitypub-html-discovery/
+     */
+    @Route('GET', '/.ghost/activitypub/ghost-post/:uuid')
+    async handleGetByGhostUuid(ctx: AppContext) {
+        const ghostUuid = requireParam(ctx, 'uuid');
+        const account = ctx.get('account');
+
+        const apId = await this.ghostPostView.getApIdByGhostUuid(
+            ghostUuid,
+            account.id,
+        );
+
+        if (apId === null) {
+            return NotFound('Post not found');
+        }
+
+        return ctx.redirect(apId, 302);
+    }
+}

--- a/src/http/api/ghost-post.controller.unit.test.ts
+++ b/src/http/api/ghost-post.controller.unit.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AppContext } from '@/app';
+import { GhostPostController } from '@/http/api/ghost-post.controller';
+import type { GhostPostView } from '@/http/api/views/ghost-post.view';
+
+const GHOST_UUID = '259e92cb-5ac2-4d62-910f-ddea29b2cf55';
+const ACCOUNT_ID = 123;
+
+function getMockAppContext(uuid: string): AppContext {
+    return {
+        req: {
+            param: (name: string) => (name === 'uuid' ? uuid : undefined),
+        },
+        get: (key: string) => {
+            if (key === 'account') {
+                return { id: ACCOUNT_ID };
+            }
+            return undefined;
+        },
+        redirect: (location: string, status: number) =>
+            new Response(null, {
+                status,
+                headers: {
+                    Location: location,
+                },
+            }),
+    } as unknown as AppContext;
+}
+
+describe('GhostPostController', () => {
+    let ghostPostView: GhostPostView;
+    let controller: GhostPostController;
+
+    beforeEach(() => {
+        ghostPostView = {
+            getApIdByGhostUuid: vi.fn(),
+        } as unknown as GhostPostView;
+
+        controller = new GhostPostController(ghostPostView);
+    });
+
+    describe('handleGetByGhostUuid', () => {
+        it('should redirect to the AP id of the post', async () => {
+            const apId =
+                'https://example.com/.ghost/activitypub/article/f4e37194-c235-4d63-9d55-88f764f9c163';
+
+            vi.mocked(ghostPostView.getApIdByGhostUuid).mockResolvedValue(apId);
+
+            const response = await controller.handleGetByGhostUuid(
+                getMockAppContext(GHOST_UUID),
+            );
+
+            expect(ghostPostView.getApIdByGhostUuid).toHaveBeenCalledWith(
+                GHOST_UUID,
+                ACCOUNT_ID,
+            );
+            expect(response.status).toBe(302);
+            expect(response.headers.get('Location')).toBe(apId);
+        });
+
+        it('should return a 404 if no post is found for the Ghost UUID', async () => {
+            vi.mocked(ghostPostView.getApIdByGhostUuid).mockResolvedValue(null);
+
+            const response = await controller.handleGetByGhostUuid(
+                getMockAppContext(GHOST_UUID),
+            );
+
+            expect(response.status).toBe(404);
+        });
+    });
+});

--- a/src/http/api/views/ghost-post.view.integration.test.ts
+++ b/src/http/api/views/ghost-post.view.integration.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { Knex } from 'knex';
+
+import type { Account } from '@/account/account.entity';
+import { GhostPostView } from '@/http/api/views/ghost-post.view';
+import { PostType } from '@/post/post.entity';
+import { createTestDb } from '@/test/db';
+import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
+
+describe('GhostPostView', () => {
+    let db: Knex;
+    let fixtureManager: FixtureManager;
+    let ghostPostView: GhostPostView;
+    let account: Account;
+
+    const ghostUuid = 'ee218320-b2e6-11ef-8a80-0242ac120002';
+
+    beforeEach(async () => {
+        db = await createTestDb();
+        fixtureManager = createFixtureManager(db);
+        ghostPostView = new GhostPostView(db);
+
+        await fixtureManager.reset();
+
+        [account] = await fixtureManager.createInternalAccount();
+    });
+
+    afterEach(async () => {
+        await db.destroy();
+    });
+
+    describe('getApIdByGhostUuid', () => {
+        it('should return the AP id of the post mapped to the Ghost UUID', async () => {
+            const post = await fixtureManager.createPost(account, {
+                type: PostType.Article,
+            });
+
+            await db('ghost_ap_post_mappings').insert({
+                ghost_uuid: ghostUuid,
+                ap_id: post.apId.href,
+            });
+
+            const result = await ghostPostView.getApIdByGhostUuid(
+                ghostUuid,
+                account.id,
+            );
+
+            expect(result).toBe(post.apId.href);
+        });
+
+        it('should return null if there is no mapping for the Ghost UUID', async () => {
+            const result = await ghostPostView.getApIdByGhostUuid(
+                ghostUuid,
+                account.id,
+            );
+
+            expect(result).toBeNull();
+        });
+
+        it('should return null if the post does not belong to the account', async () => {
+            const post = await fixtureManager.createPost(account, {
+                type: PostType.Article,
+            });
+
+            await db('ghost_ap_post_mappings').insert({
+                ghost_uuid: ghostUuid,
+                ap_id: post.apId.href,
+            });
+
+            const [otherAccount] = await fixtureManager.createInternalAccount();
+
+            const result = await ghostPostView.getApIdByGhostUuid(
+                ghostUuid,
+                otherAccount.id,
+            );
+
+            expect(result).toBeNull();
+        });
+
+        it('should return null if the post has been deleted', async () => {
+            const post = await fixtureManager.createPost(account, {
+                type: PostType.Article,
+            });
+
+            await db('ghost_ap_post_mappings').insert({
+                ghost_uuid: ghostUuid,
+                ap_id: post.apId.href,
+            });
+
+            await db('posts')
+                .where('id', post.id)
+                .update({ deleted_at: new Date() });
+
+            const result = await ghostPostView.getApIdByGhostUuid(
+                ghostUuid,
+                account.id,
+            );
+
+            expect(result).toBeNull();
+        });
+    });
+});

--- a/src/http/api/views/ghost-post.view.ts
+++ b/src/http/api/views/ghost-post.view.ts
@@ -1,0 +1,30 @@
+import type { Knex } from 'knex';
+
+export class GhostPostView {
+    constructor(private readonly db: Knex) {}
+
+    /**
+     * Get the AP id of the post that was created from a Ghost post
+     *
+     * @param ghostUuid UUID of the Ghost post
+     * @param accountId ID of the account the post belongs to
+     */
+    async getApIdByGhostUuid(
+        ghostUuid: string,
+        accountId: number,
+    ): Promise<string | null> {
+        const result = await this.db('ghost_ap_post_mappings')
+            .select('posts.ap_id')
+            .innerJoin(
+                'posts',
+                'posts.ap_id_hash',
+                'ghost_ap_post_mappings.ap_id_hash',
+            )
+            .where('ghost_ap_post_mappings.ghost_uuid', ghostUuid)
+            .where('posts.author_id', accountId)
+            .whereNull('posts.deleted_at')
+            .first();
+
+        return result?.ap_id ?? null;
+    }
+}

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -287,6 +287,7 @@ export class FixtureManager {
             this.db('bluesky_integration_account_handles').truncate(),
             this.db('account_topics').truncate(),
             this.db('topics').truncate(),
+            this.db('ghost_ap_post_mappings').truncate(),
         ]);
         await this.db.raw('SET FOREIGN_KEY_CHECKS = 1');
     }


### PR DESCRIPTION
refs https://github.com/TryGhost/ActivityPub/issues/444

## Problem

Given the URL of a Ghost post, there is currently no way to discover the ActivityPub object that was created from it ([#444](https://github.com/TryGhost/ActivityPub/issues/444)):

- The post's page (served by Ghost) does not content-negotiate `Accept: application/activity+json`, does not send a `Link` header, and does not include a `<link rel="alternate" type="application/activity+json">` tag — the three discovery mechanisms described in [ActivityPub HTML Discovery](https://swicg.github.io/activitypub-html-discovery/).
- The AP object's URL is not derivable from the post: article AP ids use a random UUID (`/.ghost/activitypub/article/{id}`), and the mapping from Ghost post to AP object only exists in this service's `ghost_ap_post_mappings` table.

Since post pages are served by Ghost itself (this service is only routed `/.ghost/activitypub/*` and `/.well-known/*`), this service can't content-negotiate the post URL directly — but it can provide the missing piece: a stable URL, derivable from data Ghost has (the post's UUID), that resolves to the AP object.

## Solution

Adds a public, unauthenticated endpoint:

```
GET /.ghost/activitypub/ghost-post/:uuid
```

which `302` redirects to the AP object mapped to the Ghost post with that UUID, or returns `404` if there is no mapping. The lookup is scoped to the account of the site the request is made against, and excludes deleted posts.

This gives Ghost (or anything else that knows a post's UUID) a stable URL it can advertise for ActivityPub discovery — e.g. by rendering `<link rel="alternate" type="application/activity+json" href="{site}/.ghost/activitypub/ghost-post/{uuid}">` in the post's `<head>`, or by issuing the redirect itself for requests that accept `activity+json` but not `text/html`. Clients that do HTML discovery (Fedify, NodeBB, etc.) can then resolve a post URL to its AP object. A follow-up in Ghost core is needed to emit the tag/header.

Implementation follows the read path (controller → view → DB): a new `GhostPostController` (mounted via the route registry) and `GhostPostView` that resolves the UUID through `ghost_ap_post_mappings` joined to `posts` via the hashed AP id columns. Also adds `ghost_ap_post_mappings` to `FixtureManager.reset()`, which was previously missing.

## Testing

- Unit tests for the controller (redirect + 404)
- Integration tests for the view (mapping hit, no mapping, wrong account, deleted post)
- e2e feature: publishes a post via the webhook, resolves it by UUID and follows the redirect to the `Article` object; unknown UUID returns `404`