### PR TITLE
Changed Renovate config to require manual review for ioredis majors

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -36,6 +36,25 @@
       ]
     },
 
+    // ioredis is the client underneath @fedify/redis, whose updates are
+    // already held for manual review above — but an ioredis bump rides in its
+    // own PR, so a major can silently re-pair @fedify/redis with a client
+    // version outside its declared peer range (pnpm only warns). ioredis
+    // majors also change wire-level behaviour (e.g. v6 switched the default
+    // protocol to RESP3) that CI can't fully vet: the e2e Redis is a
+    // plaintext single-node cluster, so TLS and multi-node redirect paths
+    // are only ever exercised in production. Minors/patches still automerge.
+    {
+      description: 'Require manual review for ioredis major updates',
+      matchPackageNames: [
+        'ioredis',
+      ],
+      matchUpdateTypes: [
+        'major',
+      ],
+      automerge: false,
+    },
+
     // CI installs Node from .nvmrc while production runs the Dockerfile base
     // image, so any update that moves one without the other leaves CI testing
     // a runtime production doesn't run. Group ALL Node updates (base image +


### PR DESCRIPTION
## Problem

ioredis updates ride the shared preset's automerge-everything rule, so a major version lands on main — and ships to production — with no human in the loop. [#2076](https://github.com/TryGhost/ActivityPub/pull/2076) (ioredis 5 → 6, closed) showed why that's the wrong default for this dependency:

- ioredis is the client underneath `@fedify/redis`, whose own updates are already carved out for manual review. But an ioredis bump arrives in its own PR, so a major can silently re-pair `@fedify/redis` with a client version outside its declared peer range (`^5.8.2` vs v6) — pnpm only warns, so nothing fails at install time and the untested pairing ships.
- Majors can change wire-level behaviour (v6 switched the default protocol to RESP3 and replaced the parser) that CI structurally cannot vet: the e2e Redis is a plaintext, authless, single-node cluster, so the TLS and multi-node redirect paths that production exercises never run before merge.

## Solution

Added a package rule that disables automerge for ioredis **major** updates only, with an inline comment capturing the reasoning above. Renovate applies repo `packageRules` after the preset's, so this rule wins over the blanket automerge. Minor and patch updates keep automerging as before, and the scoping to majors keeps the noise-reduction intent of the shared preset intact.
