### PR TITLE
🎨 Cleaned up activitypub migrations image

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ See [AGENTS.md](AGENTS.md) for the full list and testing conventions.
 
 Run `pnpm migrate` to apply pending `up` migrations against your dev db (this also happens automatically on `pnpm dev`). For the testing db, use `docker compose run migrate-testing up`.
 
-To run other `migrate` commands, drop into a shell with `docker compose exec -it migrate /bin/bash` (or `migrate-testing`). The `migrate` binary is available there, along with a `MYSQL_DB` environment variable correctly formatted for the `-database` argument.
+To run other `migrate` commands, drop into a shell with `docker compose exec -it migrate /bin/sh` (or `migrate-testing`). The `migrate` binary is available there, along with a `MYSQL_DB` environment variable correctly formatted for the `-database` argument.
 
 &nbsp;
 

--- a/migrate/Dockerfile
+++ b/migrate/Dockerfile
@@ -1,18 +1,13 @@
-FROM docker.io/library/debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818
-ARG TARGETARCH
+FROM docker.io/library/alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
-RUN apt-get update -y && \
-    apt-get install -y curl && \
-    rm -rf /var/lib/apt/lists/* && \
-    curl -fsSL -O https://github.com/golang-migrate/migrate/releases/download/v4.17.1/migrate.linux-${TARGETARCH}.tar.gz && \
-    curl -fsSL -O https://github.com/golang-migrate/migrate/releases/download/v4.17.1/sha256sum.txt && \
-    grep " migrate.linux-${TARGETARCH}.tar.gz$" sha256sum.txt | sha256sum -c - && \
-    tar xvzf migrate.linux-${TARGETARCH}.tar.gz migrate && \
-    rm migrate.linux-${TARGETARCH}.tar.gz sha256sum.txt && \
-    mv migrate /usr/bin/
+# Binary is copied from golang-migrate's published image rather than their
+# release tarball so Renovate tracks the digest. Not used as a base: it sets
+# ENTRYPOINT ["migrate"] and runs on a different version of Alpine.
+COPY --from=docker.io/migrate/migrate:v4.17.1@sha256:de154de4b7f9d0d751aacb1ec6023f5fc96f874eb88b65d050f761a33376aa4b /usr/local/bin/migrate /usr/bin/migrate
 
 COPY bin /usr/local/bin
 
+# bin/up and bin/create use a relative `migrations` path, so cwd stays at /.
 COPY ./migrations /migrations
 
 ENV MYSQL_DB=""

--- a/migrate/bin/create
+++ b/migrate/bin/create
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 echo "Running migrate create -ext sql -dir migrations -seq $1"
-migrate create -ext sql -dir migrations -seq $1 
+migrate create -ext sql -dir migrations -seq "$1"

--- a/migrate/bin/up
+++ b/migrate/bin/up
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 if [ -n "$MYSQL_DB" ]; then
-    echo "Running migrate -path migrations -database $MYSQL_DB up"
+    echo "Running migrate -path migrations -database <REDACTED> up"
     migrate -path migrations -database "$MYSQL_DB" up
 elif [ -n "$DB_HOST" ]; then
     echo "Running migrate -path migrations -database mysql://$DB_USER:<REDACTED>@tcp($DB_HOST:$DB_PORT)/$DB_NAME up"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-278/optimize-activitypub-migrations-docker-build
- switch base to alpine
- copy migrate binary from migrate image rather than curl from github

related to #2062 - shrinks the migration image from 228MB => 82.4MB on disk.