### PR TITLE
Let Docker majors automerge, except for production runtimes

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,14 +2,14 @@
   extends: [
     'github>tryghost/renovate-config',
     'docker:pinDigests',
-    'docker:disableMajor',
   ],
-  // Automerge during EU office hours only (Monday - Thursday, 07:00 - 16:59 UTC)
-  // Why? Merging to main ships to production, so we want to avoid automerging when no engineer is online
+  // Only automerge during EU office hours (Monday–Thursday, 07:00–16:59 UTC).
+  // Merging to main ships straight to production, so we don't want anything
+  // landing while there's no engineer around to pick it up.
   //
-  // Notes:
-  // - this schedule doesn't restrict when the PRs are opened by Renovate, only when they are merged
-  // - automerge schedule works only if we're using Renovate automerge over platform automerge (Github)
+  // Two things to know. The schedule controls when PRs merge, not when
+  // Renovate opens them. And it only works while we use Renovate's own
+  // automerge rather than GitHub's, which is what platformAutomerge turns off.
   platformAutomerge: false,
   automergeSchedule: [
     '* 7-16 * * 1,2,3,4',
@@ -26,7 +26,7 @@
       automerge: true,
     },
 
-    // Group Fedify updates together and require a manual review
+    // Fedify packages move together, and we review every update by hand.
     {
       groupName: 'Fedify packages',
       groupSlug: 'fedify',
@@ -36,17 +36,43 @@
       ]
     },
 
