### PR TITLE
Restrict embedded iframes in sanitized content

### DIFF
--- a/src/helpers/html.ts
+++ b/src/helpers/html.ts
@@ -1,6 +1,16 @@
 import { htmlToText } from 'html-to-text';
 import doSanitizeHtml from 'sanitize-html';
 
+// Forced onto every iframe so embedded third-party frames (from arbitrary hosts)
+// cannot navigate the top-level window, escalate their own sandbox, or otherwise
+// misbehave. Keep in parity with FORCED_IFRAME_SANDBOX in
+// https://github.com/TryGhost/Ghost/blob/main/apps/activitypub/src/utils/content-formatters.ts.
+// Intentionally omits `allow-top-navigation` (no tab hijacking). `allow-same-origin`
+// is safe: content iframes are cross-origin to the embedder, so it only grants the
+// frame its own origin, never the parent's.
+const FORCED_IFRAME_SANDBOX =
+    'allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-presentation allow-forms';
+
 export function sanitizeHtml(content: string): string {
     if (!content) {
         return content;
@@ -225,6 +235,8 @@ export function sanitizeHtml(content: string): string {
                 'height',
                 'frameborder',
                 'allowfullscreen',
+                'sandbox',
+                'referrerpolicy',
             ],
             script: ['src', 'async', 'charset'],
 
@@ -251,6 +263,19 @@ export function sanitizeHtml(content: string): string {
         },
         allowedScriptHostnames: ['platform.twitter.com', 'platform.x.com'],
         allowVulnerableTags: true,
+        // Force our sandbox onto every iframe, overriding (not merging with) any
+        // author- or attacker-supplied value. `sandbox`/`referrerpolicy` are in
+        // allowedAttributes above so they survive the subsequent attribute filter.
+        transformTags: {
+            iframe: (tagName, attribs) => ({
+                tagName,
+                attribs: {
+                    ...attribs,
+                    sandbox: FORCED_IFRAME_SANDBOX,
+                    referrerpolicy: 'no-referrer',
+                },
+            }),
+        },
     });
 }
 

--- a/src/helpers/html.unit.test.ts
+++ b/src/helpers/html.unit.test.ts
@@ -53,6 +53,47 @@ describe('sanitizeHtml', () => {
         vi.mock('sanitize-html');
         vi.resetModules();
     });
+
+    it('should force a restrictive sandbox onto iframes, overriding any supplied value', async () => {
+        // Clear the mock and let the real implementation take over
+        vi.doUnmock('sanitize-html');
+        vi.resetModules();
+
+        await import('sanitize-html');
+        const { sanitizeHtml: realSanitizeHtml } = await import('./html');
+
+        const sandbox =
+            'allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-presentation allow-forms';
+
+        // Arbitrary embed host is kept, but gets our forced sandbox + referrerpolicy
+        expect(
+            realSanitizeHtml(
+                '<iframe src="https://codepen.io/x/embed/abc"></iframe>',
+            ),
+        ).toEqual(
+            `<iframe src="https://codepen.io/x/embed/abc" sandbox="${sandbox}" referrerpolicy="no-referrer"></iframe>`,
+        );
+
+        // An attacker-supplied loose sandbox is overridden, not merged
+        expect(
+            realSanitizeHtml(
+                '<iframe src="https://evil.example/phish" sandbox="allow-top-navigation allow-modals allow-same-origin"></iframe>',
+            ),
+        ).toEqual(
+            `<iframe src="https://evil.example/phish" sandbox="${sandbox}" referrerpolicy="no-referrer"></iframe>`,
+        );
+
+        // A javascript: src is stripped, leaving an inert (src-less) sandboxed iframe
+        expect(
+            realSanitizeHtml('<iframe src="javascript:alert(1)"></iframe>'),
+        ).toEqual(
+            `<iframe sandbox="${sandbox}" referrerpolicy="no-referrer"></iframe>`,
+        );
+
+        // Restore the mock for subsequent tests
+        vi.mock('sanitize-html');
+        vi.resetModules();
+    });
 });
 
 describe('normalizePlainText', () => {


### PR DESCRIPTION
Applies a fixed sandbox to iframes in sanitized content as a defence-in-depth hardening measure.