### PR TITLE
Fixed the Node 24 heap OOMs by vendoring x-forwarded-fetch without Blobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "sanitize-html": "2.17.6",
     "sharp": "0.35.3",
     "uuid": "14.0.1",
-    "x-forwarded-fetch": "0.2.0",
     "zod": "4.4.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,9 +116,6 @@ importers:
       uuid:
         specifier: 14.0.1
         version: 14.0.1
-      x-forwarded-fetch:
-        specifier: 0.2.0
-        version: 0.2.0
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -3857,9 +3854,6 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
-  x-forwarded-fetch@0.2.0:
-    resolution: {integrity: sha512-2qsguQrLHFvP3/rnvxSSaw3DlK9eOOx9iyL+Qv+1YH8jzq6nbRk+P6gyFFNdWanyusyCHuE3/CnX3+gmLeYEeg==}
 
   xml-naming@0.3.0:
     resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
@@ -7737,8 +7731,6 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
-
-  x-forwarded-fetch@0.2.0: {}
 
   xml-naming@0.3.0: {}
 

--- a/src/http/fetch-handler.ts
+++ b/src/http/fetch-handler.ts
@@ -1,6 +1,5 @@
-import { behindProxy } from 'x-forwarded-fetch';
-
 import { isLocalEnvironment } from '@/helpers/environment';
+import { behindProxy } from '@/http/x-forwarded-request';
 
 type FetchHandler = (request: Request) => Response | Promise<Response>;
 

--- a/src/http/fetch-handler.unit.test.ts
+++ b/src/http/fetch-handler.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { createFetchHandler } from './fetch-handler';
 
@@ -106,6 +106,45 @@ describe('createFetchHandler', () => {
             expect(request.headers.get('accept')).toBe(
                 'application/activity+json',
             );
+        }
+    });
+
+    it('should preserve the body of a POST request', async () => {
+        const body = JSON.stringify({ type: 'Create', id: 'https://a.b/c' });
+
+        const request = await dispatch(
+            'production',
+            new Request('http://example.com/inbox', {
+                method: 'POST',
+                headers: { 'content-type': 'application/ld+json' },
+                body,
+            }),
+        );
+
+        expect(request.method).toBe('POST');
+        expect(await request.text()).toBe(body);
+    });
+
+    // Node >= 24.16.0 permanently retains any body that goes through
+    // Blob.prototype.stream() (https://github.com/nodejs/node/issues/63574),
+    // which is why the vendored x-forwarded-request passes bytes instead of a
+    // Blob. Guard against the Blob path creeping back in.
+    it('should not stream the request body through a Blob', async () => {
+        const streamSpy = vi.spyOn(Blob.prototype, 'stream');
+
+        try {
+            await dispatch(
+                'production',
+                new Request('http://example.com/inbox', {
+                    method: 'POST',
+                    headers: { 'content-type': 'application/ld+json' },
+                    body: '{"type":"Like"}',
+                }),
+            );
+
+            expect(streamSpy).not.toHaveBeenCalled();
+        } finally {
+            streamSpy.mockRestore();
         }
     });
 });

