### PR TITLE
Capped the V8 heap at 75% of container memory to fix Node 24 OOMs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,6 @@ RUN pnpm build
 
 EXPOSE 8080
 
-CMD ["node", "dist/app.js"]
+# Node 24's default heap ceiling (~50% of container memory) is too small for
+# our working set and causes fatal heap OOMs; 75% leaves room for off-heap usage
+CMD ["node", "--max-old-space-size-percentage=75", "dist/app.js"]


### PR DESCRIPTION
## Problem

Since the Node 24 upgrade (#2013), instances have been intermittently aborting under load with:

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

killing any in-flight requests.

Node sizes V8's default heap ceiling at ~50% of available memory. Node 22's libuv could not read cgroup v2 memory limits and fell back to host memory, so the effective ceiling in a container was much larger than intended. Node 24's libuv reads the actual container limit, so the same workload in the same container now gets a much smaller heap ceiling - below our working set. Same code, same traffic, silently shrunk ceiling.

## Fix

Cap the heap explicitly with `--max-old-space-size-percentage=75` (new in Node 24):

- A fixed `--max-old-space-size` is a poor fit because this image runs in containers with different memory limits - a value sized for the largest would exceed the total memory of the smallest, trading heap OOMs for cgroup OOM-kills (SIGKILL, no error message)
- 75% restores headroom above the working set while leaving 25% for off-heap usage (Buffers, native allocations, thread stacks)
- An explicit value also makes the ceiling deterministic so a future runtime upgrade can't silently change it again

Verified against the pinned image that the flag takes effect and scales with the container's memory limit:

```sh
docker run --rm --memory=1g node:24.18.0-alpine \
  node --max-old-space-size-percentage=75 \
  -e 'console.log(require("v8").getHeapStatistics().heap_size_limit / 1048576)'
# 816 (vs 560 default)
```

## Not addressed here

If an instance's working set genuinely grows without bound, it will still OOM at the higher ceiling - that would indicate a leak to profile, not a ceiling to raise.