-    // ioredis is the client underneath @fedify/redis, whose updates are
-    // already held for manual review above — but an ioredis bump rides in its
-    // own PR, so a major can silently re-pair @fedify/redis with a client
-    // version outside its declared peer range (pnpm only warns). ioredis
-    // majors also change wire-level behaviour (e.g. v6 switched the default
-    // protocol to RESP3) that CI can't fully vet: the e2e Redis is a
-    // plaintext single-node cluster, so TLS and multi-node redirect paths
-    // are only ever exercised in production. Minors/patches still automerge.
+    // MySQL, Redis, and Node back real production services, so we review
+    // their majors by hand.
+    //
+    // Everything else in docker-compose is test scaffolding — wiremock,
+    // caddy, jaeger, the Pub/Sub emulator. When one of those breaks, CI goes
+    // red and we know right away, so their majors can automerge. These three
+    // are different: production pins their versions outside this repo, so
+    // bumping an image here keeps CI green while quietly testing against a
+    // runtime we don't run. That's the drift worth catching.
+    //
+    // Each server is grouped with its client so the pair moves in one PR.
+    // Minors and patches still automerge.
     {
-      description: 'Require manual review for ioredis major updates',
-      matchPackageNames: [
+      description: 'Review MySQL majors by hand — server image and mysql2 client move together',
+      groupName: 'MySQL',
+      groupSlug: 'mysql',
+      matchDepNames: [
+        'mysql',
+        'mysql2',
+      ],
+      matchUpdateTypes: [
+        'major',
+      ],
+      automerge: false,
+    },
+
+    // Redis needs the extra care. ioredis is the client under @fedify/redis,
+    // and a major can pair it with a version outside that peer range — pnpm
+    // only warns. Majors also change wire-level behavior: v6 switched the
+    // default protocol to RESP3. Our e2e Redis is a plaintext single-node
+    // cluster, so TLS and multi-node redirects only ever run in production.
+    {
+      description: 'Review Redis majors by hand — server image and ioredis client move together',
+      groupName: 'Redis',
+      groupSlug: 'redis',
+      matchDepNames: [
+        'redis',
         'ioredis',
       ],
       matchUpdateTypes: [
@@ -55,14 +81,13 @@
       automerge: false,
     },
 
-    // CI installs Node from .nvmrc while production runs the Dockerfile base
-    // image, so any update that moves one without the other leaves CI testing
-    // a runtime production doesn't run. Group ALL Node updates (base image +
-    // .nvmrc) into a single, manually reviewed PR: enabled overrides
-    // docker:disableMajor for majors, and automerge overrides the blanket
-    // docker automerge rule above so a base-image bump can't ship on its own.
+    // Node gets the strictest treatment of the three. CI installs Node from
+    // .nvmrc, production runs the Dockerfile base image, and moving one
+    // without the other leaves CI testing a runtime we don't ship. So every
+    // Node update lands in one reviewed PR — not just majors — and a
+    // base-image bump can never go out on its own.
     {
-      description: 'Group Node.js updates (Dockerfile base image + .nvmrc)',
+      description: 'Review every Node update by hand — base image and .nvmrc move together',
       groupName: 'Node.js',
       groupSlug: 'node',
       matchDepNames: [
@@ -72,14 +97,13 @@
         'docker',
         'node-version',
       ],
-      enabled: true,
       automerge: false,
     },
 
-    // Pin @types/node to the deployed Node runtime major (see Dockerfile and
-    // .nvmrc). Bumping the typings ahead of the runtime lets the compiler
-    // accept newer-Node APIs that don't exist in the production runtime. Bump
-    // allowedVersions in lockstep when the Node base image is upgraded.
+    // Keep @types/node on the Node major we actually deploy (see Dockerfile
+    // and .nvmrc). Typings ahead of the runtime let the compiler accept APIs
+    // that production doesn't have. When the Node base image moves, bump
+    // allowedVersions with it.
     {
       description: 'Pin @types/node to the deployed Node runtime major',
       matchPackageNames: [


### PR DESCRIPTION
We automerge major updates everywhere else. npm dependencies and GitHub Actions both come through `github>tryghost/renovate-config`, which turns automerge on for every update type:

```json5
// Automerge all dependency updates (major, minor, and patch)
{ "matchDepTypes": ["dependencies", "devDependencies", …, "action"],
  "automerge": true, "automergeType": "pr" }
```

Docker was the one exception, because `docker:disableMajor` switched its majors off entirely.

That exception just cost us a red `main`. The Pub/Sub emulator sat on `google-cloud-cli` 499.0.0 for 22 months, because every release of a calendar-versioned image reads as a major and Renovate never proposed one. Google eventually pruned the image from gcr.io and CI stopped starting at all.

## What changes

Dropping `docker:disableMajor` brings Docker in line with everything else. Three images get held back for review instead:

| Group | Covers | Held for review |
|---|---|---|
| MySQL | `mysql` image + `mysql2` | Majors |
| Redis | `redis` image + `ioredis` | Majors |
| Node.js | `node` image + `.nvmrc` | Every update |

The split is about how a bad bump shows up:

```mermaid
flowchart TD
    A[Docker major available] --> B{Backs a production service?}
    B -->|"No — wiremock, caddy,<br/>jaeger, Pub/Sub emulator"| C[Automerge]
    B -->|"Yes — MySQL, Redis, Node"| D[Group with its client]
    D --> E[Review by hand]
    C --> F{Bad bump?}
    F -->|CI goes red| G[We find out right away]
    E --> H{Bad bump?}
    H -->|CI stays green| I[Drift is invisible —<br/>this is what review catches]
```

When test scaffolding breaks, CI goes red and we know right away, so those majors are safe to automerge. MySQL, Redis and Node back services whose production versions live outside this repo, so a bump here keeps CI green while quietly testing against a runtime we don't run. That's the failure mode worth a human look, and it's the same reasoning already behind the existing Node rule.

Grouping each server with its client means the pair moves in one PR rather than two that automerge independently. That also covers the near-miss in #2076, where an `ioredis` v6 major was queued to automerge on its own — it could have re-paired `@fedify/redis` with a client outside its peer range, which pnpm only warns about.

## Notes

- Minors and patches are unaffected and still automerge
- Fedify is untouched and still requires review on every update — I confirmed against Renovate's own PR bodies, which report `Automerge: Disabled by config` on #2134 versus `Automerge: Enabled` on a normal dependency PR
- `enabled: true` on the Node rule is gone, since it only existed to override `docker:disableMajor`
- Validated with `renovate-config-validator`, and the resolved rules are unchanged apart from the additions above
- Also rewrote the comments in this file so they explain the reasoning rather than restate the config