--- a/src/http/x-forwarded-request.ts
+++ b/src/http/x-forwarded-request.ts
@@ -1,0 +1,64 @@
+type FetchHandler = (request: Request) => Response | Promise<Response>;
+
+/**
+ * Vendored replacement for the `x-forwarded-fetch` package (v0.2.0), which
+ * rebuilt the request with the body passed as `await request.blob()`. undici's
+ * `extractBody` turns a Blob body back into a stream via
+ * `Blob.prototype.stream()`, and Node >= 24.16.0 never releases that stream's
+ * reader-wakeup handle, permanently retaining every request body
+ * (https://github.com/nodejs/node/issues/63574). Since this wraps the whole
+ * app, each inbound POST leaked its body until the instance ran out of heap.
+ *
+ * Passing the body as plain bytes keeps the same fully-buffered semantics
+ * without ever creating a Blob. The upstream Node fix
+ * (https://github.com/nodejs/node/pull/63577) is not in any 24.x release yet;
+ * even once it ships, the bytes path stays preferable — it avoids an
+ * unnecessary copy on every request.
+ */
+export function behindProxy(fetch: FetchHandler): FetchHandler {
+    return async (request) => await fetch(await getXForwardedRequest(request));
+}
+
+/**
+ * Returns a new {@link Request} whose URL and Host reflect the
+ * `X-Forwarded-Proto` / `X-Forwarded-Host` headers, with those headers
+ * removed.
+ */
+export async function getXForwardedRequest(request: Request): Promise<Request> {
+    const url = new URL(request.url);
+    const headers = new Headers(request.headers);
+
+    const proto = request.headers.get('X-Forwarded-Proto');
+    if (proto !== null) {
+        url.protocol = `${proto}:`;
+        headers.delete('X-Forwarded-Proto');
+    }
+
+    const host = request.headers.get('X-Forwarded-Host');
+    if (host !== null) {
+        url.host = host;
+        const portMatch = host.match(/:(\d+)$/);
+        url.port = portMatch ? portMatch[1] : '';
+        headers.delete('X-Forwarded-Host');
+        headers.delete('Host');
+        headers.set('Host', host);
+    }
+
+    return new Request(url, {
+        method: request.method,
+        headers,
+        body:
+            request.method === 'GET' || request.method === 'HEAD'
+                ? undefined
+                : new Uint8Array(await request.arrayBuffer()),
+        referrer: 'referrer' in request ? request.referrer : undefined,
+        referrerPolicy: request.referrerPolicy,
+        mode: request.mode,
+        credentials: request.credentials,
+        cache: request.cache,
+        redirect: request.redirect,
+        integrity: request.integrity,
+        keepalive: request.keepalive,
+        signal: request.signal,
+    });
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,1 +1,0 @@
-declare module 'x-forwarded-fetch';


### PR DESCRIPTION
## Problem

Since the Node 22 → 24.18.0 upgrade on July 22, all services have leaked memory until crashing — `external` roughly every 20 minutes (~180 SIGSEGVs/day from fatal heap OOMs), `queue`/`api` via container OOM kills — 503ing whatever federation requests were in flight.

The root cause is a Node core regression: Node ≥ 24.16.0 never releases the reader-wakeup handle that `Blob.prototype.stream()` registers, so any body that flows through a Blob is pinned forever by a strong V8 global handle (nodejs/node#63574 — heap snapshots show `GC roots → Global handles → Blob → DataQueue → InMemoryEntry → BackingStore`, with no JS retainer). The fix (nodejs/node#63577) merged to `main` on July 9 but has not shipped in any 24.x release.

Our single path into that API is `x-forwarded-fetch`, which wraps the entire app (`behindProxy` in `fetch-handler.ts`) and rebuilds every request with its body passed as `await request.blob()`. undici's `extractBody` converts a Blob body back into a stream via `Blob.stream()` — so every inbound POST leaked its body: the inbox delivery *and* the Pub/Sub push, ~2 leaked bodies per federated activity. Runtime tracing confirmed this is the only Blob creation/stream site in the app (100/100 sampled requests).

## Solution

Vendor the 40-line helper as `src/http/x-forwarded-request.ts` and pass the body as plain bytes (`new Uint8Array(await request.arrayBuffer())`) instead of a Blob — identical fully-buffered semantics, but undici extracts bytes directly and `Blob.stream()` is never called. The `x-forwarded-fetch` dependency and its `types.d.ts` shim are removed.

Validated by load-testing the production image (`node:24.18.0`) with 4,000 synthetic inbound activities per run, measuring post-GC retained heap:

| variant | retained heap / 4,000 requests | pinned Blob chains |
| --- | --- | --- |
| unpatched 24.18.0 | +41.7 MB | 8,400 |
| **this change on 24.18.0** | **+23.0 MB** | **0** |
| 24.15.0 control (pre-regression) | +22.7 MB | 2 |

The patched run is indistinguishable from the pre-regression Node version, with all activities accepted and processed. A unit test now guards against the body flowing through `Blob.stream()` again.

**Why vendor rather than wait or patch elsewhere:** reverting to Node 22 was ruled out; pinning 24.15.0 would drop the June security patches; and the 24.x backport of the Node fix has no release date. Even once it ships, the bytes path stays preferable — the Blob round-trip added a redundant full-body copy on every request on every Node version. The vendored file links the upstream issue so the workaround can be revisited later.
