### PR TITLE
Added --no-async-context-frame to test the Node 24 heap-OOM hypothesis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,8 @@ RUN pnpm build
 EXPOSE 8080
 
 # Node 24's default heap ceiling (~50% of container memory) is too small for
-# our working set and causes fatal heap OOMs; 75% leaves room for off-heap usage
-CMD ["node", "--max-old-space-size-percentage=75", "dist/app.js"]
+# our working set and causes fatal heap OOMs; 75% leaves room for off-heap usage.
+# --no-async-context-frame reverts AsyncLocalStorage to the pre-Node-24
+# implementation, which we suspect of retaining per-request context and leaking
+# the heap on the inbound federation path
+CMD ["node", "--max-old-space-size-percentage=75", "--no-async-context-frame", "dist/app.js"]


### PR DESCRIPTION
## Problem

Since the Node 22 → 24 upgrade went out on July 22 (first crash ~09:15 UTC, one instance-lifetime after revision `00890` took traffic), the `external` service has been dying with `FATAL ERROR: ... JavaScript heap out of memory` and SIGSEGV, currently ~110–190 times a day. Every crash 503s whatever inbound federation requests are in flight — this is the source of the residual 5xx we've been seeing since the memory-limit and heap-cap mitigations landed.

The leak is throughput-proportional, not spike-driven: crashed instances served nothing but ordinary shared-inbox POSTs (normal Mastodon-dominated sender mix, 2–10 KB payloads), and die after roughly 2,000 requests regardless of wall-clock time (7–54 min observed, median ~19) — about 300–400 KB retained per inbox POST. The same application code and dependency set (including Fedify 2.3.2) ran leak-free on Node 22 right up to the upgrade, so the runtime change itself is the differentiator.

## Solution

Node 24 enabled the new `AsyncContextFrame` implementation of `AsyncLocalStorage` by default, and it has known memory-retention regressions. We lean on `AsyncLocalStorage` heavily — the logging `contextLocalStorage` in `app.ts`, the flag service, the Fedify context factory, plus Fedify's and LogTape's own internals — which makes it the prime suspect for per-request context being retained.

This adds `--no-async-context-frame` to the container entrypoint, reverting `AsyncLocalStorage` to the pre-Node-24 implementation while keeping the runtime and everything else identical. It's deliberately a single-variable experiment:

- if instance lifetimes recover after deploy, we've isolated the root cause, keep Node 24 with a one-line workaround, and can file a focused upstream issue;
- if crashes continue, the hypothesis is cheaply ruled out and the fallback remains the `revert-to-node22` branch.

The flag is validated against the exact production image version (`node --no-async-context-frame` on 24.18.0 boots and `AsyncLocalStorage` behaves normally).

Worth watching after deploy: `external` instance lifetimes / signal-11 rate, and whether the signal-9 container OOM kills on `queue` and `api` subside too (they look like the same growth hitting the container limit before the V8 cap).
