### PR TITLE
Stopped Renovate reopening the Redis major PR after we close it

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -79,6 +79,7 @@
         'major',
       ],
       automerge: false,
+      recreateWhen: 'never',
     },
 
     // Node gets the strictest treatment of the three. CI installs Node from


### PR DESCRIPTION
ref #2148

We've closed the Redis major PR three times now and it has come back every time — #2153, then #2155, then #2156 — each one carrying the "Immortal: this PR will be recreated if closed unmerged" banner.

That banner isn't arbitrary. Renovate records a closure as "this branch with this title was rejected", and it refuses to trust that record when the PR's contents can shift underneath it. A grouped PR whose members move to different versions is exactly that case: our Redis group pairs ioredis `5.11.1 -> 6.0.0` with the redis image `7-alpine -> 8-alpine`, which trips the check in `generateBranchConfig` and marks the branch immortal.

```mermaid
flowchart TD
    A[PR closed unmerged] --> B{Grouped PR?}
    B -->|No| C["Title names a version<br/>'Update dependency ky to v2.1.0'"]
    C --> D[Closure is durable — stays closed]
    B -->|Yes| E{Members moving to<br/>different versions?}
    E -->|No| D
    E -->|Yes| F["Contents shift as any member moves,<br/>so branch + title can't record<br/>what we rejected"]
    F --> G[Immortal — recreated on the next run]
    G -.->|recreateWhen: 'never'| D
```

This also explains why the other majors we closed that day stayed closed: ubuntu (#2154) and mysql (#2152) were single-dep PRs whose titles name a version, so their closures mean something durable.

`recreateWhen: 'never'` on the rule tells Renovate to honour the closure anyway. Two things worth knowing about that:

- This group's title has no version in it ("Update Redis (major)"), so closing the PR now silences later Redis majors under the same title. The Dependency Dashboard lists it with a checkbox that forces the PR back, which is the escape hatch when we do want to do the upgrade.
- Only Redis gets the setting. MySQL and Node are grouped the same way and could develop the same behaviour if both members ever take majors at differing versions, but neither has, and a rule that isn't earning its place is a rule someone has to reason about later.

