### PR TITLE
Fixed Twitter/X embeds

### DIFF
--- a/src/helpers/html.ts
+++ b/src/helpers/html.ts
@@ -249,7 +249,6 @@ export function sanitizeHtml(content: string): string {
                 'loop',
             ],
         },
-        allowedScriptDomains: ['twitter.com'],
         allowedScriptHostnames: ['platform.twitter.com', 'platform.x.com'],
         allowVulnerableTags: true,
     });

--- a/src/helpers/html.ts
+++ b/src/helpers/html.ts
@@ -250,7 +250,7 @@ export function sanitizeHtml(content: string): string {
             ],
         },
         allowedScriptDomains: ['twitter.com'],
-        allowedScriptHostnames: ['platform.twitter.com'],
+        allowedScriptHostnames: ['platform.twitter.com', 'platform.x.com'],
         allowVulnerableTags: true,
     });
 }

--- a/src/helpers/html.unit.test.ts
+++ b/src/helpers/html.unit.test.ts
@@ -36,13 +36,17 @@ describe('sanitizeHtml', () => {
         await import('sanitize-html');
         const { sanitizeHtml: realSanitizeHtml } = await import('./html');
 
-        const content =
-            '<script src="https://bad.com/script.js"></script><script src="https://twitter.com/script.js"></script><p>Hello, world!</p>';
+        const content = [
+            '<script src="https://bad.com/script.js"></script>',
+            '<script src="https://platform.twitter.com/widgets.js"></script>',
+            '<script src="https://platform.x.com/widgets.js"></script>',
+            '<p>Hello, world!</p>',
+        ].join('');
 
         const result = realSanitizeHtml(content);
 
         expect(result).toEqual(
-            '<script></script><script src="https://twitter.com/script.js"></script><p>Hello, world!</p>',
+            '<script></script><script src="https://platform.twitter.com/widgets.js"></script><script src="https://platform.x.com/widgets.js"></script><p>Hello, world!</p>',
         );
 
         // Restore the mock for subsequent tests


### PR DESCRIPTION
With the Twitter → X rebrand, the Twitter widget moved from being hosted on `platform.twitter.com` to new being hosted on `platform.x.com`. 

With this change, both legacy and new URLs are supported as widget hosts. Also cleaned up the unnecessary `allowedScriptDomains: ['twitter.com']`.
