### PR TITLE
Fixed CI by moving the Pub/Sub emulator to a version that still exists

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       retries: 120
 
   pubsub:
-    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:499.0.0-emulators@sha256:38606e0ec8b892ff2be6fb7238c6b98e7b0b69f60ed433fa2b196bdf4646caf9
+    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:582.0.0-emulators@sha256:d343049a5b3fc0c880a51412ba0c53a3f6a3fc727978cef52931ea5f6fda5b9f
     command: /bin/bash -c "/opt/activitypub/start-pubsub.sh"
     volumes:
       - ./dev/pubsub/start.sh:/opt/activitypub/start-pubsub.sh
@@ -248,7 +248,7 @@ services:
   pubsub-testing:
     networks:
       - test_network
-    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:499.0.0-emulators@sha256:38606e0ec8b892ff2be6fb7238c6b98e7b0b69f60ed433fa2b196bdf4646caf9
+    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:582.0.0-emulators@sha256:d343049a5b3fc0c880a51412ba0c53a3f6a3fc727978cef52931ea5f6fda5b9f
     command: /bin/bash -c "/opt/activitypub/start-pubsub.sh"
     volumes:
       - ./dev/pubsub/start.sh:/opt/activitypub/start-pubsub.sh


### PR DESCRIPTION
Every job that starts the Docker Compose stack has been failing since Google pruned `google-cloud-cli` 499.0.0 from gcr.io:

```
manifest for gcr.io/google.com/cloudsdktool/google-cloud-cli@sha256:38606e0e…
not found: manifest unknown: Requested entity was not found.
```

Both Vitest and E2E die before a single test runs, so `main` and every open PR are red. The last green run was #2137 yesterday at 09:43 UTC.

gcr.io keeps a rolling window of roughly 48 emulator tags, and 537.0.0 is now the oldest one left. Our pin from November 2024 finally fell off the end of it — the repository itself is healthy, and `latest`, `stable`, and `emulators` all still resolve. Only the exact version we pinned is gone, along with its digest.

Moved both the dev and testing services to `582.0.0-emulators`. That's a big jump, so I checked the emulator still does what `dev/pubsub/start.sh` expects rather than assuming:

- All four topics come up: `dead-letter-topic`, `fedify-topic`, `fedify-retry-topic`, `ghost-topic`
- All three subscriptions come up, and keep their `deadLetterPolicy` (5 delivery attempts) and `retryPolicy` (1s–20s backoff)

Renovate never offered a newer version because `docker:disableMajor` hid every one of these calendar-versioned releases. That's fixed separately in #2148 so the pin can't quietly go stale again.
