### PR TITLE
Excluded posts with a published date set in the future from feeds

### DIFF
--- a/src/feed/feed.service.integration.test.ts
+++ b/src/feed/feed.service.integration.test.ts
@@ -322,8 +322,8 @@ describe('FeedService', () => {
             );
 
             await accountService.recordAccountFollow(
-                followedAccount as unknown as AccountType,
-                userAccount as unknown as AccountType,
+                followedAccount,
+                userAccount,
             );
 
             const pastPost = await createPost(followedAccount, {

--- a/src/feed/feed.service.integration.test.ts
+++ b/src/feed/feed.service.integration.test.ts
@@ -311,6 +311,48 @@ describe('FeedService', () => {
             ]);
         });
 
+        it('should not return posts with a published date in the future', async () => {
+            const feedService = new FeedService(client, moderationService);
+
+            const userAccount = await createInternalAccount(
+                'future-filter-user.com',
+            );
+            const followedAccount = await createInternalAccount(
+                'future-filter-followed.com',
+            );
+
+            await accountService.recordAccountFollow(
+                followedAccount as unknown as AccountType,
+                userAccount as unknown as AccountType,
+            );
+
+            const pastPost = await createPost(followedAccount, {
+                audience: Audience.Public,
+                publishedAt: new Date('2024-01-01T10:00:00Z'),
+            });
+            await postRepository.save(pastPost);
+
+            const oneDayFromNow = new Date(Date.now() + 24 * 60 * 60 * 1000);
+            const futurePost = await createPost(followedAccount, {
+                audience: Audience.Public,
+                publishedAt: oneDayFromNow,
+            });
+            await postRepository.save(futurePost);
+
+            await feedService.addPostToFeeds(pastPost as PublicPost);
+            await feedService.addPostToFeeds(futurePost as PublicPost);
+
+            const feed = await feedService.getFeedData({
+                accountId: userAccount.id!,
+                feedType: 'Inbox',
+                limit: 10,
+                cursor: null,
+            });
+
+            expect(feed.results).toHaveLength(1);
+            expect(feed.results[0].post_id).toEqual(pastPost.id);
+        });
+
         it('should correctly set followedByMe flag for authors', async () => {
             const feedService = new FeedService(client, moderationService);
 
@@ -674,6 +716,55 @@ describe('FeedService', () => {
             expect(businessFeed.results).toHaveLength(2);
             expect(businessFeed.results[0].post_id).toBe(businessPost2.id); // Jan 4
             expect(businessFeed.results[1].post_id).toBe(businessPost1.id); // Jan 2
+        });
+
+        it('should not return posts with a published date in the future', async () => {
+            const feedService = new FeedService(client, moderationService);
+
+            const viewerAccount = await createInternalAccount(
+                'discovery-future-viewer.com',
+            );
+            const authorAccount = await createInternalAccount(
+                'discovery-future-author.com',
+            );
+
+            const [topicId] = await client('topics').insert({
+                name: 'Technology',
+                slug: 'technology',
+            });
+
+            await client('account_topics').insert({
+                account_id: authorAccount.id,
+                topic_id: topicId,
+            });
+
+            const pastPost = await createPost(authorAccount, {
+                type: PostType.Article,
+                audience: Audience.Public,
+                publishedAt: new Date('2024-01-01T10:00:00Z'),
+            });
+            await postRepository.save(pastPost);
+
+            const oneDayFromNow = new Date(Date.now() + 24 * 60 * 60 * 1000);
+            const futurePost = await createPost(authorAccount, {
+                type: PostType.Article,
+                audience: Audience.Public,
+                publishedAt: oneDayFromNow,
+            });
+            await postRepository.save(futurePost);
+
+            await feedService.addPostToDiscoveryFeeds(pastPost as PublicPost);
+            await feedService.addPostToDiscoveryFeeds(futurePost as PublicPost);
+
+            const feed = await feedService.getDiscoveryFeedData(
+                topicId,
+                viewerAccount.id,
+                10,
+                null,
+            );
+
+            expect(feed.results).toHaveLength(1);
+            expect(feed.results[0].post_id).toEqual(pastPost.id);
         });
 
         it('should sanitize posts before rendering in discovery feeds', async () => {

--- a/src/feed/feed.service.integration.test.ts
+++ b/src/feed/feed.service.integration.test.ts
@@ -311,91 +311,6 @@ describe('FeedService', () => {
             ]);
         });
 
-        it('should not return posts with a published date in the future', async () => {
-            const feedService = new FeedService(client, moderationService);
-
-            const userAccount = await createInternalAccount(
-                'future-filter-user.com',
-            );
-            const followedAccount = await createInternalAccount(
-                'future-filter-followed.com',
-            );
-
-            await accountService.recordAccountFollow(
-                followedAccount,
-                userAccount,
-            );
-
-            const pastPost = await createPost(followedAccount, {
-                audience: Audience.Public,
-                publishedAt: new Date('2024-01-01T10:00:00Z'),
-            });
-            await postRepository.save(pastPost);
-
-            const oneDayFromNow = new Date(Date.now() + 24 * 60 * 60 * 1000);
-            const futurePost = await createPost(followedAccount, {
-                audience: Audience.Public,
-                publishedAt: oneDayFromNow,
-            });
-            await postRepository.save(futurePost);
-
-            await feedService.addPostToFeeds(pastPost as PublicPost);
-            await feedService.addPostToFeeds(futurePost as PublicPost);
-
-            const feed = await feedService.getFeedData({
-                accountId: userAccount.id!,
-                feedType: 'Inbox',
-                limit: 10,
-                cursor: null,
-            });
-
-            expect(feed.results).toHaveLength(1);
-            expect(feed.results[0].post_id).toEqual(pastPost.id);
-        });
-
-        it('should not return reposts of posts with a published date in the future', async () => {
-            const feedService = new FeedService(client, moderationService);
-
-            const userAccount = await createInternalAccount(
-                'future-repost-user.com',
-            );
-            const reposterAccount = await createInternalAccount(
-                'future-repost-reposter.com',
-            );
-            const authorAccount = await createInternalAccount(
-                'future-repost-author.com',
-            );
-
-            await accountService.recordAccountFollow(
-                reposterAccount,
-                userAccount,
-            );
-
-            const oneDayFromNow = new Date(Date.now() + 24 * 60 * 60 * 1000);
-            const futurePost = await createPost(authorAccount, {
-                audience: Audience.Public,
-                publishedAt: oneDayFromNow,
-            });
-            await postRepository.save(futurePost);
-
-            futurePost.addRepost(reposterAccount);
-            await postRepository.save(futurePost);
-
-            await feedService.addPostToFeeds(
-                futurePost as PublicPost,
-                reposterAccount.id,
-            );
-
-            const feed = await feedService.getFeedData({
-                accountId: userAccount.id!,
-                feedType: 'Inbox',
-                limit: 10,
-                cursor: null,
-            });
-
-            expect(feed.results).toHaveLength(0);
-        });
-
         it('should correctly set followedByMe flag for authors', async () => {
             const feedService = new FeedService(client, moderationService);
 
@@ -759,55 +674,6 @@ describe('FeedService', () => {
             expect(businessFeed.results).toHaveLength(2);
             expect(businessFeed.results[0].post_id).toBe(businessPost2.id); // Jan 4
             expect(businessFeed.results[1].post_id).toBe(businessPost1.id); // Jan 2
-        });
-
-        it('should not return posts with a published date in the future', async () => {
-            const feedService = new FeedService(client, moderationService);
-
-            const viewerAccount = await createInternalAccount(
-                'discovery-future-viewer.com',
-            );
-            const authorAccount = await createInternalAccount(
-                'discovery-future-author.com',
-            );
-
-            const [topicId] = await client('topics').insert({
-                name: 'Technology',
-                slug: 'technology',
-            });
-
-            await client('account_topics').insert({
-                account_id: authorAccount.id,
-                topic_id: topicId,
-            });
-
-            const pastPost = await createPost(authorAccount, {
-                type: PostType.Article,
-                audience: Audience.Public,
-                publishedAt: new Date('2024-01-01T10:00:00Z'),
-            });
-            await postRepository.save(pastPost);
-
-            const oneDayFromNow = new Date(Date.now() + 24 * 60 * 60 * 1000);
-            const futurePost = await createPost(authorAccount, {
-                type: PostType.Article,
-                audience: Audience.Public,
-                publishedAt: oneDayFromNow,
-            });
-            await postRepository.save(futurePost);
-
-            await feedService.addPostToDiscoveryFeeds(pastPost as PublicPost);
-            await feedService.addPostToDiscoveryFeeds(futurePost as PublicPost);
-
-            const feed = await feedService.getDiscoveryFeedData(
-                topicId,
-                viewerAccount.id,
-                10,
-                null,
-            );
-
-            expect(feed.results).toHaveLength(1);
-            expect(feed.results[0].post_id).toEqual(pastPost.id);
         });
 
         it('should sanitize posts before rendering in discovery feeds', async () => {
@@ -1379,6 +1245,67 @@ describe('FeedService', () => {
     });
 
     describe('addPostToFeeds', () => {
+        it('should not add posts with a published date in the future', async () => {
+            const feedService = new FeedService(client, moderationService);
+
+            const authorAccount = await createInternalAccount(
+                'future-post-author.com',
+            );
+
+            const oneDayFromNow = new Date(Date.now() + 24 * 60 * 60 * 1000);
+            const futurePost = await createPost(authorAccount, {
+                audience: Audience.Public,
+                publishedAt: oneDayFromNow,
+            });
+            await postRepository.save(futurePost);
+
+            const updatedUserIds = await feedService.addPostToFeeds(
+                futurePost as PublicPost,
+            );
+
+            expect(updatedUserIds).toHaveLength(0);
+
+            const feedEntries = await client('feeds').where(
+                'post_id',
+                futurePost.id,
+            );
+            expect(feedEntries).toHaveLength(0);
+        });
+
+        it('should not add reposts of posts with a published date in the future', async () => {
+            const feedService = new FeedService(client, moderationService);
+
+            const authorAccount = await createInternalAccount(
+                'future-repost-author.com',
+            );
+            const reposterAccount = await createInternalAccount(
+                'future-repost-reposter.com',
+            );
+
+            const oneDayFromNow = new Date(Date.now() + 24 * 60 * 60 * 1000);
+            const futurePost = await createPost(authorAccount, {
+                audience: Audience.Public,
+                publishedAt: oneDayFromNow,
+            });
+            await postRepository.save(futurePost);
+
+            futurePost.addRepost(reposterAccount);
+            await postRepository.save(futurePost);
+
+            const updatedUserIds = await feedService.addPostToFeeds(
+                futurePost as PublicPost,
+                reposterAccount.id,
+            );
+
+            expect(updatedUserIds).toHaveLength(0);
+
+            const feedEntries = await client('feeds').where(
+                'post_id',
+                futurePost.id,
+            );
+            expect(feedEntries).toHaveLength(0);
+        });
+
         it('should add a post to the feeds of the users that should see it', async () => {
             const feedService = new FeedService(client, moderationService);
 
@@ -1763,6 +1690,40 @@ describe('FeedService', () => {
                 author_id: authorAccount.id,
                 post_type: PostType.Article,
             });
+        });
+
+        it('should not add posts with a published date in the future', async () => {
+            const feedService = new FeedService(client, moderationService);
+
+            const authorAccount = await createInternalAccount(
+                'discovery-future-author.com',
+            );
+
+            const [topicId] = await client('topics').insert({
+                name: 'Technology',
+                slug: 'technology',
+            });
+
+            await client('account_topics').insert({
+                account_id: authorAccount.id,
+                topic_id: topicId,
+            });
+
+            const oneDayFromNow = new Date(Date.now() + 24 * 60 * 60 * 1000);
+            const futurePost = await createPost(authorAccount, {
+                type: PostType.Article,
+                audience: Audience.Public,
+                publishedAt: oneDayFromNow,
+            });
+            await postRepository.save(futurePost);
+
+            await feedService.addPostToDiscoveryFeeds(futurePost as PublicPost);
+
+            const discoveryFeeds = await client('discovery_feeds').where(
+                'post_id',
+                futurePost.id,
+            );
+            expect(discoveryFeeds).toHaveLength(0);
         });
 
         it('should NOT add notes to discovery feeds', async () => {

--- a/src/feed/feed.service.integration.test.ts
+++ b/src/feed/feed.service.integration.test.ts
@@ -353,6 +353,49 @@ describe('FeedService', () => {
             expect(feed.results[0].post_id).toEqual(pastPost.id);
         });
 
+        it('should not return reposts of posts with a published date in the future', async () => {
+            const feedService = new FeedService(client, moderationService);
+
+            const userAccount = await createInternalAccount(
+                'future-repost-user.com',
+            );
+            const reposterAccount = await createInternalAccount(
+                'future-repost-reposter.com',
+            );
+            const authorAccount = await createInternalAccount(
+                'future-repost-author.com',
+            );
+
+            await accountService.recordAccountFollow(
+                reposterAccount,
+                userAccount,
+            );
+
+            const oneDayFromNow = new Date(Date.now() + 24 * 60 * 60 * 1000);
+            const futurePost = await createPost(authorAccount, {
+                audience: Audience.Public,
+                publishedAt: oneDayFromNow,
+            });
+            await postRepository.save(futurePost);
+
+            futurePost.addRepost(reposterAccount);
+            await postRepository.save(futurePost);
+
+            await feedService.addPostToFeeds(
+                futurePost as PublicPost,
+                reposterAccount.id,
+            );
+
+            const feed = await feedService.getFeedData({
+                accountId: userAccount.id!,
+                feedType: 'Inbox',
+                limit: 10,
+                cursor: null,
+            });
+
+            expect(feed.results).toHaveLength(0);
+        });
+
         it('should correctly set followedByMe flag for authors', async () => {
             const feedService = new FeedService(client, moderationService);
 

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -5,19 +5,10 @@ import { sanitizeHtml } from '@/helpers/html';
 import type { ModerationService } from '@/moderation/moderation.service';
 import {
     type FollowersOnlyPost,
-    type Post,
     PostType,
     type PublicPost,
 } from '@/post/post.entity';
 export type FeedType = 'Inbox' | 'Feed';
-
-/**
- * Posts with a published_at date set in the future are not rendered on
- * feeds, else they would pin themselves to the top
- */
-function publishedDateInFuture(post: Post): boolean {
-    return post.publishedAt > new Date();
-}
 
 interface GetFeedDataOptions {
     /**
@@ -425,7 +416,9 @@ export class FeedService {
             return [];
         }
 
-        if (publishedDateInFuture(post)) {
+        // Posts with a published_at date set in the future are not rendered
+        // on feeds, else they would pin themselves to the top
+        if (post.publishedAt > new Date()) {
             return [];
         }
 
@@ -485,7 +478,9 @@ export class FeedService {
             return [];
         }
 
-        if (publishedDateInFuture(post)) {
+        // Posts with a published_at date set in the future are not rendered
+        // on feeds, else they would pin themselves to the top
+        if (post.publishedAt > new Date()) {
             return [];
         }
 

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -243,6 +243,9 @@ export class FeedService {
             // their claimed date passes, otherwise they would stick to the
             // top of the feed
             .where('feeds.published_at', '<=', new Date())
+            // For reposts, feeds.published_at holds the repost date, so the
+            // post's own claimed date needs checking too
+            .where('posts.published_at', '<=', new Date())
             .modify((query) => {
                 if (options.cursor) {
                     query.where('feeds.published_at', '<', options.cursor);

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -5,16 +5,17 @@ import { sanitizeHtml } from '@/helpers/html';
 import type { ModerationService } from '@/moderation/moderation.service';
 import {
     type FollowersOnlyPost,
+    type Post,
     PostType,
     type PublicPost,
 } from '@/post/post.entity';
 export type FeedType = 'Inbox' | 'Feed';
 
 /**
- * Publishers control published_at and can claim a future date — such posts
- * are never added to feeds, otherwise they would pin themselves to the top
+ * Posts with a published_at date set in the future are not rendered on
+ * feeds, else they would pin themselves to the top
  */
-function claimsFutureDate(post: PublicPost | FollowersOnlyPost): boolean {
+function publishedDateInFuture(post: Post): boolean {
     return post.publishedAt > new Date();
 }
 
@@ -424,7 +425,7 @@ export class FeedService {
             return [];
         }
 
-        if (claimsFutureDate(post)) {
+        if (publishedDateInFuture(post)) {
             return [];
         }
 
@@ -484,7 +485,7 @@ export class FeedService {
             return [];
         }
 
-        if (claimsFutureDate(post)) {
+        if (publishedDateInFuture(post)) {
             return [];
         }
 

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -11,12 +11,11 @@ import {
 export type FeedType = 'Inbox' | 'Feed';
 
 /**
- * Publishers control published_at and can claim a future date — hide such
- * posts until that date passes so they cannot pin themselves to the top
- * of a feed
+ * Publishers control published_at and can claim a future date — such posts
+ * are never added to feeds, otherwise they would pin themselves to the top
  */
-function excludePostsClaimingFutureDates(query: Knex.QueryBuilder) {
-    query.where('posts.published_at', '<=', new Date());
+function claimsFutureDate(post: PublicPost | FollowersOnlyPost): boolean {
+    return post.publishedAt > new Date();
 }
 
 interface GetFeedDataOptions {
@@ -247,7 +246,6 @@ export class FeedService {
             })
             .whereRaw('feeds.user_id = ?', [userId])
             .where('feeds.post_type', postType)
-            .modify(excludePostsClaimingFutureDates)
             .modify((query) => {
                 if (options.cursor) {
                     query.where('feeds.published_at', '<', options.cursor);
@@ -386,7 +384,6 @@ export class FeedService {
             })
             .whereRaw('discovery_feeds.topic_id = ?', [topicId])
             .where('discovery_feeds.post_type', postType)
-            .modify(excludePostsClaimingFutureDates)
             .whereNull('blocks.id')
             .whereNull('domain_blocks.id')
             .modify((query) => {
@@ -424,6 +421,10 @@ export class FeedService {
         }
 
         if (post.inReplyTo) {
+            return [];
+        }
+
+        if (claimsFutureDate(post)) {
             return [];
         }
 
@@ -480,6 +481,10 @@ export class FeedService {
 
         // If the post is a reply, we should not add it to any feeds
         if (post.inReplyTo) {
+            return [];
+        }
+
+        if (claimsFutureDate(post)) {
             return [];
         }
 

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -10,6 +10,15 @@ import {
 } from '@/post/post.entity';
 export type FeedType = 'Inbox' | 'Feed';
 
+/**
+ * Publishers control published_at and can claim a future date — hide such
+ * posts until that date passes so they cannot pin themselves to the top
+ * of a feed
+ */
+function excludePostsClaimingFutureDates(query: Knex.QueryBuilder) {
+    query.where('posts.published_at', '<=', new Date());
+}
+
 interface GetFeedDataOptions {
     /**
      * ID of the account associated with the user to get the feed for
@@ -238,14 +247,7 @@ export class FeedService {
             })
             .whereRaw('feeds.user_id = ?', [userId])
             .where('feeds.post_type', postType)
-            // Publishers control the published date of their posts, so a post
-            // can claim a date in the future — such posts are hidden until
-            // their claimed date passes, otherwise they would stick to the
-            // top of the feed
-            .where('feeds.published_at', '<=', new Date())
-            // For reposts, feeds.published_at holds the repost date, so the
-            // post's own claimed date needs checking too
-            .where('posts.published_at', '<=', new Date())
+            .modify(excludePostsClaimingFutureDates)
             .modify((query) => {
                 if (options.cursor) {
                     query.where('feeds.published_at', '<', options.cursor);
@@ -384,11 +386,7 @@ export class FeedService {
             })
             .whereRaw('discovery_feeds.topic_id = ?', [topicId])
             .where('discovery_feeds.post_type', postType)
-            // Publishers control the published date of their posts, so a post
-            // can claim a date in the future — such posts are hidden until
-            // their claimed date passes, otherwise they would stick to the
-            // top of the feed
-            .where('discovery_feeds.published_at', '<=', new Date())
+            .modify(excludePostsClaimingFutureDates)
             .whereNull('blocks.id')
             .whereNull('domain_blocks.id')
             .modify((query) => {

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -238,6 +238,11 @@ export class FeedService {
             })
             .whereRaw('feeds.user_id = ?', [userId])
             .where('feeds.post_type', postType)
+            // Publishers control the published date of their posts, so a post
+            // can claim a date in the future — such posts are hidden until
+            // their claimed date passes, otherwise they would stick to the
+            // top of the feed
+            .where('feeds.published_at', '<=', new Date())
             .modify((query) => {
                 if (options.cursor) {
                     query.where('feeds.published_at', '<', options.cursor);
@@ -376,6 +381,11 @@ export class FeedService {
             })
             .whereRaw('discovery_feeds.topic_id = ?', [topicId])
             .where('discovery_feeds.post_type', postType)
+            // Publishers control the published date of their posts, so a post
+            // can claim a date in the future — such posts are hidden until
+            // their claimed date passes, otherwise they would stick to the
+            // top of the feed
+            .where('discovery_feeds.published_at', '<=', new Date())
             .whereNull('blocks.id')
             .whereNull('domain_blocks.id')
             .modify((query) => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1977

Posts can have a published_at date set in the future: the Ghost Admin API and content imports accept arbitrary dates, and remote fediverse servers can claim any date they like. Both the main feed and the discovery feeds sort by `published_at` descending, so a post dated in the future pins itself to the top of every page — and sits above every pagination cursor — until real time catches up with its claimed date.

Posts claiming a future published date are now never added to feeds or discovery feeds.

Filtering at write time was chosen over a read-time predicate because the feed read queries are tuned so every `where()` is served by an index, and correctness would require checking `posts.published_at` — repost entries store the repost date in `feeds.published_at`, so the feed tables' own timestamp cannot catch a reposted future-dated post. A read-time check on the joined `posts` row would discard rows after the join, making worst-case query cost depend on how many future-dated rows a publisher creates. With the write-time guard the read queries are untouched.

The trade-off is that a future-dated post is excluded outright rather than deferred until its claimed date passes. That's the intended treatment: a published post dated in the future is a value only abuse or misconfiguration produces, and either way it shouldn't surface later as if legitimate.

Future-dated rows that already made it into the feed tables are handled separately as a one-off data cleanup.
