### PR TITLE
Fixed WebFinger 404s caused by stale www/non-www sibling sites

### DIFF
--- a/src/account/account.repository.knex.integration.test.ts
+++ b/src/account/account.repository.knex.integration.test.ts
@@ -75,13 +75,26 @@ describe('KnexAccountRepository', () => {
 
         const account = await accountRepository.getBySite(site);
 
+        assert(account, 'An Account should have been fetched');
         assert(account.uuid !== null, 'Account should have a uuid');
+    });
+
+    it('Returns null when getting by a site that has no user', async () => {
+        const [, site] = await fixtureManager.createInternalAccount();
+
+        await client('users').where('site_id', site.id).del();
+
+        const account = await accountRepository.getBySite(site);
+
+        assert(account === null, 'No Account should have been fetched');
     });
 
     it('Can get by apId', async () => {
         const [, site] = await fixtureManager.createInternalAccount();
 
         const account = await accountRepository.getBySite(site);
+
+        assert(account, 'An Account should have been fetched');
 
         const row = await client('accounts')
             .where({ id: account.id })
@@ -180,6 +193,8 @@ describe('KnexAccountRepository', () => {
             id: 1,
         } as Site);
 
+        assert(accountEntity, 'An Account should have been fetched');
+
         const updated = accountEntity.updateProfile({
             name: 'Updated Name',
             bio: 'Updated Bio',
@@ -223,6 +238,8 @@ describe('KnexAccountRepository', () => {
         const accountEntity = await accountRepository.getBySite({
             id: 1,
         } as Site);
+
+        assert(accountEntity, 'An Account should have been fetched');
 
         const firstUpdated = accountEntity.updateProfile({
             avatarUrl: new URL('https://example.com/avatar.png'),

--- a/src/account/account.repository.knex.ts
+++ b/src/account/account.repository.knex.ts
@@ -251,13 +251,17 @@ export class KnexAccountRepository {
     }
 
     /**
-     * @deprecated
-     * Use `ctx.get('account')` instead
+     * Get the account for a site, or null if the site has no user.
+     *
+     * In request handlers prefer `ctx.get('account')` — the host
+     * middleware has already loaded it. This method exists for resolving
+     * the account of a site outside of the request's own host context
+     * (e.g. WebFinger resolution).
      */
-    async getBySite(site: Site): Promise<Account> {
+    async getBySite(site: Site): Promise<Account | null> {
         const users = await this.db('users').where('site_id', site.id);
         if (users.length === 0) {
-            throw new Error(`No user found for site: ${site.id}`);
+            return null;
         }
 
         if (users.length > 1) {

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -685,7 +685,13 @@ export class AccountService {
     }
 
     async getAccountForSite(site: Site): Promise<Account> {
-        return this.accountRepository.getBySite(site);
+        const account = await this.accountRepository.getBySite(site);
+
+        if (!account) {
+            throw new Error(`No user found for site: ${site.id}`);
+        }
+
+        return account;
     }
 
     /**

--- a/src/feed/feed.service.integration.test.ts
+++ b/src/feed/feed.service.integration.test.ts
@@ -45,6 +45,10 @@ describe('FeedService', () => {
         const site = await siteService.initialiseSiteForHost(host);
         const account = await accountRepository.getBySite(site);
 
+        if (!account) {
+            throw new Error(`No account found for site: ${site.host}`);
+        }
+
         accountSitesMap.set(Number(account.id), site);
 
         return account;

--- a/src/http/api/account.controller.ts
+++ b/src/http/api/account.controller.ts
@@ -155,9 +155,7 @@ export class AccountController {
             return new Response(null, { status: 404 });
         }
 
-        const siteDefaultAccount = await this.accountRepository.getBySite(
-            ctx.get('site'),
-        );
+        const siteDefaultAccount = ctx.get('account');
 
         let accountDto: AccountDTO | null = null;
 
@@ -197,7 +195,6 @@ export class AccountController {
     @RequireRoles(GhostRole.Owner, GhostRole.Administrator)
     async handleGetAccountFollows(ctx: AppContext) {
         const logger = ctx.get('logger');
-        const site = ctx.get('site');
 
         const handle = requireParam(ctx, 'handle');
 
@@ -206,7 +203,7 @@ export class AccountController {
             return new Response(null, { status: 400 });
         }
 
-        const siteDefaultAccount = await this.accountRepository.getBySite(site);
+        const siteDefaultAccount = ctx.get('account');
 
         const queryNext = ctx.req.query('next');
         const next = queryNext ? decodeURIComponent(queryNext) : null;
@@ -304,12 +301,10 @@ export class AccountController {
         }
 
         const logger = ctx.get('logger');
-        const site = ctx.get('site');
 
         const handle = requireParam(ctx, 'handle');
 
-        const currentContextAccount =
-            await this.accountRepository.getBySite(site);
+        const currentContextAccount = ctx.get('account');
 
         let accountPosts: AccountPosts;
 

--- a/src/http/api/post.controller.ts
+++ b/src/http/api/post.controller.ts
@@ -13,7 +13,6 @@ import {
 } from '@fedify/vocab';
 import { z } from 'zod';
 
-import type { KnexAccountRepository } from '@/account/account.repository.knex';
 import type { AccountService } from '@/account/account.service';
 import type { AppContext, ContextData } from '@/app';
 import { ACTOR_DEFAULT_HANDLE } from '@/constants';
@@ -44,7 +43,6 @@ export class PostController {
     constructor(
         private readonly postService: PostService,
         private readonly accountService: AccountService,
-        private readonly accountRepository: KnexAccountRepository,
         private readonly postRepository: KnexPostRepository,
         private readonly fedify: Federation<ContextData>,
     ) {}
@@ -143,7 +141,7 @@ export class PostController {
             });
         }
 
-        const account = await this.accountRepository.getBySite(ctx.get('site'));
+        const account = ctx.get('account');
         const deleteResult = await this.postService.deleteByApId(
             idAsUrl,
             account,

--- a/src/http/api/post.controller.unit.test.ts
+++ b/src/http/api/post.controller.unit.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Federation } from '@fedify/fedify';
 
 import type { AccountEntity } from '@/account/account.entity';
-import type { KnexAccountRepository } from '@/account/account.repository.knex';
 import type { AccountService } from '@/account/account.service';
 import type { AppContext, ContextData } from '@/app';
 import { error, ok } from '@/core/result';
@@ -25,7 +24,6 @@ describe('Post API', () => {
     let account: AccountEntity;
     let postService: PostService;
     let accountService: AccountService;
-    let accountRepository: KnexAccountRepository;
     let postRepository: KnexPostRepository;
     let postController: PostController;
     let fedify: Federation<ContextData>;
@@ -112,13 +110,11 @@ describe('Post API', () => {
         accountService = {
             checkIfAccountIsFollowing: vi.fn().mockResolvedValue(false),
         } as unknown as AccountService;
-        accountRepository = {} as unknown as KnexAccountRepository;
         postRepository = {} as unknown as KnexPostRepository;
         fedify = {} as unknown as Federation<ContextData>;
         postController = new PostController(
             postService,
             accountService,
-            accountRepository,
             postRepository,
             fedify,
         );

--- a/src/http/api/webfinger.controller.ts
+++ b/src/http/api/webfinger.controller.ts
@@ -64,25 +64,19 @@ export class WebFingerController {
             return this.createWebfingerResponse(customDomainAccount);
         }
 
-        const site =
-            (await this.siteService.getSiteByHost(normalizedResourceHost)) ||
-            (await this.siteService.getSiteByHost(
-                `www.${normalizedResourceHost}`,
-            ));
+        const resourceLookup = await this.findAccountForHandleHost(
+            resourceUsername,
+            normalizedResourceHost,
+        );
 
-        if (site) {
-            const account = await this.getAccountBySiteOrNull(site);
+        if (resourceLookup.account) {
+            return this.createWebfingerResponse(resourceLookup.account);
+        }
 
-            if (
-                !account ||
-                !this.resourceUsernameMatchesAccount(resourceUsername, account)
-            ) {
-                return new Response(null, {
-                    status: 404,
-                });
-            }
-
-            return this.createWebfingerResponse(account);
+        if (resourceLookup.siteFound) {
+            return new Response(null, {
+                status: 404,
+            });
         }
 
         const requestHost = ctx.req.header('host')?.split(':')[0];
@@ -95,33 +89,60 @@ export class WebFingerController {
         }
 
         if (normalizedRequestHost) {
-            const requestSite =
-                (await this.siteService.getSiteByHost(normalizedRequestHost)) ||
-                (await this.siteService.getSiteByHost(
-                    `www.${normalizedRequestHost}`,
-                ));
+            const requestLookup = await this.findAccountForHandleHost(
+                resourceUsername,
+                normalizedRequestHost,
+            );
 
-            if (requestSite) {
-                const account = await this.getAccountBySiteOrNull(requestSite);
-
-                if (
-                    account &&
-                    this.resourceUsernameMatchesAccount(
-                        resourceUsername,
-                        account,
-                    )
-                ) {
-                    return this.createWebfingerResponse(
-                        account,
-                        normalizedResourceHost,
-                    );
-                }
+            if (requestLookup.account) {
+                return this.createWebfingerResponse(
+                    requestLookup.account,
+                    normalizedResourceHost,
+                );
             }
         }
 
         return new Response(null, {
             status: 404,
         });
+    }
+
+    /**
+     * Find the account that answers to the requested username on either
+     * variant of a handle host (`host` and `www.host`).
+     *
+     * Multiple site rows can exist for the same publication (e.g. a stale
+     * registration left behind by a www/non-www domain change), so a
+     * username mismatch on one variant must not prevent the other variant
+     * from resolving. The bare host is checked first, so when both variants
+     * match the requested username the bare host wins.
+     */
+    private async findAccountForHandleHost(
+        resourceUsername: string,
+        handleHost: string,
+    ): Promise<{ siteFound: boolean; account: Account | null }> {
+        let siteFound = false;
+
+        for (const host of [handleHost, `www.${handleHost}`]) {
+            const site = await this.siteService.getSiteByHost(host);
+
+            if (!site) {
+                continue;
+            }
+
+            siteFound = true;
+
+            const account = await this.getAccountBySiteOrNull(site);
+
+            if (
+                account &&
+                this.resourceUsernameMatchesAccount(resourceUsername, account)
+            ) {
+                return { siteFound, account };
+            }
+        }
+
+        return { siteFound, account: null };
     }
 
     private async getAccountBySiteOrNull(site: {

--- a/src/http/api/webfinger.controller.ts
+++ b/src/http/api/webfinger.controller.ts
@@ -132,7 +132,7 @@ export class WebFingerController {
 
             siteFound = true;
 
-            const account = await this.getAccountBySiteOrNull(site);
+            const account = await this.accountRepository.getBySite(site);
 
             if (
                 account &&
@@ -143,19 +143,6 @@ export class WebFingerController {
         }
 
         return { siteFound, account: null };
-    }
-
-    private async getAccountBySiteOrNull(site: {
-        id: number;
-        host: string;
-        webhook_secret: string;
-        ghost_uuid: string | null;
-    }) {
-        try {
-            return await this.accountRepository.getBySite(site);
-        } catch (_error) {
-            return null;
-        }
     }
 
     private createWebfingerResponse(

--- a/src/http/api/webfinger.unit.test.ts
+++ b/src/http/api/webfinger.unit.test.ts
@@ -263,9 +263,7 @@ describe('handleWebFinger', () => {
             return Promise.resolve(null);
         });
 
-        vi.mocked(accountRepository.getBySite).mockRejectedValue(
-            new Error('No account found'),
-        );
+        vi.mocked(accountRepository.getBySite).mockResolvedValue(null);
 
         const response = await webFingerController.handleWebFinger(ctx, next);
 
@@ -273,6 +271,31 @@ describe('handleWebFinger', () => {
         expect(siteService.getSiteByHost).toHaveBeenCalledWith(
             'www.example.com',
         );
+    });
+
+    it('should propagate account lookup errors instead of falling back', async () => {
+        const ctx = getCtx({ resource: 'acct:alice@example.com' });
+        const next = vi.fn();
+
+        vi.mocked(siteService.getSiteByHost).mockImplementation((host) => {
+            if (host === 'example.com') {
+                return Promise.resolve({ host: 'example.com' } as Site);
+            }
+            if (host === 'www.example.com') {
+                return Promise.resolve({ host: 'www.example.com' } as Site);
+            }
+
+            return Promise.resolve(null);
+        });
+
+        vi.mocked(accountRepository.getBySite).mockRejectedValue(
+            new Error('Connection lost'),
+        );
+
+        await expect(
+            webFingerController.handleWebFinger(ctx, next),
+        ).rejects.toThrow('Connection lost');
+        expect(next).not.toHaveBeenCalled();
     });
 
     it('should return a custom webfinger response', async () => {
@@ -436,7 +459,7 @@ describe('handleWebFinger', () => {
         });
     });
 
-    it('should resolve via the www site when the bare-host site account fails to load', async () => {
+    it('should resolve via the www site when the bare-host site has no account', async () => {
         const ctx = getCtx({ resource: 'acct:alice@example.com' });
         const next = vi.fn();
 
@@ -453,7 +476,7 @@ describe('handleWebFinger', () => {
 
         vi.mocked(accountRepository.getBySite).mockImplementation((site) => {
             if (site.host === 'example.com') {
-                return Promise.reject(new Error('No account found'));
+                return Promise.resolve(null);
             }
 
             return Promise.resolve({

--- a/src/http/api/webfinger.unit.test.ts
+++ b/src/http/api/webfinger.unit.test.ts
@@ -349,6 +349,217 @@ describe('handleWebFinger', () => {
         });
     });
 
+    it('should resolve via the www site when a stale bare-host site does not match the username', async () => {
+        const ctx = getCtx({ resource: 'acct:alice@example.com' });
+        const next = vi.fn();
+
+        vi.mocked(siteService.getSiteByHost).mockImplementation((host) => {
+            if (host === 'example.com') {
+                return Promise.resolve({ host: 'example.com' } as Site);
+            }
+            if (host === 'www.example.com') {
+                return Promise.resolve({ host: 'www.example.com' } as Site);
+            }
+
+            return Promise.resolve(null);
+        });
+
+        vi.mocked(accountRepository.getBySite).mockImplementation((site) => {
+            if (site.host === 'example.com') {
+                // Stale registration left behind by a domain change,
+                // still on the original username
+                return Promise.resolve({
+                    username: 'index',
+                    url: 'https://example.com',
+                    apId: new URL('https://example.com/users/index'),
+                    webfingerHost: null,
+                } as unknown as Account);
+            }
+
+            // Live registration whose display username was changed
+            return Promise.resolve({
+                username: 'alice',
+                url: 'https://www.example.com',
+                apId: new URL('https://www.example.com/users/index'),
+                webfingerHost: null,
+            } as unknown as Account);
+        });
+
+        const response = await webFingerController.handleWebFinger(ctx, next);
+
+        expect(response?.status).toBe(200);
+        expect(await response?.json()).toMatchObject({
+            subject: 'acct:alice@example.com',
+            aliases: ['https://www.example.com/users/index'],
+        });
+    });
+
+    it('should prefer the bare-host site when both variants match the username', async () => {
+        const ctx = getCtx({ resource: 'acct:index@example.com' });
+        const next = vi.fn();
+
+        vi.mocked(siteService.getSiteByHost).mockImplementation((host) => {
+            if (host === 'example.com') {
+                return Promise.resolve({ host: 'example.com' } as Site);
+            }
+            if (host === 'www.example.com') {
+                return Promise.resolve({ host: 'www.example.com' } as Site);
+            }
+
+            return Promise.resolve(null);
+        });
+
+        vi.mocked(accountRepository.getBySite).mockImplementation((site) => {
+            if (site.host === 'example.com') {
+                return Promise.resolve({
+                    username: 'index',
+                    url: 'https://example.com',
+                    apId: new URL('https://example.com/users/index'),
+                    webfingerHost: null,
+                } as unknown as Account);
+            }
+
+            return Promise.resolve({
+                username: 'index',
+                url: 'https://www.example.com',
+                apId: new URL('https://www.example.com/users/index'),
+                webfingerHost: null,
+            } as unknown as Account);
+        });
+
+        const response = await webFingerController.handleWebFinger(ctx, next);
+
+        expect(response?.status).toBe(200);
+        expect(await response?.json()).toMatchObject({
+            subject: 'acct:index@example.com',
+            aliases: ['https://example.com/users/index'],
+        });
+    });
+
+    it('should resolve via the www site when the bare-host site account fails to load', async () => {
+        const ctx = getCtx({ resource: 'acct:alice@example.com' });
+        const next = vi.fn();
+
+        vi.mocked(siteService.getSiteByHost).mockImplementation((host) => {
+            if (host === 'example.com') {
+                return Promise.resolve({ host: 'example.com' } as Site);
+            }
+            if (host === 'www.example.com') {
+                return Promise.resolve({ host: 'www.example.com' } as Site);
+            }
+
+            return Promise.resolve(null);
+        });
+
+        vi.mocked(accountRepository.getBySite).mockImplementation((site) => {
+            if (site.host === 'example.com') {
+                return Promise.reject(new Error('No account found'));
+            }
+
+            return Promise.resolve({
+                username: 'alice',
+                url: 'https://www.example.com',
+                apId: new URL('https://www.example.com/users/alice'),
+                webfingerHost: null,
+            } as unknown as Account);
+        });
+
+        const response = await webFingerController.handleWebFinger(ctx, next);
+
+        expect(response?.status).toBe(200);
+        expect(await response?.json()).toMatchObject({
+            subject: 'acct:alice@example.com',
+            aliases: ['https://www.example.com/users/alice'],
+        });
+    });
+
+    it('should return 404 when neither host variant matches the username', async () => {
+        const ctx = getCtx({ resource: 'acct:bob@example.com' });
+        const next = vi.fn();
+
+        vi.mocked(siteService.getSiteByHost).mockImplementation((host) => {
+            if (host === 'example.com') {
+                return Promise.resolve({ host: 'example.com' } as Site);
+            }
+            if (host === 'www.example.com') {
+                return Promise.resolve({ host: 'www.example.com' } as Site);
+            }
+
+            return Promise.resolve(null);
+        });
+
+        vi.mocked(accountRepository.getBySite).mockImplementation((site) => {
+            if (site.host === 'example.com') {
+                return Promise.resolve({
+                    username: 'index',
+                    url: 'https://example.com',
+                    apId: new URL('https://example.com/users/index'),
+                    webfingerHost: null,
+                } as unknown as Account);
+            }
+
+            return Promise.resolve({
+                username: 'alice',
+                url: 'https://www.example.com',
+                apId: new URL('https://www.example.com/users/index'),
+                webfingerHost: null,
+            } as unknown as Account);
+        });
+
+        const response = await webFingerController.handleWebFinger(ctx, next);
+
+        expect(response?.status).toBe(404);
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should resolve a custom domain via the www variant of the request host when the bare request host does not match', async () => {
+        const ctx = getCtx(
+            { resource: 'acct:alice@custom.example.com' },
+            'blog.example.com',
+        );
+        const next = vi.fn();
+
+        vi.mocked(siteService.getSiteByHost).mockImplementation((host) => {
+            if (host === 'blog.example.com') {
+                return Promise.resolve({ host: 'blog.example.com' } as Site);
+            }
+            if (host === 'www.blog.example.com') {
+                return Promise.resolve({
+                    host: 'www.blog.example.com',
+                } as Site);
+            }
+
+            return Promise.resolve(null);
+        });
+
+        vi.mocked(accountRepository.getBySite).mockImplementation((site) => {
+            if (site.host === 'blog.example.com') {
+                // Stale registration left behind by a domain change
+                return Promise.resolve({
+                    username: 'bob',
+                    url: 'https://blog.example.com',
+                    apId: new URL('https://blog.example.com/users/bob'),
+                    webfingerHost: null,
+                } as unknown as Account);
+            }
+
+            return Promise.resolve({
+                username: 'alice',
+                url: 'https://www.blog.example.com',
+                apId: new URL('https://www.blog.example.com/users/index'),
+                webfingerHost: null,
+            } as unknown as Account);
+        });
+
+        const response = await webFingerController.handleWebFinger(ctx, next);
+
+        expect(response?.status).toBe(200);
+        expect(await response?.json()).toMatchObject({
+            subject: 'acct:alice@custom.example.com',
+            aliases: ['https://www.blog.example.com/users/index'],
+        });
+    });
+
     it('should return 404 when the resource username does not match the site account', async () => {
         const ctx = getCtx({ resource: 'acct:bob@example.com' });
         const next = vi.fn();

--- a/src/post/post.repository.knex.integration.test.ts
+++ b/src/post/post.repository.knex.integration.test.ts
@@ -29,7 +29,7 @@ import { PostDerepostedEvent } from '@/post/post-dereposted.event';
 import { PostLikedEvent } from '@/post/post-liked.event';
 import { PostRepostedEvent } from '@/post/post-reposted.event';
 import { PostUpdatedEvent } from '@/post/post-updated.event';
-import { SiteService } from '@/site/site.service';
+import { type Site, SiteService } from '@/site/site.service';
 import { generateTestCryptoKeyPair } from '@/test/crypto-key-pair';
 import { createTestDb } from '@/test/db';
 import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
@@ -44,9 +44,19 @@ describe('KnexPostRepository', () => {
     let client: Knex;
     let fixtureManager: FixtureManager;
 
+    const getAccountForSite = async (site: Site) => {
+        const account = await accountRepository.getBySite(site);
+
+        if (!account) {
+            throw new Error(`No account found for site: ${site.host}`);
+        }
+
+        return account;
+    };
+
     const getAccount = async (host: string) => {
         const site = await siteService.initialiseSiteForHost(host);
-        const account = await accountRepository.getBySite(site);
+        const account = await getAccountForSite(site);
 
         return account;
     };
@@ -108,7 +118,7 @@ describe('KnexPostRepository', () => {
     describe('Events', () => {
         it('Waits for the post to be added to feeds before returning', async () => {
             const site = await siteService.initialiseSiteForHost('testing.com');
-            const account = await accountRepository.getBySite(site);
+            const account = await getAccountForSite(site);
             const postResult = await Post.createArticleFromGhostPost(account, {
                 title: 'Title',
                 uuid: '3f1c5e84-9a2b-4d7f-8e62-1a6b9c9d4f10',
@@ -137,7 +147,7 @@ describe('KnexPostRepository', () => {
 
         it('Waits for the deleted post to be removed from feeds before returning', async () => {
             const site = await siteService.initialiseSiteForHost('testing.com');
-            const account = await accountRepository.getBySite(site);
+            const account = await getAccountForSite(site);
             const postResult = await Post.createArticleFromGhostPost(account, {
                 title: 'Title',
                 uuid: '3f1c5e84-9a2b-4d7f-8e62-1a6b9c9d4f10',
@@ -188,7 +198,7 @@ describe('KnexPostRepository', () => {
         it('Can handle a deleted post', async () => {
             const site =
                 await siteService.initialiseSiteForHost('testing-delete.com');
-            const account = await accountRepository.getBySite(site);
+            const account = await getAccountForSite(site);
             const postResult = await Post.createArticleFromGhostPost(account, {
                 title: 'Title',
                 uuid: '3f1c5e84-9a2b-4d7f-8e62-1a6b9c9d4f10',
@@ -236,7 +246,7 @@ describe('KnexPostRepository', () => {
             const site = await siteService.initialiseSiteForHost(
                 'testing-deleted-reply.com',
             );
-            const account = await accountRepository.getBySite(site);
+            const account = await getAccountForSite(site);
             const postResult = await Post.createArticleFromGhostPost(account, {
                 title: 'Title',
                 uuid: '3f1c5e84-9a2b-4d7f-8e62-1a6b9c9d4f10',
@@ -315,7 +325,7 @@ describe('KnexPostRepository', () => {
             const site = await siteService.initialiseSiteForHost(
                 'testing-atomic-delete.com',
             );
-            const account = await accountRepository.getBySite(site);
+            const account = await getAccountForSite(site);
 
             // Create parent with 3 replies
             const parentPost = Post.createNote(account, 'Parent post content');
@@ -373,8 +383,8 @@ describe('KnexPostRepository', () => {
             const site = await siteService.initialiseSiteForHost(
                 'testing-delete-likes.com',
             );
-            const account = await accountRepository.getBySite(site);
-            const likerAccount = await accountRepository.getBySite(
+            const account = await getAccountForSite(site);
+            const likerAccount = await getAccountForSite(
                 await siteService.initialiseSiteForHost('liker-site.com'),
             );
 
@@ -420,7 +430,7 @@ describe('KnexPostRepository', () => {
             const site = await siteService.initialiseSiteForHost(
                 'testing-new-deleted.com',
             );
-            const account = await accountRepository.getBySite(site);
+            const account = await getAccountForSite(site);
             const postResult = await Post.createArticleFromGhostPost(account, {
                 title: 'Title',
                 uuid: randomUUID(),
@@ -453,7 +463,7 @@ describe('KnexPostRepository', () => {
     it('Can save a Post created with out of bounds fields', async () => {
         const site =
             await siteService.initialiseSiteForHost('testing-saving.com');
-        const account = await accountRepository.getBySite(site);
+        const account = await getAccountForSite(site);
         const post = Post.createFromData(account, {
             type: PostType.Article,
             content: 'Hello, world!',
@@ -481,7 +491,7 @@ describe('KnexPostRepository', () => {
     it('Can save a Post', async () => {
         const site =
             await siteService.initialiseSiteForHost('testing-saving.com');
-        const account = await accountRepository.getBySite(site);
+        const account = await getAccountForSite(site);
         const postResult = await Post.createArticleFromGhostPost(account, {
             title: 'Title',
             uuid: randomUUID(),
@@ -512,7 +522,7 @@ describe('KnexPostRepository', () => {
         const site = await siteService.initialiseSiteForHost(
             'testing-saving-multiple-posts-same-ap-id.com',
         );
-        const account = await accountRepository.getBySite(site);
+        const account = await getAccountForSite(site);
         const postApId = new URL(`https://${site.host}/hello-world`);
 
         const eventsEmitSpy = vi.spyOn(events, 'emitAsync');
@@ -567,7 +577,7 @@ describe('KnexPostRepository', () => {
         const site = await siteService.initialiseSiteForHost(
             'testing-post-created-event.com',
         );
-        const account = await accountRepository.getBySite(site);
+        const account = await getAccountForSite(site);
 
         const eventsEmitSpy = vi.spyOn(events, 'emitAsync');
 
@@ -597,7 +607,7 @@ describe('KnexPostRepository', () => {
         const site = await siteService.initialiseSiteForHost(
             'testing-post-update.com',
         );
-        const account = await accountRepository.getBySite(site);
+        const account = await getAccountForSite(site);
 
         const eventsEmitSpy = vi.spyOn(events, 'emitAsync');
 
@@ -625,7 +635,7 @@ describe('KnexPostRepository', () => {
         const site = await siteService.initialiseSiteForHost(
             'testing-by-apid.com',
         );
-        const account = await accountRepository.getBySite(site);
+        const account = await getAccountForSite(site);
         const postResult = await Post.createArticleFromGhostPost(account, {
             title: 'Title',
             uuid: randomUUID(),
@@ -656,7 +666,7 @@ describe('KnexPostRepository', () => {
         const site = await siteService.initialiseSiteForHost(
             'testing-by-apid.com',
         );
-        const account = await accountRepository.getBySite(site);
+        const account = await getAccountForSite(site);
         const postResult = await Post.createArticleFromGhostPost(account, {
             title: 'Title',
             uuid: randomUUID(),
@@ -687,7 +697,7 @@ describe('KnexPostRepository', () => {
         const site = await siteService.initialiseSiteForHost(
             'testing-account-uuid.com',
         );
-        const account = await accountRepository.getBySite(site);
+        const account = await getAccountForSite(site);
 
         if (!account.id) {
             throw new Error('Expected account to have an id');
@@ -731,7 +741,7 @@ describe('KnexPostRepository', () => {
         const site = await siteService.initialiseSiteForHost(
             'testing-deleted-tombstone.com',
         );
-        const account = await accountRepository.getBySite(site);
+        const account = await getAccountForSite(site);
         const postResult = await Post.createArticleFromGhostPost(account, {
             title: 'Title',
             uuid: randomUUID(),
@@ -1154,7 +1164,7 @@ describe('KnexPostRepository', () => {
         const site = await siteService.initialiseSiteForHost(
             'testing-attachments.com',
         );
-        const account = await accountRepository.getBySite(site);
+        const account = await getAccountForSite(site);
         const attachments = [
             {
                 type: 'Document',
@@ -1195,7 +1205,7 @@ describe('KnexPostRepository', () => {
             'testing-is-liked-by-account.com',
         );
 
-        const account = await accountRepository.getBySite(site);
+        const account = await getAccountForSite(site);
         const postResult = await Post.createArticleFromGhostPost(account, {
             title: 'Title',
             uuid: randomUUID(),
@@ -1236,8 +1246,8 @@ describe('KnexPostRepository', () => {
         const site = await siteService.initialiseSiteForHost(
             'testing-is-reposted-by-account.com',
         );
-        const account = await accountRepository.getBySite(site);
-        const reposterAccount = await accountRepository.getBySite(
+        const account = await getAccountForSite(site);
+        const reposterAccount = await getAccountForSite(
             await siteService.initialiseSiteForHost('reposter-site.com'),
         );
 
@@ -1359,7 +1369,7 @@ describe('KnexPostRepository', () => {
         const site = await siteService.initialiseSiteForHost(
             'testing-metadata.com',
         );
-        const account = await accountRepository.getBySite(site);
+        const account = await getAccountForSite(site);
 
         const postResult = await Post.createArticleFromGhostPost(account, {
             title: 'Title',
@@ -2025,7 +2035,7 @@ describe('KnexPostRepository', () => {
         it('should handle updating a post with new parameters', async () => {
             const site =
                 await siteService.initialiseSiteForHost('testing-update.com');
-            const account = await accountRepository.getBySite(site);
+            const account = await getAccountForSite(site);
 
             // Original post
             const postResult = await Post.createArticleFromGhostPost(account, {
@@ -2147,7 +2157,7 @@ describe('KnexPostRepository', () => {
             const site = await siteService.initialiseSiteForHost(
                 'testing-no-update.com',
             );
-            const account = await accountRepository.getBySite(site);
+            const account = await getAccountForSite(site);
 
             const postResult = await Post.createArticleFromGhostPost(account, {
                 title: 'Original Title',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1905/social-web-not-working

When a publication's domain moves between the www and non-www variant, a new site registration is created and the old one is left behind. WebFinger resolution picked a single site row - the bare host if present, otherwise the www variant - so a stale bare-host row would answer for the whole domain: queries for the live account's username returned 404 while the stale row's old username kept resolving. The failure surfaces when a customer changes their handle

Resolution now checks both host variants and returns the first account that answers to the requested username:

| Case                         | Before        | After         |
| ---------------------------- | ------------- | ------------- |
| Single site row, match       | 200           | 200           |
| Single site row, no match    | 404           | 404           |
| Both rows, bare host matches | 200 from bare | 200 from bare |
| Both rows, only www matches  | 404           | 200 from www  |
| Both rows, neither matches   | 404           | 404           |
| No site rows                 | fall through  | fall through  |

Only the "only www matches" case changes, so the fix can only turn 404s into matches - no existing 200 response changes shape. The preserved fall-through for unknown domains is what the custom domain validation flow depends on. The same handling applies to the request-host branch used during that validation