### PR TITLE
Skipped processing account deletion activities

### DIFF
--- a/src/activity-handlers/delete.handler.ts
+++ b/src/activity-handlers/delete.handler.ts
@@ -41,7 +41,9 @@ export class DeleteHandler {
         }
 
         if (isAccountDelete(deleteActivity)) {
-            ctx.data.logger.debug('Delete is an account deletion, exit early');
+            ctx.data.logger.debug(
+                'Delete activity is an account deletion, exit early',
+            );
             return;
         }
 

--- a/src/activity-handlers/delete.handler.ts
+++ b/src/activity-handlers/delete.handler.ts
@@ -7,6 +7,24 @@ import { exhaustiveCheck, getError, isError } from '@/core/result';
 import { getRelatedActivities } from '@/db';
 import type { PostService } from '@/post/post.service';
 
+/**
+ * Check whether a Delete activity is an account deletion, i.e. its object
+ * references the actor itself
+ *
+ * We don't process account deletions, and they are fanned out to every
+ * site the deleted account ever touched — so they must be recognised
+ * without any network I/O (the actor is deleted; fetching it can only
+ * return 410 Gone)
+ */
+function isAccountDelete(deleteActivity: Delete): boolean {
+    const objectId = deleteActivity.objectId;
+    const actorId = deleteActivity.actorId;
+
+    return (
+        objectId !== null && actorId !== null && objectId.href === actorId.href
+    );
+}
+
 export class DeleteHandler {
     constructor(
         private readonly postService: PostService,
@@ -19,6 +37,11 @@ export class DeleteHandler {
         ctx.data.logger.debug('Parsed delete object', { parsed });
         if (!deleteActivity.id) {
             ctx.data.logger.debug('Missing delete id - exit');
+            return;
+        }
+
+        if (isAccountDelete(deleteActivity)) {
+            ctx.data.logger.debug('Delete is an account deletion, exit early');
             return;
         }
 

--- a/src/activity-handlers/delete.handler.unit.test.ts
+++ b/src/activity-handlers/delete.handler.unit.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Delete, Note, Person } from '@fedify/vocab';
+
+import type { AccountService } from '@/account/account.service';
+import type { FedifyContext } from '@/app';
+import type { PostService } from '@/post/post.service';
+import { DeleteHandler } from './delete.handler';
+
+vi.mock('@/db', () => ({
+    getRelatedActivities: vi.fn().mockResolvedValue([]),
+}));
+
+describe('DeleteHandler', () => {
+    let handler: DeleteHandler;
+    let mockPostService: PostService;
+    let mockAccountService: AccountService;
+    let mockContext: FedifyContext;
+    let mockLogger: {
+        debug: ReturnType<typeof vi.fn>;
+        error: ReturnType<typeof vi.fn>;
+    };
+    let mockGlobalDb: {
+        delete: ReturnType<typeof vi.fn>;
+    };
+
+    const actorApId = new URL('https://example.com/users/alice');
+    const noteApId = new URL('https://example.com/notes/123');
+
+    const actor = new Person({ id: actorApId, preferredUsername: 'alice' });
+
+    beforeEach(() => {
+        mockLogger = {
+            debug: vi.fn(),
+            error: vi.fn(),
+        };
+
+        mockGlobalDb = {
+            delete: vi.fn(),
+        };
+
+        mockPostService = {
+            deleteByApId: vi.fn(),
+        } as unknown as PostService;
+
+        mockAccountService = {
+            getByApId: vi.fn().mockResolvedValue(null),
+        } as unknown as AccountService;
+
+        mockContext = {
+            data: {
+                logger: mockLogger,
+                globaldb: mockGlobalDb,
+            },
+            parseUri: vi.fn((url) => ({ type: 'object', id: url?.href })),
+        } as unknown as FedifyContext;
+
+        handler = new DeleteHandler(mockPostService, mockAccountService);
+    });
+
+    it('should ignore Delete activities with no id', async () => {
+        const deleteActivity = new Delete({
+            actor: actorApId,
+            object: noteApId,
+        });
+
+        await handler.handle(mockContext, deleteActivity);
+
+        expect(mockLogger.debug).toHaveBeenCalledWith(
+            'Missing delete id - exit',
+        );
+        expect(mockAccountService.getByApId).not.toHaveBeenCalled();
+    });
+
+    it('should ignore account deletions (object is the actor itself)', async () => {
+        const deleteActivity = new Delete({
+            id: new URL('https://example.com/users/alice#delete'),
+            actor: actorApId,
+            object: actorApId,
+        });
+
+        await handler.handle(mockContext, deleteActivity);
+
+        expect(mockLogger.debug).toHaveBeenCalledWith(
+            'Delete is an account deletion, exit early',
+        );
+        expect(mockAccountService.getByApId).not.toHaveBeenCalled();
+        expect(mockPostService.deleteByApId).not.toHaveBeenCalled();
+    });
+
+    it('should ignore account deletions with an embedded actor object', async () => {
+        const deleteActivity = new Delete({
+            id: new URL('https://example.com/users/alice#delete'),
+            actor: actorApId,
+            object: new Person({
+                id: actorApId,
+                preferredUsername: 'alice',
+            }),
+        });
+
+        await handler.handle(mockContext, deleteActivity);
+
+        expect(mockLogger.debug).toHaveBeenCalledWith(
+            'Delete is an account deletion, exit early',
+        );
+        expect(mockAccountService.getByApId).not.toHaveBeenCalled();
+        expect(mockPostService.deleteByApId).not.toHaveBeenCalled();
+    });
+
+    it('should not make any network requests for account deletions', async () => {
+        const fetchSpy = vi
+            .spyOn(globalThis, 'fetch')
+            .mockRejectedValue(new Error('network disabled in unit tests'));
+
+        try {
+            const deleteActivity = new Delete({
+                id: new URL('https://example.com/users/alice#delete'),
+                actor: actorApId,
+                object: actorApId,
+            });
+
+            await handler.handle(mockContext, deleteActivity);
+
+            expect(fetchSpy).not.toHaveBeenCalled();
+        } finally {
+            fetchSpy.mockRestore();
+        }
+    });
+
+    it('should process Delete activities whose object is a post URI', async () => {
+        // Our own outgoing Delete activities reference the post by URI only
+        const deleteActivity = new Delete({
+            id: new URL('https://example.com/deletes/123'),
+            actor,
+            object: noteApId,
+        });
+
+        await handler.handle(mockContext, deleteActivity);
+
+        expect(mockAccountService.getByApId).toHaveBeenCalledWith(actorApId);
+    });
+
+    it('should process Delete activities with an embedded post object', async () => {
+        const deleteActivity = new Delete({
+            id: new URL('https://example.com/deletes/123'),
+            actor,
+            object: new Note({ id: noteApId }),
+        });
+
+        await handler.handle(mockContext, deleteActivity);
+
+        expect(mockAccountService.getByApId).toHaveBeenCalledWith(actorApId);
+    });
+});

--- a/src/activity-handlers/delete.handler.unit.test.ts
+++ b/src/activity-handlers/delete.handler.unit.test.ts
@@ -100,7 +100,7 @@ describe('DeleteHandler', () => {
         await handler.handle(mockContext, deleteActivity);
 
         expect(mockLogger.debug).toHaveBeenCalledWith(
-            'Delete is an account deletion, exit early',
+            'Delete activity is an account deletion, exit early',
         );
         expect(mockAccountService.getByApId).not.toHaveBeenCalled();
         expect(mockPostService.deleteByApId).not.toHaveBeenCalled();
@@ -119,7 +119,7 @@ describe('DeleteHandler', () => {
         await handler.handle(mockContext, deleteActivity);
 
         expect(mockLogger.debug).toHaveBeenCalledWith(
-            'Delete is an account deletion, exit early',
+            'Delete activity is an account deletion, exit early',
         );
         expect(mockAccountService.getByApId).not.toHaveBeenCalled();
         expect(mockPostService.deleteByApId).not.toHaveBeenCalled();

--- a/src/activity-handlers/delete.handler.unit.test.ts
+++ b/src/activity-handlers/delete.handler.unit.test.ts
@@ -2,9 +2,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Delete, Note, Person } from '@fedify/vocab';
 
+import type { Account } from '@/account/account.entity';
 import type { AccountService } from '@/account/account.service';
 import type { FedifyContext } from '@/app';
+import { ok } from '@/core/result';
 import type { PostService } from '@/post/post.service';
+import { createTestExternalAccount } from '@/test/account-entity-test-helpers';
 import { DeleteHandler } from './delete.handler';
 
 vi.mock('@/db', () => ({
@@ -29,7 +32,22 @@ describe('DeleteHandler', () => {
 
     const actor = new Person({ id: actorApId, preferredUsername: 'alice' });
 
-    beforeEach(() => {
+    let senderAccount: Account;
+
+    beforeEach(async () => {
+        senderAccount = await createTestExternalAccount(456, {
+            username: 'alice',
+            name: 'Alice',
+            bio: null,
+            url: null,
+            avatarUrl: null,
+            bannerImageUrl: null,
+            customFields: null,
+            apId: actorApId,
+            apFollowers: null,
+            apInbox: new URL('https://example.com/users/alice/inbox'),
+        });
+
         mockLogger = {
             debug: vi.fn(),
             error: vi.fn(),
@@ -40,11 +58,11 @@ describe('DeleteHandler', () => {
         };
 
         mockPostService = {
-            deleteByApId: vi.fn(),
+            deleteByApId: vi.fn().mockResolvedValue(ok(true)),
         } as unknown as PostService;
 
         mockAccountService = {
-            getByApId: vi.fn().mockResolvedValue(null),
+            getByApId: vi.fn().mockResolvedValue(senderAccount),
         } as unknown as AccountService;
 
         mockContext = {
@@ -138,6 +156,10 @@ describe('DeleteHandler', () => {
         await handler.handle(mockContext, deleteActivity);
 
         expect(mockAccountService.getByApId).toHaveBeenCalledWith(actorApId);
+        expect(mockPostService.deleteByApId).toHaveBeenCalledWith(
+            noteApId,
+            senderAccount,
+        );
     });
 
     it('should process Delete activities with an embedded post object', async () => {
@@ -150,5 +172,9 @@ describe('DeleteHandler', () => {
         await handler.handle(mockContext, deleteActivity);
 
         expect(mockAccountService.getByApId).toHaveBeenCalledWith(actorApId);
+        expect(mockPostService.deleteByApId).toHaveBeenCalledWith(
+            noteApId,
+            senderAccount,
+        );
     });
 });


### PR DESCRIPTION
## Problem

When an account on a large instance is deleted, the origin server fans the Delete activity out to every server the account ever touched. As a multitenant service we receive one copy per hosted site, so a single account deletion on mastodon.social can arrive hundreds of times within seconds — during one wave we received ~1,450 copies of Deletes for just two deleted accounts in about a minute, across ~670 hosted domains.

The Delete handler fetched the actor from the origin before doing anything else, but a deleted account can only answer 410 Gone, so every copy burned an outbound request, logged a `Failed to fetch document: 410` error, and added memory pressure from JSON-LD processing. During the wave above, both the api and queue services exhausted their heap (`Ineffective mark-compacts near heap limit`), crashed with SIGSEGV, and failed in-flight requests with 503s.

## Solution

We don't process account deletions at all — the only Deletes we act on are post deletions — so the handler now recognises account deletions up front and returns immediately, before any network I/O.

An account deletion is identified by its shape alone: **the object references the actor itself**. This is deliberately a negative check rather than a positive "is the object a note or article" check, because the positive check can't be done reliably without fetching: the object of an incoming Delete is often a bare URI (our own outgoing Delete activities reference the post by URI only — see `fediverse-bridge.ts`), and fetching the object of a Delete is pointless since it's deleted. The object-equals-actor shape, by contrast, is how every major implementation expresses an account deletion, and comparing two ids that are already on the activity costs nothing.

The handler also gains its first unit tests, built on real `@fedify/vocab` instances: account deletions (bare-URI and embedded-actor shapes) are dropped without any `fetch` call (asserted via spy), while post deletions in both shapes we receive (bare URI, embedded object) still go through. The existing `handle-delete.feature` e2e scenarios cover that legitimate note deletions still work end-to-end.
