### PR TITLE
Capped future published dates when adding posts to feeds

### DIFF
--- a/src/feed/feed.service.integration.test.ts
+++ b/src/feed/feed.service.integration.test.ts
@@ -1569,6 +1569,33 @@ describe('FeedService', () => {
             expect(feedEntry).toBeTruthy();
             expect(feedEntry.published_at).toEqual(originalPublishDate);
         });
+
+        it('should cap a future published date at the current time', async () => {
+            const feedService = new FeedService(client, moderationService);
+
+            const authorAccount = await createInternalAccount(
+                'future-post-author.com',
+            );
+
+            const oneDayFromNow = new Date(Date.now() + 24 * 60 * 60 * 1000);
+            const post = await createPost(authorAccount, {
+                audience: Audience.Public,
+                publishedAt: oneDayFromNow,
+            });
+            await postRepository.save(post);
+
+            await feedService.addPostToFeeds(post as PublicPost);
+
+            const feed = await getFeedDataForAccount(authorAccount);
+
+            expect(feed).toHaveLength(1);
+            expect(feed[0].published_at.getTime()).toBeLessThanOrEqual(
+                Date.now(),
+            );
+            expect(feed[0].published_at.getTime()).toBeGreaterThan(
+                Date.now() - 60 * 1000,
+            );
+        });
     });
 
     describe('addPostToDiscoveryFeeds', () => {
@@ -1629,6 +1656,47 @@ describe('FeedService', () => {
                 author_id: authorAccount.id,
                 post_type: PostType.Article,
             });
+        });
+
+        it('should cap a future published date at the current time', async () => {
+            const feedService = new FeedService(client, moderationService);
+
+            const authorAccount = await createInternalAccount(
+                'discovery-future-author.com',
+            );
+
+            const [topicId] = await client('topics').insert({
+                name: 'Technology',
+                slug: 'technology',
+            });
+
+            await client('account_topics').insert({
+                account_id: authorAccount.id,
+                topic_id: topicId,
+            });
+
+            const oneDayFromNow = new Date(Date.now() + 24 * 60 * 60 * 1000);
+            const article = await createPost(authorAccount, {
+                type: PostType.Article,
+                audience: Audience.Public,
+                publishedAt: oneDayFromNow,
+            });
+            await postRepository.save(article);
+
+            await feedService.addPostToDiscoveryFeeds(article as PublicPost);
+
+            const discoveryFeeds = await client('discovery_feeds').where(
+                'post_id',
+                article.id,
+            );
+
+            expect(discoveryFeeds).toHaveLength(1);
+            expect(
+                discoveryFeeds[0].published_at.getTime(),
+            ).toBeLessThanOrEqual(Date.now());
+            expect(discoveryFeeds[0].published_at.getTime()).toBeGreaterThan(
+                Date.now() - 60 * 1000,
+            );
         });
 
         it('should NOT add notes to discovery feeds', async () => {

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -10,6 +10,17 @@ import {
 } from '@/post/post.entity';
 export type FeedType = 'Inbox' | 'Feed';
 
+/**
+ * Publishers control the published date of their posts, so a post can claim a
+ * date in the future — capping the feed ranking timestamp prevents such posts
+ * from sticking to the top of feeds until real time catches up with them
+ */
+function capAtNow(date: Date): Date {
+    const now = new Date();
+
+    return date > now ? now : date;
+}
+
 interface GetFeedDataOptions {
     /**
      * ID of the account associated with the user to get the feed for
@@ -426,7 +437,7 @@ export class FeedService {
 
         const discoveryFeedEntries = topics.map((t) => ({
             post_type: post.type,
-            published_at: post.publishedAt,
+            published_at: capAtNow(post.publishedAt),
             topic_id: t.topic_id,
             post_id: post.id,
             author_id: post.author.id,
@@ -534,7 +545,9 @@ export class FeedService {
         const feedEntries = userIds.map((userId) => ({
             post_type: post.type,
             published_at:
-                repostedBy && repost ? repost.created_at : post.publishedAt,
+                repostedBy && repost
+                    ? repost.created_at
+                    : capAtNow(post.publishedAt),
             audience: post.audience,
             user_id: userId,
             post_id: post.id,


### PR DESCRIPTION
Publishers control the published date of their posts: the Ghost Admin API and content imports accept arbitrary dates, and remote fediverse servers can claim any date they like. Both the main feed and the discovery feeds sort by `published_at` descending, so a post dated in the future pins itself to the top of every page — and sits above every pagination cursor — until real time catches up with its claimed date.

The ranking timestamp is now capped at the current time when a post is inserted into `feeds` and `discovery_feeds`.

Capping happens at the feed layer rather than on the post itself because `post.publishedAt` is canonical data that we re-emit in outgoing ActivityPub objects, and rewriting it would make our copy of a post disagree with its origin server. The feed tables' `published_at` is already a denormalised ranking column, so "when should this sort in a timeline" is exactly the semantic it owns. This mirrors how other fediverse servers handle it — Mastodon orders timelines by receipt time precisely so remote content can't choose its own rank.

Repost entries are unaffected: they already rank by the repost's own `created_at`, which we generate ourselves.

Note that rows inserted before this change keep their future dates, so any posts currently pinned will stay pinned until their claimed dates pass or the rows are cleaned up separately.
