### PR TITLE
Stopped fetching remote actors for Delete activities from unknown senders

### DIFF
--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -102,6 +102,14 @@ export class AccountService {
     ) {}
 
     /**
+     * Get an Account by the ActivityPub ID from the database only —
+     * never fetches from the remote server
+     */
+    async getStoredByApId(id: URL): Promise<Account | null> {
+        return this.accountRepository.getByApId(id);
+    }
+
+    /**
      * @deprecated use `ensureByApId`
      * Get an Account by the ActivityPub ID
      * If it is not found locally in our database it will be

--- a/src/activity-handlers/delete.handler.ts
+++ b/src/activity-handlers/delete.handler.ts
@@ -1,4 +1,4 @@
-import type { Actor, Delete } from '@fedify/vocab';
+import type { Delete } from '@fedify/vocab';
 
 import type { Account } from '@/account/account.entity';
 import type { AccountService } from '@/account/account.service';
@@ -22,18 +22,8 @@ export class DeleteHandler {
             return;
         }
 
-        let sender: Actor | null = null;
-        try {
-            sender = await deleteActivity.getActor(ctx);
-        } catch (error) {
-            ctx.data.logger.debug(
-                'Error fetching sender from delete activity',
-                { error },
-            );
-            return;
-        }
-
-        if (sender === null || sender.id === null) {
+        const senderId = deleteActivity.actorId;
+        if (senderId === null) {
             ctx.data.logger.debug('Delete sender missing, exit early');
             return;
         }
@@ -43,10 +33,15 @@ export class DeleteHandler {
             return;
         }
 
+        // Deletes are fanned out to every site the deleted actor ever
+        // touched, so most reference an actor we have never stored — and
+        // fetching a deleted actor only yields a 410. Check the database
+        // before any network I/O and drop the activity if the sender is
+        // unknown.
         let senderAccount: Account | null = null;
 
         try {
-            senderAccount = await this.accountService.getByApId(sender.id);
+            senderAccount = await this.accountService.getStoredByApId(senderId);
         } catch (error) {
             ctx.data.logger.error('Error fetching sender account', { error });
             return;

--- a/src/activity-handlers/delete.handler.unit.test.ts
+++ b/src/activity-handlers/delete.handler.unit.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Delete } from '@fedify/vocab';
+
+import type { AccountService } from '@/account/account.service';
+import type { FedifyContext } from '@/app';
+import { error, ok } from '@/core/result';
+import type { PostService } from '@/post/post.service';
+import { createTestExternalAccount } from '@/test/account-entity-test-helpers';
+import { DeleteHandler } from './delete.handler';
+
+vi.mock('@/db', () => ({
+    getRelatedActivities: vi.fn().mockResolvedValue([]),
+}));
+
+import { getRelatedActivities } from '@/db';
+
+describe('DeleteHandler', () => {
+    let handler: DeleteHandler;
+    let mockPostService: PostService;
+    let mockAccountService: AccountService;
+    let mockContext: FedifyContext;
+    let mockLogger: {
+        debug: ReturnType<typeof vi.fn>;
+        error: ReturnType<typeof vi.fn>;
+    };
+    let mockGlobalDb: {
+        delete: ReturnType<typeof vi.fn>;
+    };
+
+    const senderApId = new URL('https://example.com/users/alice');
+    const objectApId = new URL('https://example.com/posts/123');
+
+    function createMockDelete(overrides: Partial<Delete> = {}): Delete {
+        return {
+            id: new URL('https://example.com/deletes/123'),
+            actorId: senderApId,
+            objectId: objectApId,
+            ...overrides,
+        } as unknown as Delete;
+    }
+
+    beforeEach(() => {
+        vi.mocked(getRelatedActivities).mockResolvedValue([]);
+
+        mockLogger = {
+            debug: vi.fn(),
+            error: vi.fn(),
+        };
+
+        mockGlobalDb = {
+            delete: vi.fn(),
+        };
+
+        mockPostService = {
+            deleteByApId: vi.fn().mockResolvedValue(ok(true)),
+        } as unknown as PostService;
+
+        mockAccountService = {
+            getStoredByApId: vi.fn().mockResolvedValue(null),
+        } as unknown as AccountService;
+
+        mockContext = {
+            data: {
+                logger: mockLogger,
+                globaldb: mockGlobalDb,
+            },
+            parseUri: vi.fn((url) => ({ type: 'object', id: url?.href })),
+        } as unknown as FedifyContext;
+
+        handler = new DeleteHandler(mockPostService, mockAccountService);
+    });
+
+    it('should ignore Delete activities with no id', async () => {
+        await handler.handle(mockContext, createMockDelete({ id: null }));
+
+        expect(mockAccountService.getStoredByApId).not.toHaveBeenCalled();
+        expect(mockPostService.deleteByApId).not.toHaveBeenCalled();
+    });
+
+    it('should ignore Delete activities with no actor', async () => {
+        await handler.handle(mockContext, createMockDelete({ actorId: null }));
+
+        expect(mockAccountService.getStoredByApId).not.toHaveBeenCalled();
+        expect(mockPostService.deleteByApId).not.toHaveBeenCalled();
+    });
+
+    it('should ignore Delete activities with no object id', async () => {
+        await handler.handle(mockContext, createMockDelete({ objectId: null }));
+
+        expect(mockAccountService.getStoredByApId).not.toHaveBeenCalled();
+        expect(mockPostService.deleteByApId).not.toHaveBeenCalled();
+    });
+
+    it('should drop Delete activities from senders we have not stored', async () => {
+        vi.mocked(mockAccountService.getStoredByApId).mockResolvedValue(null);
+
+        await handler.handle(mockContext, createMockDelete());
+
+        expect(mockAccountService.getStoredByApId).toHaveBeenCalledWith(
+            senderApId,
+        );
+        expect(mockPostService.deleteByApId).not.toHaveBeenCalled();
+        expect(mockGlobalDb.delete).not.toHaveBeenCalled();
+    });
+
+    it('should exit early if looking up the sender fails', async () => {
+        vi.mocked(mockAccountService.getStoredByApId).mockRejectedValue(
+            new Error('db down'),
+        );
+
+        await handler.handle(mockContext, createMockDelete());
+
+        expect(mockPostService.deleteByApId).not.toHaveBeenCalled();
+        expect(mockLogger.error).toHaveBeenCalledWith(
+            'Error fetching sender account',
+            { error: new Error('db down') },
+        );
+    });
+
+    it('should delete the post when the sender is a stored account', async () => {
+        const senderAccount = await createTestExternalAccount(456, {
+            username: 'alice',
+            name: 'Alice',
+            bio: null,
+            url: null,
+            avatarUrl: null,
+            bannerImageUrl: null,
+            customFields: null,
+            apId: senderApId,
+            apFollowers: null,
+            apInbox: new URL('https://example.com/users/alice/inbox'),
+        });
+        vi.mocked(mockAccountService.getStoredByApId).mockResolvedValue(
+            senderAccount,
+        );
+
+        await handler.handle(mockContext, createMockDelete());
+
+        expect(mockPostService.deleteByApId).toHaveBeenCalledWith(
+            objectApId,
+            senderAccount,
+        );
+    });
+
+    it('should remove related activities after a successful delete', async () => {
+        const senderAccount = await createTestExternalAccount(456, {
+            username: 'alice',
+            name: 'Alice',
+            bio: null,
+            url: null,
+            avatarUrl: null,
+            bannerImageUrl: null,
+            customFields: null,
+            apId: senderApId,
+            apFollowers: null,
+            apInbox: new URL('https://example.com/users/alice/inbox'),
+        });
+        vi.mocked(mockAccountService.getStoredByApId).mockResolvedValue(
+            senderAccount,
+        );
+        vi.mocked(getRelatedActivities).mockResolvedValue([
+            { id: 'activity-1' },
+            { id: 'activity-2' },
+        ]);
+
+        await handler.handle(mockContext, createMockDelete());
+
+        expect(getRelatedActivities).toHaveBeenCalledWith(objectApId.href);
+        expect(mockGlobalDb.delete).toHaveBeenCalledWith(['activity-1']);
+        expect(mockGlobalDb.delete).toHaveBeenCalledWith(['activity-2']);
+    });
+
+    it('should not remove related activities when the delete fails', async () => {
+        const senderAccount = await createTestExternalAccount(456, {
+            username: 'alice',
+            name: 'Alice',
+            bio: null,
+            url: null,
+            avatarUrl: null,
+            bannerImageUrl: null,
+            customFields: null,
+            apId: senderApId,
+            apFollowers: null,
+            apInbox: new URL('https://example.com/users/alice/inbox'),
+        });
+        vi.mocked(mockAccountService.getStoredByApId).mockResolvedValue(
+            senderAccount,
+        );
+        vi.mocked(mockPostService.deleteByApId).mockResolvedValue(
+            error('not-author'),
+        );
+
+        await handler.handle(mockContext, createMockDelete());
+
+        expect(mockGlobalDb.delete).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Problem

When an account on a large instance is deleted, the origin server fans the Delete activity out to every server the account ever touched. As a multitenant service we receive one copy per hosted site, so a single account deletion on mastodon.social can arrive hundreds of times within seconds — during one wave we received ~1,450 copies of Deletes for just two deleted accounts in about a minute, across ~670 hosted domains.

The Delete handler fetched the actor from the origin before doing anything else, and its fallback account lookup (the deprecated `AccountService.getByApId`) could trigger a second remote fetch — even creating an external account for actors we had never seen, only to then discover there was nothing to delete. For a deleted account those fetches can only return 410 Gone, so every copy burned an outbound request, logged a `Failed to fetch document: 410` error, and added memory pressure from JSON-LD processing. During the wave above, both the api and queue services exhausted their heap (`Ineffective mark-compacts near heap limit`), crashed with SIGSEGV, and failed in-flight requests with 503s.

## Solution

The handler now reads the sender id straight off the activity (`actorId`, already authenticated by HTTP/LD signature verification upstream) and checks the database before any network I/O, dropping the activity if the sender is unknown. This is the same approach Mastodon takes for Deletes from unknown accounts.

Nothing is lost by dropping early: any post we have stored also has its author stored (posts carry an author FK), so a Delete from an unknown sender never had anything to delete. Known-sender behaviour is unchanged and covered by the existing `handle-delete.feature` e2e scenarios; the handler also gains its first unit tests, covering the early exits, the unknown-sender drop, and the known-sender delete flow.

The lookup goes through a new `AccountService.getStoredByApId`, a local-only variant that never falls back to a remote fetch, since the existing service methods (`getByApId`, `ensureByApId`) both reach out to the origin when the account isn't stored.
