### PR TITLE
Fixed remote custom handle discovery via WebFinger subject

### DIFF
--- a/src/account/account.repository.knex.integration.test.ts
+++ b/src/account/account.repository.knex.integration.test.ts
@@ -799,6 +799,25 @@ describe('KnexAccountRepository', () => {
         ).resolves.toBe(false);
     });
 
+    it('does not resolve a WebFinger handle held by an external account', async () => {
+        const externalAccount = await fixtureManager.createExternalAccount(
+            'https://john.onolan.org/',
+        );
+
+        await client('accounts')
+            .update({ webfinger_host: 'onolan.org' })
+            .where('id', externalAccount.id);
+
+        // We do not host this account, so answering WebFinger for its handle
+        // would point callers at another server from our own domain
+        const fetched = await accountRepository.getByWebfingerHandle(
+            externalAccount.username,
+            'onolan.org',
+        );
+
+        expect(fetched).toBeNull();
+    });
+
     it('resolves a custom WebFinger host by stable actor username', async () => {
         const site = await fixtureManager.createSite('blog.example.com');
         const draftData = await createInternalAccountDraftData({

--- a/src/account/account.repository.knex.integration.test.ts
+++ b/src/account/account.repository.knex.integration.test.ts
@@ -782,6 +782,10 @@ describe('KnexAccountRepository', () => {
         const updated = account.setWebfingerHost('example.com');
 
         await accountRepository.save(updated);
+        await accountRepository.updateWebfingerHost(
+            updated.id,
+            updated.webfingerHost,
+        );
 
         const fetched = await accountRepository.getByWebfingerHandle(
             'index',
@@ -797,6 +801,37 @@ describe('KnexAccountRepository', () => {
                 account.id,
             ),
         ).resolves.toBe(false);
+    });
+
+    it('does not overwrite webfinger_host on a profile save', async () => {
+        const site = await fixtureManager.createSite('blog.example.com');
+        const draftData = await createInternalAccountDraftData({
+            host: new URL(`https://${site.host}`),
+            username: 'index',
+            name: 'Test',
+            bio: null,
+            url: new URL(`https://${site.host}`),
+            avatarUrl: null,
+            bannerImageUrl: null,
+            customFields: null,
+        });
+
+        // Created with webfingerHost null — stands in for a concurrent save
+        // that loaded the row before updateWebfingerHost completed.
+        const account = await accountRepository.create(
+            AccountEntity.draft(draftData),
+        );
+
+        await accountRepository.updateWebfingerHost(account.id, 'example.com');
+
+        await accountRepository.save(
+            account.updateProfile({ name: 'Renamed' }),
+        );
+
+        const row = await client('accounts').where({ id: account.id }).first();
+
+        expect(row.name).toBe('Renamed');
+        expect(row.webfinger_host).toBe('example.com');
     });
 
     it('does not resolve a WebFinger handle held by an external account', async () => {
@@ -839,6 +874,10 @@ describe('KnexAccountRepository', () => {
             .updateProfile({ username: 'alice' });
 
         await accountRepository.save(updated);
+        await accountRepository.updateWebfingerHost(
+            updated.id,
+            updated.webfingerHost,
+        );
 
         const fetched = await accountRepository.getByWebfingerHandle(
             'index',

--- a/src/account/account.repository.knex.ts
+++ b/src/account/account.repository.knex.ts
@@ -106,6 +106,10 @@ export class KnexAccountRepository {
     async save(account: Account): Promise<void> {
         const events = AccountEntity.pullEvents(account);
         await this.db.transaction(async (transaction) => {
+            // webfinger_host is intentionally omitted: a concurrent
+            // updateWebfingerHost must not be overwritten by a stale
+            // in-memory snapshot from a profile / follow / block save.
+            // Callers that mean to change the host use updateWebfingerHost.
             const rows = await transaction('accounts')
                 .update({
                     name: account.name,
@@ -116,7 +120,6 @@ export class KnexAccountRepository {
                     custom_fields: account.customFields
                         ? JSON.stringify(account.customFields)
                         : null,
-                    webfinger_host: account.webfingerHost,
                 })
                 .where({ id: account.id });
 
@@ -501,8 +504,10 @@ export class KnexAccountRepository {
     /**
      * Update only the `webfinger_host` column
      *
-     * Used by refresh paths that resolve the host over the network, so a stale
-     * in-memory entity cannot overwrite concurrently updated profile fields.
+     * Sole writer of this column after create. Kept separate from `save()` so a
+     * stale in-memory entity cannot overwrite a host another path just
+     * resolved, and so a host refresh cannot overwrite concurrent profile
+     * fields.
      */
     async updateWebfingerHost(
         accountId: number,

--- a/src/account/account.repository.knex.ts
+++ b/src/account/account.repository.knex.ts
@@ -20,6 +20,7 @@ import {
 } from '@/account/events';
 import type { AsyncEvents } from '@/core/events';
 import { parseURL } from '@/core/url';
+import { accountMatchesDomain } from '@/moderation/domain-blocks';
 import type { Site } from '@/site/site.service';
 
 interface AccountRow {
@@ -189,9 +190,8 @@ export class KnexAccountRepository {
                             'accounts.id',
                         )
                         .where('follows.follower_id', blockerId)
-                        .whereRaw(
-                            'accounts.domain_hash = UNHEX(SHA2(LOWER(?), 256))',
-                            [domainHostname],
+                        .where(
+                            accountMatchesDomain(transaction, domainHostname),
                         )
                         .delete();
 
@@ -204,9 +204,8 @@ export class KnexAccountRepository {
                             'accounts.id',
                         )
                         .where('follows.following_id', blockerId)
-                        .whereRaw(
-                            'accounts.domain_hash = UNHEX(SHA2(LOWER(?), 256))',
-                            [domainHostname],
+                        .where(
+                            accountMatchesDomain(transaction, domainHostname),
                         )
                         .delete();
                 } else if (event instanceof DomainUnblockedEvent) {

--- a/src/account/account.repository.knex.ts
+++ b/src/account/account.repository.knex.ts
@@ -445,6 +445,14 @@ export class KnexAccountRepository {
         return rows.map((row) => new URL(row.ap_id));
     }
 
+    /**
+     * Look up an internal account by its WebFinger handle
+     *
+     * Scoped to internal accounts because callers use this to decide what this
+     * server answers WebFinger for, and which handles a new site may claim.
+     * External accounts can also hold a `webfinger_host`, but those handles are
+     * served by the instance the account actually lives on.
+     */
     async getByWebfingerHandle(
         username: string,
         host: string,
@@ -462,7 +470,7 @@ export class KnexAccountRepository {
                 'accounts.webfinger_host_hash = UNHEX(SHA2(LOWER(?), 256))',
                 [host],
             )
-            .leftJoin('users', 'users.account_id', 'accounts.id')
+            .innerJoin('users', 'users.account_id', 'accounts.id')
             .select(
                 'accounts.id',
                 'accounts.uuid',
@@ -489,6 +497,21 @@ export class KnexAccountRepository {
         }
 
         return this.mapRowToAccountEntity(accountRow);
+    }
+
+    /**
+     * Update only the `webfinger_host` column
+     *
+     * Used by refresh paths that resolve the host over the network, so a stale
+     * in-memory entity cannot overwrite concurrently updated profile fields.
+     */
+    async updateWebfingerHost(
+        accountId: number,
+        webfingerHost: string | null,
+    ): Promise<void> {
+        await this.db('accounts')
+            .update({ webfinger_host: webfingerHost })
+            .where({ id: accountId });
     }
 
     async hasWebfingerHandleConflict(

--- a/src/account/account.service.integration.test.ts
+++ b/src/account/account.service.integration.test.ts
@@ -56,6 +56,10 @@ vi.mock('@fedify/vocab', async () => {
     };
 });
 
+vi.mock('@fedify/webfinger', () => ({
+    lookupWebFinger: vi.fn().mockResolvedValue(null),
+}));
+
 describe('AccountService', () => {
     let service: AccountService;
     let events: AsyncEvents;

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -37,6 +37,7 @@ import { isHandle } from '@/helpers/activitypub/actor';
 import {
     lookupObject as lookupActivityPubObject,
     lookupActorProfile,
+    resolveExternalWebfingerHost,
 } from '@/lookup-helpers';
 
 interface GetFollowingAccountsOptions {
@@ -110,7 +111,7 @@ export class AccountService {
     async getByApId(id: URL): Promise<Account | null> {
         const account = await this.accountRepository.getByApId(id);
         if (account) {
-            return account;
+            return this.refreshExternalWebfingerHostIfMissing(account);
         }
 
         const context = this.fedifyContextFactory.getFedifyContext();
@@ -133,6 +134,10 @@ export class AccountService {
         }
 
         const data = await mapActorToExternalAccountData(potentialActor);
+        data.webfinger_host = await this.resolveWebfingerHostForExternal(
+            data.username,
+            new URL(data.ap_id),
+        );
 
         await this.createExternalAccount(data);
 
@@ -144,7 +149,9 @@ export class AccountService {
     ): Promise<Result<Account, RemoteAccountFetchError>> {
         const account = await this.accountRepository.getByApId(id);
         if (account) {
-            return ok(account);
+            return ok(
+                await this.refreshExternalWebfingerHostIfMissing(account),
+            );
         }
 
         const context = this.fedifyContextFactory.getFedifyContext();
@@ -188,6 +195,11 @@ export class AccountService {
         } catch (_err) {
             return error('invalid-data');
         }
+
+        data.webfinger_host = await this.resolveWebfingerHostForExternal(
+            data.username,
+            new URL(data.ap_id),
+        );
 
         await this.createExternalAccount(data);
 
@@ -423,6 +435,89 @@ export class AccountService {
     }
 
     /**
+     * Resolve the WebFinger handle host for a remote actor.
+     *
+     * Returns the custom subject host when present. When WebFinger confirms the
+     * actor host is canonical, returns that host so callers can persist it and
+     * skip re-resolving on later ensureByApId calls. Returns null only when
+     * lookup fails (caller should leave any existing value unchanged).
+     */
+    private async resolveWebfingerHostForExternal(
+        username: string,
+        apId: URL,
+    ): Promise<string | null> {
+        const resolution = await resolveExternalWebfingerHost(username, apId);
+        if (resolution.type === 'custom') {
+            return resolution.host;
+        }
+        if (resolution.type === 'default') {
+            return normalizeWebfingerHost(apId.host);
+        }
+        return null;
+    }
+
+    /**
+     * One-shot backfill for external accounts that predate remote WebFinger
+     * persistence. Once a host is stored (custom or confirmed default), further
+     * ensureByApId calls skip the lookup. custom→custom changes still arrive via
+     * actor Update → {@link refreshExternalWebfingerHost}.
+     */
+    private async refreshExternalWebfingerHostIfMissing(
+        account: Account,
+    ): Promise<Account> {
+        if (account.isInternal || account.webfingerHost !== null) {
+            return account;
+        }
+
+        return this.refreshExternalWebfingerHost(account);
+    }
+
+    /**
+     * Re-resolve and persist the WebFinger subject host for an external account.
+     * Lookup failures leave the stored value unchanged.
+     */
+    async refreshExternalWebfingerHost(account: Account): Promise<Account> {
+        if (account.isInternal) {
+            return account;
+        }
+
+        const nextHost = await this.resolveWebfingerHostForExternal(
+            account.username,
+            account.apId,
+        );
+
+        if (nextHost === null || nextHost === account.webfingerHost) {
+            return account;
+        }
+
+        const actorHost = normalizeWebfingerHost(account.apId.host);
+        if (nextHost !== actorHost) {
+            const conflict =
+                await this.accountRepository.hasWebfingerHandleConflict(
+                    account.username,
+                    nextHost,
+                    account.id,
+                );
+
+            if (conflict) {
+                return account;
+            }
+        }
+
+        const updated = account.setWebfingerHost(nextHost);
+        try {
+            await this.accountRepository.save(updated);
+        } catch (err) {
+            if (isDuplicateEntryError(err)) {
+                return account;
+            }
+            throw err;
+        }
+
+        return updated;
+    }
+
+    /**
      * Create an internal account
      *
      * An internal account is an account that is linked to a user
@@ -562,7 +657,7 @@ export class AccountService {
             uuid: randomUUID(),
             ap_private_key: null,
             domain: new URL(accountData.ap_id).host,
-            webfinger_host: null,
+            webfinger_host: accountData.webfinger_host ?? null,
         };
 
         try {
@@ -579,10 +674,20 @@ export class AccountService {
                     ])
                     .first<AccountType>();
 
-                if (!existingAccount) {
-                    throw error;
+                if (existingAccount) {
+                    return existingAccount;
                 }
-                return existingAccount;
+
+                // Likely a webfinger_host uniqueness conflict — retry without
+                // the custom host rather than failing account creation.
+                if (dataToInsert.webfinger_host) {
+                    return this.createExternalAccount({
+                        ...accountData,
+                        webfinger_host: null,
+                    });
+                }
+
+                throw error;
             }
             throw error;
         }
@@ -930,6 +1035,10 @@ export class AccountService {
         const updated = account.updateProfile(profileData);
 
         await this.accountRepository.save(updated);
+
+        if (!account.isInternal) {
+            await this.refreshExternalWebfingerHost(updated);
+        }
 
         return ok(true);
     }

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -533,7 +533,7 @@ export class AccountService {
 
             if (conflict) {
                 getLogger(['activitypub']).warn(
-                    'WebFinger handle @{username}@{host} for {apId} is already held by another account, leaving host unchanged',
+                    'WebFinger handle @{username}@{host} for {apId} is already held by another account, falling back to actor host',
                     {
                         username: account.username,
                         host: nextHost,
@@ -541,10 +541,9 @@ export class AccountService {
                     },
                 );
 
-                // After a rename the previous host was verified for a different
-                // local-part. Refuse to keep it attached to the new username
-                // when the newly resolved host cannot be claimed.
-                if (options.usernameChanged && account.webfingerHost !== null) {
+                // WebFinger no longer advertises the stored host (or never did
+                // for this local-part). Keeping it would show a stale handle.
+                if (account.webfingerHost !== null) {
                     await this.accountRepository.updateWebfingerHost(
                         account.id,
                         null,
@@ -562,6 +561,22 @@ export class AccountService {
             );
         } catch (err) {
             if (isDuplicateEntryError(err)) {
+                getLogger(['activitypub']).warn(
+                    'WebFinger handle @{username}@{host} for {apId} conflicted on write, falling back to actor host',
+                    {
+                        username: account.username,
+                        host: nextHost,
+                        apId: account.apId.href,
+                    },
+                );
+
+                if (account.webfingerHost !== null && nextHost !== null) {
+                    await this.accountRepository.updateWebfingerHost(
+                        account.id,
+                        null,
+                    );
+                }
+
                 return;
             }
             throw err;

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -393,7 +393,7 @@ export class AccountService {
     ): Promise<Result<Account, WebfingerHostError>> {
         if (host === null) {
             const updated = account.setWebfingerHost(null);
-            await this.accountRepository.save(updated);
+            await this.persistWebfingerHostChange(updated);
             return ok(updated);
         }
 
@@ -406,7 +406,7 @@ export class AccountService {
 
         if (normalizedHost === fallbackHost) {
             const updated = account.setWebfingerHost(null);
-            await this.accountRepository.save(updated);
+            await this.persistWebfingerHostChange(updated);
             return ok(updated);
         }
 
@@ -421,7 +421,7 @@ export class AccountService {
 
         const updated = account.setWebfingerHost(normalizedHost);
         try {
-            await this.accountRepository.save(updated);
+            await this.persistWebfingerHostChange(updated);
         } catch (err) {
             if (isDuplicateEntryError(err)) {
                 return error({ type: 'conflict', host: normalizedHost });
@@ -431,6 +431,20 @@ export class AccountService {
         }
 
         return ok(updated);
+    }
+
+    /**
+     * Persist an intentional WebFinger host change.
+     *
+     * `save()` no longer writes `webfinger_host`, so the column is updated
+     * separately — the same seam external refresh uses.
+     */
+    private async persistWebfingerHostChange(account: Account): Promise<void> {
+        await this.accountRepository.save(account);
+        await this.accountRepository.updateWebfingerHost(
+            account.id,
+            account.webfingerHost,
+        );
     }
 
     /**

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -6,6 +6,7 @@ import {
     isActor,
     lookupObject as lookupFedifyObject,
 } from '@fedify/vocab';
+import { getLogger } from '@logtape/logtape';
 import type { Knex } from 'knex';
 
 import { type Account, AccountEntity } from '@/account/account.entity';
@@ -37,7 +38,7 @@ import { isHandle } from '@/helpers/activitypub/actor';
 import {
     lookupObject as lookupActivityPubObject,
     lookupActorProfile,
-    resolveExternalWebfingerHost,
+    resolveCustomWebfingerHost,
 } from '@/lookup-helpers';
 
 interface GetFollowingAccountsOptions {
@@ -111,7 +112,7 @@ export class AccountService {
     async getByApId(id: URL): Promise<Account | null> {
         const account = await this.accountRepository.getByApId(id);
         if (account) {
-            return this.refreshExternalWebfingerHostIfMissing(account);
+            return account;
         }
 
         const context = this.fedifyContextFactory.getFedifyContext();
@@ -134,7 +135,7 @@ export class AccountService {
         }
 
         const data = await mapActorToExternalAccountData(potentialActor);
-        data.webfinger_host = await this.resolveWebfingerHostForExternal(
+        data.webfinger_host = await this.resolveCustomWebfingerHostForExternal(
             data.username,
             new URL(data.ap_id),
         );
@@ -149,9 +150,7 @@ export class AccountService {
     ): Promise<Result<Account, RemoteAccountFetchError>> {
         const account = await this.accountRepository.getByApId(id);
         if (account) {
-            return ok(
-                await this.refreshExternalWebfingerHostIfMissing(account),
-            );
+            return ok(account);
         }
 
         const context = this.fedifyContextFactory.getFedifyContext();
@@ -196,7 +195,7 @@ export class AccountService {
             return error('invalid-data');
         }
 
-        data.webfinger_host = await this.resolveWebfingerHostForExternal(
+        data.webfinger_host = await this.resolveCustomWebfingerHostForExternal(
             data.username,
             new URL(data.ap_id),
         );
@@ -435,63 +434,69 @@ export class AccountService {
     }
 
     /**
-     * Resolve the WebFinger handle host for a remote actor.
+     * Resolve the custom WebFinger handle host to store for a remote actor.
      *
-     * Returns the custom subject host when present. When WebFinger confirms the
-     * actor host is canonical, returns that host so callers can persist it and
-     * skip re-resolving on later ensureByApId calls. Returns null only when
-     * lookup fails (caller should leave any existing value unchanged).
+     * Only a verified custom host is ever returned. A null `webfinger_host`
+     * already means "use the actor host" for every reader of the column, so the
+     * actor host is never written back into it.
      */
-    private async resolveWebfingerHostForExternal(
+    private async resolveCustomWebfingerHostForExternal(
         username: string,
         apId: URL,
     ): Promise<string | null> {
-        const resolution = await resolveExternalWebfingerHost(username, apId);
-        if (resolution.type === 'custom') {
-            return resolution.host;
+        const resolution = await resolveCustomWebfingerHost(username, apId);
+
+        if (resolution.type !== 'custom') {
+            return null;
         }
-        if (resolution.type === 'default') {
-            return normalizeWebfingerHost(apId.host);
+
+        const conflict =
+            await this.accountRepository.hasWebfingerHandleConflict(
+                username,
+                resolution.host,
+                0,
+            );
+
+        if (conflict) {
+            getLogger(['activitypub']).warn(
+                'WebFinger handle @{username}@{host} for {apId} is already held by another account, storing default host',
+                { username, host: resolution.host, apId: apId.href },
+            );
+
+            return null;
         }
-        return null;
+
+        return resolution.host;
     }
 
     /**
-     * One-shot backfill for external accounts that predate remote WebFinger
-     * persistence. Once a host is stored (custom or confirmed default), further
-     * ensureByApId calls skip the lookup. custom→custom changes still arrive via
-     * actor Update → {@link refreshExternalWebfingerHost}.
+     * Re-resolve and persist the custom WebFinger host for an external account.
+     *
+     * Only the `webfinger_host` column is written, so this cannot clobber
+     * profile fields updated concurrently. A failed lookup leaves the stored
+     * value unchanged; a successful lookup that finds no custom host clears it.
      */
-    private async refreshExternalWebfingerHostIfMissing(
-        account: Account,
-    ): Promise<Account> {
-        if (account.isInternal || account.webfingerHost !== null) {
-            return account;
-        }
-
-        return this.refreshExternalWebfingerHost(account);
-    }
-
-    /**
-     * Re-resolve and persist the WebFinger subject host for an external account.
-     * Lookup failures leave the stored value unchanged.
-     */
-    async refreshExternalWebfingerHost(account: Account): Promise<Account> {
+    async refreshExternalWebfingerHost(account: Account): Promise<void> {
         if (account.isInternal) {
-            return account;
+            return;
         }
 
-        const nextHost = await this.resolveWebfingerHostForExternal(
+        const resolution = await resolveCustomWebfingerHost(
             account.username,
             account.apId,
         );
 
-        if (nextHost === null || nextHost === account.webfingerHost) {
-            return account;
+        if (resolution.type === 'unavailable') {
+            return;
         }
 
-        const actorHost = normalizeWebfingerHost(account.apId.host);
-        if (nextHost !== actorHost) {
+        const nextHost = resolution.type === 'custom' ? resolution.host : null;
+
+        if (nextHost === account.webfingerHost) {
+            return;
+        }
+
+        if (nextHost !== null) {
             const conflict =
                 await this.accountRepository.hasWebfingerHandleConflict(
                     account.username,
@@ -500,21 +505,30 @@ export class AccountService {
                 );
 
             if (conflict) {
-                return account;
+                getLogger(['activitypub']).warn(
+                    'WebFinger handle @{username}@{host} for {apId} is already held by another account, leaving host unchanged',
+                    {
+                        username: account.username,
+                        host: nextHost,
+                        apId: account.apId.href,
+                    },
+                );
+
+                return;
             }
         }
 
-        const updated = account.setWebfingerHost(nextHost);
         try {
-            await this.accountRepository.save(updated);
+            await this.accountRepository.updateWebfingerHost(
+                account.id,
+                nextHost,
+            );
         } catch (err) {
             if (isDuplicateEntryError(err)) {
-                return account;
+                return;
             }
             throw err;
         }
-
-        return updated;
     }
 
     /**
@@ -678,9 +692,19 @@ export class AccountService {
                     return existingAccount;
                 }
 
-                // Likely a webfinger_host uniqueness conflict — retry without
-                // the custom host rather than failing account creation.
+                // The handle was free when it was checked, so another insert
+                // took it in between. Fall back to the actor host rather than
+                // failing to ingest the account.
                 if (dataToInsert.webfinger_host) {
+                    getLogger(['activitypub']).warn(
+                        'WebFinger handle @{username}@{host} for {apId} was claimed concurrently, storing default host',
+                        {
+                            username: accountData.username,
+                            host: dataToInsert.webfinger_host,
+                            apId: accountData.ap_id,
+                        },
+                    );
+
                     return this.createExternalAccount({
                         ...accountData,
                         webfinger_host: null,
@@ -1036,9 +1060,10 @@ export class AccountService {
 
         await this.accountRepository.save(updated);
 
-        if (!account.isInternal) {
-            await this.refreshExternalWebfingerHost(updated);
-        }
+        // An actor Update is the only federation signal we get for a remote
+        // handle domain change, since the custom host lives in WebFinger rather
+        // than on the actor document.
+        await this.refreshExternalWebfingerHost(updated);
 
         return ok(true);
     }

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -437,14 +437,16 @@ export class AccountService {
      * Persist an intentional WebFinger host change.
      *
      * `save()` no longer writes `webfinger_host`, so the column is updated
-     * separately — the same seam external refresh uses.
+     * separately — the same seam external refresh uses. The host is written
+     * first so WebFinger can answer for it before `save()` emits
+     * AccountUpdatedEvent and federates an Update to peers.
      */
     private async persistWebfingerHostChange(account: Account): Promise<void> {
-        await this.accountRepository.save(account);
         await this.accountRepository.updateWebfingerHost(
             account.id,
             account.webfingerHost,
         );
+        await this.accountRepository.save(account);
     }
 
     /**
@@ -487,10 +489,15 @@ export class AccountService {
      * Re-resolve and persist the custom WebFinger host for an external account.
      *
      * Only the `webfinger_host` column is written, so this cannot clobber
-     * profile fields updated concurrently. A failed lookup leaves the stored
-     * value unchanged; a successful lookup that finds no custom host clears it.
+     * profile fields updated concurrently. A failed lookup normally leaves the
+     * stored value unchanged — except when the username just changed, in which
+     * case a previous host was verified for a different local-part and must be
+     * cleared rather than displayed under the new name.
      */
-    async refreshExternalWebfingerHost(account: Account): Promise<void> {
+    async refreshExternalWebfingerHost(
+        account: Account,
+        options: { usernameChanged?: boolean } = {},
+    ): Promise<void> {
         if (account.isInternal) {
             return;
         }
@@ -501,6 +508,12 @@ export class AccountService {
         );
 
         if (resolution.type === 'unavailable') {
+            if (options.usernameChanged && account.webfingerHost !== null) {
+                await this.accountRepository.updateWebfingerHost(
+                    account.id,
+                    null,
+                );
+            }
             return;
         }
 
@@ -527,6 +540,16 @@ export class AccountService {
                         apId: account.apId.href,
                     },
                 );
+
+                // After a rename the previous host was verified for a different
+                // local-part. Refuse to keep it attached to the new username
+                // when the newly resolved host cannot be claimed.
+                if (options.usernameChanged && account.webfingerHost !== null) {
+                    await this.accountRepository.updateWebfingerHost(
+                        account.id,
+                        null,
+                    );
+                }
 
                 return;
             }
@@ -1070,14 +1093,29 @@ export class AccountService {
             return error('account-not-found');
         }
 
-        const updated = account.updateProfile(profileData);
+        const usernameChanged =
+            account.username.toLowerCase() !== data.username.toLowerCase();
+
+        // Clear any stored custom host before the username write so we never
+        // briefly hold (or unique-constrain) an unverified @newuser@oldhost.
+        let accountForUpdate = account;
+        if (
+            usernameChanged &&
+            !account.isInternal &&
+            account.webfingerHost !== null
+        ) {
+            await this.accountRepository.updateWebfingerHost(account.id, null);
+            accountForUpdate = account.setWebfingerHost(null);
+        }
+
+        const updated = accountForUpdate.updateProfile(profileData);
 
         await this.accountRepository.save(updated);
 
         // An actor Update is the only federation signal we get for a remote
         // handle domain change, since the custom host lives in WebFinger rather
         // than on the actor document.
-        await this.refreshExternalWebfingerHost(updated);
+        await this.refreshExternalWebfingerHost(updated, { usernameChanged });
 
         return ok(true);
     }

--- a/src/account/account.service.unit.test.ts
+++ b/src/account/account.service.unit.test.ts
@@ -23,6 +23,9 @@ vi.mock('@fedify/vocab', async () => {
 vi.mock('@/lookup-helpers', () => ({
     lookupActorProfile: vi.fn(),
     lookupObject: vi.fn(),
+    resolveExternalWebfingerHost: vi.fn().mockResolvedValue({
+        type: 'unavailable',
+    }),
 }));
 
 describe('AccountService', () => {
@@ -593,8 +596,11 @@ describe('AccountService', () => {
 
     describe('updateAccountByApId', () => {
         it('should update the account with the provided data', async () => {
-            const updated = {} as unknown as AccountEntity;
+            const updated = {
+                isInternal: true,
+            } as unknown as AccountEntity;
             const account = {
+                isInternal: true,
                 updateProfile: vi.fn().mockReturnValue(updated),
             } as unknown as AccountEntity;
 
@@ -631,7 +637,10 @@ describe('AccountService', () => {
 
         it('should handle empty values for avatarUrl, bannerImageUrl, url, and customFields', async () => {
             const account = {
-                updateProfile: vi.fn(),
+                isInternal: true,
+                updateProfile: vi.fn().mockReturnValue({
+                    isInternal: true,
+                }),
             } as unknown as AccountEntity;
 
             vi.mocked(knexAccountRepository.getByApId).mockImplementation(() =>
@@ -657,6 +666,149 @@ describe('AccountService', () => {
                 url: null,
                 customFields: null,
             });
+        });
+
+        it('refreshes webfinger host for external accounts after profile update', async () => {
+            const withWebfinger = {
+                isInternal: false,
+                webfingerHost: 'custom.example',
+            } as unknown as AccountEntity;
+            const afterProfile = {
+                isInternal: false,
+                webfingerHost: null,
+                username: 'alice',
+                apId: new URL('https://blog.example.com/users/alice'),
+                id: 9,
+                setWebfingerHost: vi.fn().mockReturnValue(withWebfinger),
+            } as unknown as AccountEntity;
+            const account = {
+                isInternal: false,
+                updateProfile: vi.fn().mockReturnValue(afterProfile),
+            } as unknown as AccountEntity;
+
+            vi.mocked(knexAccountRepository.getByApId).mockResolvedValue(
+                account,
+            );
+            vi.mocked(
+                knexAccountRepository.hasWebfingerHandleConflict,
+            ).mockResolvedValue(false);
+            vi.mocked(
+                lookupHelpers.resolveExternalWebfingerHost,
+            ).mockResolvedValue({
+                type: 'custom',
+                host: 'custom.example',
+            });
+
+            await accountService.updateAccountByApId(
+                new URL('https://blog.example.com/users/alice'),
+                {
+                    name: 'Alice',
+                    bio: 'bio',
+                    username: 'alice',
+                    avatarUrl: '',
+                    bannerImageUrl: '',
+                    url: '',
+                    customFields: null,
+                },
+            );
+
+            expect(
+                lookupHelpers.resolveExternalWebfingerHost,
+            ).toHaveBeenCalledWith('alice', afterProfile.apId);
+            expect(afterProfile.setWebfingerHost).toHaveBeenCalledWith(
+                'custom.example',
+            );
+            expect(knexAccountRepository.save).toHaveBeenCalledWith(
+                withWebfinger,
+            );
+        });
+    });
+
+    describe('ensureByApId webfinger refresh', () => {
+        it('backfills webfinger_host for an existing external account with a null host', async () => {
+            const refreshed = {
+                isInternal: false,
+                webfingerHost: 'onolan.org',
+            } as unknown as AccountEntity;
+            const account = {
+                isInternal: false,
+                id: 1,
+                username: 'john',
+                apId: new URL(
+                    'https://john.onolan.org/.ghost/activitypub/users/index',
+                ),
+                webfingerHost: null,
+                setWebfingerHost: vi.fn().mockReturnValue(refreshed),
+            } as unknown as AccountEntity;
+
+            vi.mocked(knexAccountRepository.getByApId).mockResolvedValue(
+                account,
+            );
+            vi.mocked(
+                knexAccountRepository.hasWebfingerHandleConflict,
+            ).mockResolvedValue(false);
+            vi.mocked(
+                lookupHelpers.resolveExternalWebfingerHost,
+            ).mockResolvedValue({
+                type: 'custom',
+                host: 'onolan.org',
+            });
+
+            const result = await accountService.ensureByApId(account.apId);
+
+            expect(result).toEqual(ok(refreshed));
+            expect(account.setWebfingerHost).toHaveBeenCalledWith('onolan.org');
+            expect(knexAccountRepository.save).toHaveBeenCalledWith(refreshed);
+        });
+
+        it('skips WebFinger when webfinger_host is already set', async () => {
+            const account = {
+                isInternal: false,
+                webfingerHost: 'onolan.org',
+                apId: new URL(
+                    'https://john.onolan.org/.ghost/activitypub/users/index',
+                ),
+            } as unknown as AccountEntity;
+
+            vi.mocked(knexAccountRepository.getByApId).mockResolvedValue(
+                account,
+            );
+
+            const result = await accountService.ensureByApId(account.apId);
+
+            expect(result).toEqual(ok(account));
+            expect(
+                lookupHelpers.resolveExternalWebfingerHost,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('stores the actor host when WebFinger confirms the default', async () => {
+            const refreshed = {
+                webfingerHost: 'blog.example.com',
+            } as unknown as AccountEntity;
+            const account = {
+                isInternal: false,
+                id: 2,
+                username: 'alice',
+                apId: new URL('https://blog.example.com/users/alice'),
+                webfingerHost: null,
+                setWebfingerHost: vi.fn().mockReturnValue(refreshed),
+            } as unknown as AccountEntity;
+
+            vi.mocked(knexAccountRepository.getByApId).mockResolvedValue(
+                account,
+            );
+            vi.mocked(
+                lookupHelpers.resolveExternalWebfingerHost,
+            ).mockResolvedValue({
+                type: 'default',
+            });
+
+            await accountService.ensureByApId(account.apId);
+
+            expect(account.setWebfingerHost).toHaveBeenCalledWith(
+                'blog.example.com',
+            );
         });
     });
 

--- a/src/account/account.service.unit.test.ts
+++ b/src/account/account.service.unit.test.ts
@@ -329,10 +329,9 @@ describe('AccountService', () => {
             expect(knexAccountRepository.save).toHaveBeenCalledWith(
                 updatedAccount,
             );
-            expect(knexAccountRepository.updateWebfingerHost).toHaveBeenCalledWith(
-                1,
-                'example.com',
-            );
+            expect(
+                knexAccountRepository.updateWebfingerHost,
+            ).toHaveBeenCalledWith(1, 'example.com');
         });
 
         it('clears the custom domain without live validation', async () => {
@@ -356,10 +355,9 @@ describe('AccountService', () => {
             expect(knexAccountRepository.save).toHaveBeenCalledWith(
                 updatedAccount,
             );
-            expect(knexAccountRepository.updateWebfingerHost).toHaveBeenCalledWith(
-                1,
-                null,
-            );
+            expect(
+                knexAccountRepository.updateWebfingerHost,
+            ).toHaveBeenCalledWith(1, null);
         });
     });
 

--- a/src/account/account.service.unit.test.ts
+++ b/src/account/account.service.unit.test.ts
@@ -23,7 +23,7 @@ vi.mock('@fedify/vocab', async () => {
 vi.mock('@/lookup-helpers', () => ({
     lookupActorProfile: vi.fn(),
     lookupObject: vi.fn(),
-    resolveExternalWebfingerHost: vi.fn().mockResolvedValue({
+    resolveCustomWebfingerHost: vi.fn().mockResolvedValue({
         type: 'unavailable',
     }),
 }));
@@ -49,6 +49,7 @@ describe('AccountService', () => {
             getByApId: vi.fn(),
             getByInboxUrl: vi.fn(),
             hasWebfingerHandleConflict: vi.fn().mockResolvedValue(false),
+            updateWebfingerHost: vi.fn(),
         } as unknown as KnexAccountRepository;
         fedifyContext = {};
         fedifyContextFactory = {
@@ -669,17 +670,12 @@ describe('AccountService', () => {
         });
 
         it('refreshes webfinger host for external accounts after profile update', async () => {
-            const withWebfinger = {
-                isInternal: false,
-                webfingerHost: 'custom.example',
-            } as unknown as AccountEntity;
             const afterProfile = {
                 isInternal: false,
                 webfingerHost: null,
                 username: 'alice',
                 apId: new URL('https://blog.example.com/users/alice'),
                 id: 9,
-                setWebfingerHost: vi.fn().mockReturnValue(withWebfinger),
             } as unknown as AccountEntity;
             const account = {
                 isInternal: false,
@@ -693,7 +689,7 @@ describe('AccountService', () => {
                 knexAccountRepository.hasWebfingerHandleConflict,
             ).mockResolvedValue(false);
             vi.mocked(
-                lookupHelpers.resolveExternalWebfingerHost,
+                lookupHelpers.resolveCustomWebfingerHost,
             ).mockResolvedValue({
                 type: 'custom',
                 host: 'custom.example',
@@ -713,24 +709,21 @@ describe('AccountService', () => {
             );
 
             expect(
-                lookupHelpers.resolveExternalWebfingerHost,
+                lookupHelpers.resolveCustomWebfingerHost,
             ).toHaveBeenCalledWith('alice', afterProfile.apId);
-            expect(afterProfile.setWebfingerHost).toHaveBeenCalledWith(
-                'custom.example',
-            );
-            expect(knexAccountRepository.save).toHaveBeenCalledWith(
-                withWebfinger,
-            );
+            // Only the host column is written, so a concurrent profile update
+            // cannot be clobbered by this stale entity
+            expect(
+                knexAccountRepository.updateWebfingerHost,
+            ).toHaveBeenCalledWith(9, 'custom.example');
         });
     });
 
-    describe('ensureByApId webfinger refresh', () => {
-        it('backfills webfinger_host for an existing external account with a null host', async () => {
-            const refreshed = {
-                isInternal: false,
-                webfingerHost: 'onolan.org',
-            } as unknown as AccountEntity;
-            const account = {
+    describe('refreshExternalWebfingerHost', () => {
+        const externalAccount = (
+            overrides: Partial<Record<string, unknown>> = {},
+        ) =>
+            ({
                 isInternal: false,
                 id: 1,
                 username: 'john',
@@ -738,33 +731,98 @@ describe('AccountService', () => {
                     'https://john.onolan.org/.ghost/activitypub/users/index',
                 ),
                 webfingerHost: null,
-                setWebfingerHost: vi.fn().mockReturnValue(refreshed),
-            } as unknown as AccountEntity;
+                ...overrides,
+            }) as unknown as AccountEntity;
 
-            vi.mocked(knexAccountRepository.getByApId).mockResolvedValue(
-                account,
+        it('persists a verified custom host', async () => {
+            vi.mocked(
+                lookupHelpers.resolveCustomWebfingerHost,
+            ).mockResolvedValue({ type: 'custom', host: 'onolan.org' });
+
+            await accountService.refreshExternalWebfingerHost(
+                externalAccount(),
             );
-            vi.mocked(
-                knexAccountRepository.hasWebfingerHandleConflict,
-            ).mockResolvedValue(false);
-            vi.mocked(
-                lookupHelpers.resolveExternalWebfingerHost,
-            ).mockResolvedValue({
-                type: 'custom',
-                host: 'onolan.org',
-            });
 
-            const result = await accountService.ensureByApId(account.apId);
-
-            expect(result).toEqual(ok(refreshed));
-            expect(account.setWebfingerHost).toHaveBeenCalledWith('onolan.org');
-            expect(knexAccountRepository.save).toHaveBeenCalledWith(refreshed);
+            expect(
+                knexAccountRepository.updateWebfingerHost,
+            ).toHaveBeenCalledWith(1, 'onolan.org');
         });
 
-        it('skips WebFinger when webfinger_host is already set', async () => {
+        it('never writes the actor host, so null keeps meaning "use the actor host"', async () => {
+            vi.mocked(
+                lookupHelpers.resolveCustomWebfingerHost,
+            ).mockResolvedValue({ type: 'none' });
+
+            await accountService.refreshExternalWebfingerHost(
+                externalAccount(),
+            );
+
+            expect(
+                knexAccountRepository.updateWebfingerHost,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('clears a stored host once the custom handle stops resolving', async () => {
+            vi.mocked(
+                lookupHelpers.resolveCustomWebfingerHost,
+            ).mockResolvedValue({ type: 'none' });
+
+            await accountService.refreshExternalWebfingerHost(
+                externalAccount({ webfingerHost: 'onolan.org' }),
+            );
+
+            expect(
+                knexAccountRepository.updateWebfingerHost,
+            ).toHaveBeenCalledWith(1, null);
+        });
+
+        it('leaves a stored host alone when the lookup is unavailable', async () => {
+            vi.mocked(
+                lookupHelpers.resolveCustomWebfingerHost,
+            ).mockResolvedValue({ type: 'unavailable' });
+
+            await accountService.refreshExternalWebfingerHost(
+                externalAccount({ webfingerHost: 'onolan.org' }),
+            );
+
+            expect(
+                knexAccountRepository.updateWebfingerHost,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('does not take a handle already held by another account', async () => {
+            vi.mocked(
+                lookupHelpers.resolveCustomWebfingerHost,
+            ).mockResolvedValue({ type: 'custom', host: 'onolan.org' });
+            vi.mocked(
+                knexAccountRepository.hasWebfingerHandleConflict,
+            ).mockResolvedValue(true);
+
+            await accountService.refreshExternalWebfingerHost(
+                externalAccount(),
+            );
+
+            expect(
+                knexAccountRepository.updateWebfingerHost,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('ignores internal accounts, whose host is set by the site owner', async () => {
+            await accountService.refreshExternalWebfingerHost(
+                externalAccount({ isInternal: true }),
+            );
+
+            expect(
+                lookupHelpers.resolveCustomWebfingerHost,
+            ).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('ensureByApId', () => {
+        it('does not hit the network for an account already in the database', async () => {
             const account = {
                 isInternal: false,
-                webfingerHost: 'onolan.org',
+                webfingerHost: null,
                 apId: new URL(
                     'https://john.onolan.org/.ghost/activitypub/users/index',
                 ),
@@ -778,37 +836,9 @@ describe('AccountService', () => {
 
             expect(result).toEqual(ok(account));
             expect(
-                lookupHelpers.resolveExternalWebfingerHost,
+                lookupHelpers.resolveCustomWebfingerHost,
             ).not.toHaveBeenCalled();
-        });
-
-        it('stores the actor host when WebFinger confirms the default', async () => {
-            const refreshed = {
-                webfingerHost: 'blog.example.com',
-            } as unknown as AccountEntity;
-            const account = {
-                isInternal: false,
-                id: 2,
-                username: 'alice',
-                apId: new URL('https://blog.example.com/users/alice'),
-                webfingerHost: null,
-                setWebfingerHost: vi.fn().mockReturnValue(refreshed),
-            } as unknown as AccountEntity;
-
-            vi.mocked(knexAccountRepository.getByApId).mockResolvedValue(
-                account,
-            );
-            vi.mocked(
-                lookupHelpers.resolveExternalWebfingerHost,
-            ).mockResolvedValue({
-                type: 'default',
-            });
-
-            await accountService.ensureByApId(account.apId);
-
-            expect(account.setWebfingerHost).toHaveBeenCalledWith(
-                'blog.example.com',
-            );
+            expect(knexAccountRepository.save).not.toHaveBeenCalled();
         });
     });
 

--- a/src/account/account.service.unit.test.ts
+++ b/src/account/account.service.unit.test.ts
@@ -924,6 +924,25 @@ describe('AccountService', () => {
             ).toHaveBeenCalledWith(1, null);
         });
 
+        it('clears a stored host when a domain change conflicts', async () => {
+            // WebFinger now advertises @user@new.example, but that slot is
+            // taken — keep showing @user@old.example would be a stale handle
+            vi.mocked(
+                lookupHelpers.resolveCustomWebfingerHost,
+            ).mockResolvedValue({ type: 'custom', host: 'new.example' });
+            vi.mocked(
+                knexAccountRepository.hasWebfingerHandleConflict,
+            ).mockResolvedValue(true);
+
+            await accountService.refreshExternalWebfingerHost(
+                externalAccount({ webfingerHost: 'old.example' }),
+            );
+
+            expect(
+                knexAccountRepository.updateWebfingerHost,
+            ).toHaveBeenCalledWith(1, null);
+        });
+
         it('does not take a handle already held by another account', async () => {
             vi.mocked(
                 lookupHelpers.resolveCustomWebfingerHost,

--- a/src/account/account.service.unit.test.ts
+++ b/src/account/account.service.unit.test.ts
@@ -326,12 +326,21 @@ describe('AccountService', () => {
             expect(account.setWebfingerHost).toHaveBeenCalledWith(
                 'example.com',
             );
-            expect(knexAccountRepository.save).toHaveBeenCalledWith(
-                updatedAccount,
-            );
             expect(
                 knexAccountRepository.updateWebfingerHost,
             ).toHaveBeenCalledWith(1, 'example.com');
+            expect(knexAccountRepository.save).toHaveBeenCalledWith(
+                updatedAccount,
+            );
+            // Host must be queryable via WebFinger before AccountUpdatedEvent
+            // federates an Update to peers
+            expect(
+                vi.mocked(knexAccountRepository.updateWebfingerHost).mock
+                    .invocationCallOrder[0],
+            ).toBeLessThan(
+                vi.mocked(knexAccountRepository.save).mock
+                    .invocationCallOrder[0],
+            );
         });
 
         it('clears the custom domain without live validation', async () => {
@@ -352,12 +361,19 @@ describe('AccountService', () => {
             expect(result).toEqual(ok(updatedAccount));
             expect(fetchMock).not.toHaveBeenCalled();
             expect(account.setWebfingerHost).toHaveBeenCalledWith(null);
+            expect(
+                knexAccountRepository.updateWebfingerHost,
+            ).toHaveBeenCalledWith(1, null);
             expect(knexAccountRepository.save).toHaveBeenCalledWith(
                 updatedAccount,
             );
             expect(
-                knexAccountRepository.updateWebfingerHost,
-            ).toHaveBeenCalledWith(1, null);
+                vi.mocked(knexAccountRepository.updateWebfingerHost).mock
+                    .invocationCallOrder[0],
+            ).toBeLessThan(
+                vi.mocked(knexAccountRepository.save).mock
+                    .invocationCallOrder[0],
+            );
         });
     });
 
@@ -612,9 +628,11 @@ describe('AccountService', () => {
         it('should update the account with the provided data', async () => {
             const updated = {
                 isInternal: true,
+                username: 'alice',
             } as unknown as AccountEntity;
             const account = {
                 isInternal: true,
+                username: 'alice',
                 updateProfile: vi.fn().mockReturnValue(updated),
             } as unknown as AccountEntity;
 
@@ -652,8 +670,10 @@ describe('AccountService', () => {
         it('should handle empty values for avatarUrl, bannerImageUrl, url, and customFields', async () => {
             const account = {
                 isInternal: true,
+                username: 'alice',
                 updateProfile: vi.fn().mockReturnValue({
                     isInternal: true,
+                    username: 'alice',
                 }),
             } as unknown as AccountEntity;
 
@@ -692,6 +712,7 @@ describe('AccountService', () => {
             } as unknown as AccountEntity;
             const account = {
                 isInternal: false,
+                username: 'alice',
                 updateProfile: vi.fn().mockReturnValue(afterProfile),
             } as unknown as AccountEntity;
 
@@ -729,6 +750,64 @@ describe('AccountService', () => {
             expect(
                 knexAccountRepository.updateWebfingerHost,
             ).toHaveBeenCalledWith(9, 'custom.example');
+        });
+
+        it('clears a stored host when username changes and WebFinger is unavailable', async () => {
+            const afterProfile = {
+                isInternal: false,
+                webfingerHost: null,
+                username: 'alice',
+                apId: new URL('https://blog.example.com/users/bob'),
+                id: 9,
+            } as unknown as AccountEntity;
+            const afterClear = {
+                isInternal: false,
+                webfingerHost: null,
+                username: 'bob',
+                apId: new URL('https://blog.example.com/users/bob'),
+                id: 9,
+                updateProfile: vi.fn().mockReturnValue(afterProfile),
+            } as unknown as AccountEntity;
+            const account = {
+                isInternal: false,
+                username: 'bob',
+                webfingerHost: 'custom.example',
+                id: 9,
+                setWebfingerHost: vi.fn().mockReturnValue(afterClear),
+            } as unknown as AccountEntity;
+
+            vi.mocked(knexAccountRepository.getByApId).mockResolvedValue(
+                account,
+            );
+            vi.mocked(
+                lookupHelpers.resolveCustomWebfingerHost,
+            ).mockResolvedValue({ type: 'unavailable' });
+
+            await accountService.updateAccountByApId(
+                new URL('https://blog.example.com/users/bob'),
+                {
+                    name: 'Alice',
+                    bio: 'bio',
+                    username: 'alice',
+                    avatarUrl: '',
+                    bannerImageUrl: '',
+                    url: '',
+                    customFields: null,
+                },
+            );
+
+            // Host cleared before the username write — never (alice, custom.example)
+            expect(account.setWebfingerHost).toHaveBeenCalledWith(null);
+            expect(
+                knexAccountRepository.updateWebfingerHost,
+            ).toHaveBeenCalledWith(9, null);
+            expect(
+                vi.mocked(knexAccountRepository.updateWebfingerHost).mock
+                    .invocationCallOrder[0],
+            ).toBeLessThan(
+                vi.mocked(knexAccountRepository.save).mock
+                    .invocationCallOrder[0],
+            );
         });
     });
 
@@ -801,6 +880,48 @@ describe('AccountService', () => {
             expect(
                 knexAccountRepository.updateWebfingerHost,
             ).not.toHaveBeenCalled();
+        });
+
+        it('clears a stored host when the username changed and lookup is unavailable', async () => {
+            // A host verified for @bob@custom must not survive a rename to
+            // alice when we cannot re-verify — otherwise we display an
+            // unverified handle
+            vi.mocked(
+                lookupHelpers.resolveCustomWebfingerHost,
+            ).mockResolvedValue({ type: 'unavailable' });
+
+            await accountService.refreshExternalWebfingerHost(
+                externalAccount({
+                    username: 'alice',
+                    webfingerHost: 'custom.example',
+                }),
+                { usernameChanged: true },
+            );
+
+            expect(
+                knexAccountRepository.updateWebfingerHost,
+            ).toHaveBeenCalledWith(1, null);
+        });
+
+        it('clears a stored host when username changed but the new host conflicts', async () => {
+            vi.mocked(
+                lookupHelpers.resolveCustomWebfingerHost,
+            ).mockResolvedValue({ type: 'custom', host: 'custom.example' });
+            vi.mocked(
+                knexAccountRepository.hasWebfingerHandleConflict,
+            ).mockResolvedValue(true);
+
+            await accountService.refreshExternalWebfingerHost(
+                externalAccount({
+                    username: 'alice',
+                    webfingerHost: 'old-custom.example',
+                }),
+                { usernameChanged: true },
+            );
+
+            expect(
+                knexAccountRepository.updateWebfingerHost,
+            ).toHaveBeenCalledWith(1, null);
         });
 
         it('does not take a handle already held by another account', async () => {

--- a/src/account/account.service.unit.test.ts
+++ b/src/account/account.service.unit.test.ts
@@ -282,7 +282,10 @@ describe('AccountService', () => {
 
     describe('setWebfingerHost', () => {
         it('saves a validated custom domain', async () => {
-            const updatedAccount = {} as AccountEntity;
+            const updatedAccount = {
+                id: 1,
+                webfingerHost: 'example.com',
+            } as AccountEntity;
             const account = {
                 id: 1,
                 username: 'index',
@@ -326,11 +329,19 @@ describe('AccountService', () => {
             expect(knexAccountRepository.save).toHaveBeenCalledWith(
                 updatedAccount,
             );
+            expect(knexAccountRepository.updateWebfingerHost).toHaveBeenCalledWith(
+                1,
+                'example.com',
+            );
         });
 
         it('clears the custom domain without live validation', async () => {
-            const updatedAccount = {} as AccountEntity;
+            const updatedAccount = {
+                id: 1,
+                webfingerHost: null,
+            } as AccountEntity;
             const account = {
+                id: 1,
                 apId: new URL('https://blog.example.com/users/index'),
                 setWebfingerHost: vi.fn().mockReturnValue(updatedAccount),
             } as unknown as AccountEntity;
@@ -344,6 +355,10 @@ describe('AccountService', () => {
             expect(account.setWebfingerHost).toHaveBeenCalledWith(null);
             expect(knexAccountRepository.save).toHaveBeenCalledWith(
                 updatedAccount,
+            );
+            expect(knexAccountRepository.updateWebfingerHost).toHaveBeenCalledWith(
+                1,
+                null,
             );
         });
     });

--- a/src/account/types.ts
+++ b/src/account/types.ts
@@ -46,4 +46,6 @@ export interface Account {
 export type ExternalAccountData = Omit<
     Account,
     'id' | 'ap_private_key' | 'webfinger_host'
->;
+> & {
+    webfinger_host?: string | null;
+};

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -2,6 +2,10 @@ import { chunk } from 'es-toolkit';
 import type { Knex } from 'knex';
 
 import { sanitizeHtml } from '@/helpers/html';
+import {
+    accountMatchesDomain,
+    domainBlockMatchesAccount,
+} from '@/moderation/domain-blocks';
 import type { ModerationService } from '@/moderation/moderation.service';
 import {
     type FollowersOnlyPost,
@@ -276,8 +280,9 @@ export class FeedService {
         cursor: string | null,
     ): Promise<GetFeedDataResult> {
         const postType: PostType = PostType.Article;
+        const db = this.db;
 
-        const results = await this.db('discovery_feeds')
+        const results = await db('discovery_feeds')
             .select(
                 // Post fields
                 'posts.id as post_id',
@@ -364,10 +369,9 @@ export class FeedService {
                     viewerAccountId.toString(),
                 );
             })
-            .leftJoin('domain_blocks', function () {
-                this.on(
-                    'domain_blocks.domain_hash',
-                    'author_account.domain_hash',
+            .leftJoin('domain_blocks', (join) => {
+                join.on(
+                    domainBlockMatchesAccount(db, 'author_account'),
                 ).andOnVal(
                     'domain_blocks.blocker_id',
                     '=',
@@ -654,9 +658,7 @@ export class FeedService {
                 );
             })
             .where('feeds.user_id', user.id)
-            .andWhereRaw('accounts.domain_hash = UNHEX(SHA2(LOWER(?), 256))', [
-                blockedDomain.host,
-            ])
+            .andWhere(accountMatchesDomain(this.db, blockedDomain.host))
             .delete();
     }
 

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -670,7 +670,7 @@ export class FeedService {
                 );
             })
             .where('feeds.user_id', user.id)
-            .andWhere(accountMatchesDomain(this.db, blockedDomain.host))
+            .andWhere(accountMatchesDomain(this.db, blockedDomain.hostname))
             .delete();
     }
 

--- a/src/http/api/views/account.follows.view.ts
+++ b/src/http/api/views/account.follows.view.ts
@@ -14,6 +14,7 @@ import { getAccountHandle } from '@/account/utils';
 import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import { error, getValue, isError, ok, type Result } from '@/core/result';
 import type { MinimalAccountDTO } from '@/http/api/types';
+import { resolveExternalWebfingerHost } from '@/lookup-helpers';
 import type { ModerationService } from '@/moderation/moderation.service';
 
 /**
@@ -406,12 +407,22 @@ export class AccountFollowsView {
                         continue;
                     }
 
+                    const actorId = new URL(followsActor.id);
+                    const resolution = await resolveExternalWebfingerHost(
+                        followsActor.preferredUsername,
+                        actorId,
+                    );
+                    const handleHost =
+                        resolution.type === 'custom'
+                            ? resolution.host
+                            : actorId.host;
+
                     accounts.push({
                         id: followsActor.id,
                         apId: followsActor.id,
                         name: followsActor.name,
                         handle: getAccountHandle(
-                            new URL(followsActor.id).host,
+                            handleHost,
                             followsActor.preferredUsername,
                         ),
                         avatarUrl: followsActor.icon.url,

--- a/src/http/api/views/account.follows.view.ts
+++ b/src/http/api/views/account.follows.view.ts
@@ -14,6 +14,7 @@ import { getAccountHandle } from '@/account/utils';
 import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import { error, getValue, isError, ok, type Result } from '@/core/result';
 import type { MinimalAccountDTO } from '@/http/api/types';
+import { isAccountDomainBlocked } from '@/moderation/domain-blocks';
 import type { ModerationService } from '@/moderation/moderation.service';
 
 /**
@@ -140,7 +141,11 @@ export class AccountFollowsView {
                 isFollowing: !!result.followed_by_me,
                 followedByMe: !!result.followed_by_me,
                 blockedByMe: !!result.blocked_by_me,
-                domainBlockedByMe: blockedDomains.has(apIdUrl.hostname),
+                domainBlockedByMe: isAccountDomainBlocked(
+                    blockedDomains,
+                    apIdUrl.hostname,
+                    result.webfinger_host,
+                ),
             });
         }
 
@@ -387,7 +392,11 @@ export class AccountFollowsView {
                         isFollowing: !!followeeAccount.followed_by_me,
                         followedByMe: !!followeeAccount.followed_by_me,
                         blockedByMe: !!followeeAccount.blocked_by_me,
-                        domainBlockedByMe: blockedDomains.has(apIdUrl.hostname),
+                        domainBlockedByMe: isAccountDomainBlocked(
+                            blockedDomains,
+                            apIdUrl.hostname,
+                            followeeAccount.webfinger_host,
+                        ),
                     });
                 } else {
                     const followsActorObj = await lookupObject(item.href, {
@@ -422,7 +431,12 @@ export class AccountFollowsView {
                         isFollowing: false,
                         followedByMe: false,
                         blockedByMe: false,
-                        domainBlockedByMe: blockedDomains.has(item.hostname),
+                        // No stored row yet, so the actor host is the only
+                        // domain this account is known under
+                        domainBlockedByMe: isAccountDomainBlocked(
+                            blockedDomains,
+                            item.hostname,
+                        ),
                     });
                 }
             } catch (_err) {

--- a/src/http/api/views/account.follows.view.ts
+++ b/src/http/api/views/account.follows.view.ts
@@ -419,22 +419,27 @@ export class AccountFollowsView {
                     // unknown actor sequentially, and the remote page size is
                     // not ours to bound. Custom hosts show up once the account
                     // is ingested through `ensureByApId`.
+                    const followsActorId = new URL(followsActor.id);
+
                     accounts.push({
                         id: followsActor.id,
                         apId: followsActor.id,
                         name: followsActor.name,
                         handle: getAccountHandle(
-                            new URL(followsActor.id).host,
+                            followsActorId.host,
                             followsActor.preferredUsername,
                         ),
                         avatarUrl: followsActor.icon.url,
                         isFollowing: false,
                         followedByMe: false,
                         blockedByMe: false,
-                        // No stored row yet, so the actor host is the only
-                        // domain this account is known under
+                        // There is no stored row to read a custom host from, so
+                        // the two hosts this actor is known under are its
+                        // canonical id and the URL the collection listed it
+                        // under, which a redirect can move to another domain
                         domainBlockedByMe: isAccountDomainBlocked(
                             blockedDomains,
+                            followsActorId.hostname,
                             item.hostname,
                         ),
                     });

--- a/src/http/api/views/account.follows.view.ts
+++ b/src/http/api/views/account.follows.view.ts
@@ -14,7 +14,6 @@ import { getAccountHandle } from '@/account/utils';
 import type { FedifyContextFactory } from '@/activitypub/fedify-context.factory';
 import { error, getValue, isError, ok, type Result } from '@/core/result';
 import type { MinimalAccountDTO } from '@/http/api/types';
-import { resolveExternalWebfingerHost } from '@/lookup-helpers';
 import type { ModerationService } from '@/moderation/moderation.service';
 
 /**
@@ -407,22 +406,16 @@ export class AccountFollowsView {
                         continue;
                     }
 
-                    const actorId = new URL(followsActor.id);
-                    const resolution = await resolveExternalWebfingerHost(
-                        followsActor.preferredUsername,
-                        actorId,
-                    );
-                    const handleHost =
-                        resolution.type === 'custom'
-                            ? resolution.host
-                            : actorId.host;
-
+                    // No WebFinger lookup here: this loop already fetches each
+                    // unknown actor sequentially, and the remote page size is
+                    // not ours to bound. Custom hosts show up once the account
+                    // is ingested through `ensureByApId`.
                     accounts.push({
                         id: followsActor.id,
                         apId: followsActor.id,
                         name: followsActor.name,
                         handle: getAccountHandle(
-                            handleHost,
+                            new URL(followsActor.id).host,
                             followsActor.preferredUsername,
                         ),
                         avatarUrl: followsActor.icon.url,

--- a/src/http/api/views/account.search.view.ts
+++ b/src/http/api/views/account.search.view.ts
@@ -2,6 +2,7 @@ import type { Knex } from 'knex';
 
 import { getAccountHandle } from '@/account/utils';
 import type { AccountSearchResult } from '@/http/api/search.controller';
+import { domainBlockMatchesAccount } from '@/moderation/domain-blocks';
 
 const SEARCH_RESULT_LIMIT = 20;
 
@@ -107,7 +108,8 @@ export class AccountSearchView {
         limit: number,
         rankExpression?: Knex.Raw,
     ): Promise<AccountSearchResult[]> {
-        const query = this.db('accounts')
+        const db = this.db;
+        const query = db('accounts')
             .select(
                 'accounts.ap_id',
                 'accounts.name',
@@ -155,11 +157,8 @@ export class AccountSearchView {
                     viewerAccountId.toString(),
                 );
             })
-            .leftJoin('domain_blocks', function () {
-                this.on(
-                    'domain_blocks.domain_hash',
-                    'accounts.domain_hash',
-                ).andOnVal(
+            .leftJoin('domain_blocks', (join) => {
+                join.on(domainBlockMatchesAccount(db)).andOnVal(
                     'domain_blocks.blocker_id',
                     '=',
                     viewerAccountId.toString(),

--- a/src/http/api/views/account.view.integration.test.ts
+++ b/src/http/api/views/account.view.integration.test.ts
@@ -18,6 +18,9 @@ import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
 vi.mock('@/lookup-helpers', () => ({
     lookupActorProfile: vi.fn(),
     lookupObject: vi.fn(),
+    resolveExternalWebfingerHost: vi.fn().mockResolvedValue({
+        type: 'unavailable',
+    }),
 }));
 
 describe('AccountView', () => {

--- a/src/http/api/views/account.view.integration.test.ts
+++ b/src/http/api/views/account.view.integration.test.ts
@@ -10,11 +10,7 @@ import { AsyncEvents } from '@/core/events';
 import { error, ok } from '@/core/result';
 import type { AccountDTO, AccountDTOWithBluesky } from '@/http/api/types';
 import { AccountView } from '@/http/api/views/account.view';
-import {
-    lookupActorProfile,
-    lookupObject,
-    resolveCustomWebfingerHost,
-} from '@/lookup-helpers';
+import { lookupActorProfile, lookupObject } from '@/lookup-helpers';
 import { Audience, Post, PostType } from '@/post/post.entity';
 import { KnexPostRepository } from '@/post/post.repository.knex';
 import { createTestDb } from '@/test/db';
@@ -23,9 +19,6 @@ import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
 vi.mock('@/lookup-helpers', () => ({
     lookupActorProfile: vi.fn(),
     lookupObject: vi.fn(),
-    resolveCustomWebfingerHost: vi.fn().mockResolvedValue({
-        type: 'unavailable',
-    }),
 }));
 
 describe('AccountView', () => {
@@ -610,9 +603,24 @@ describe('AccountView', () => {
             const view = await accountView.viewByApId(account.apId.toString());
 
             expect(view!.handle).toBe(`@${account.username}@onolan.org`);
-            // Re-resolving here would cost a WebFinger round trip per profile
-            // load and could regress the handle whenever that lookup failed
-            expect(resolveCustomWebfingerHost).not.toHaveBeenCalled();
+        });
+
+        it('falls back to the actor host for an account we have never stored', async () => {
+            const apId = new URL(
+                'https://john.onolan.org/.ghost/activitypub/users/index',
+            );
+
+            vi.mocked(lookupObject).mockResolvedValue(
+                new Person({
+                    id: apId,
+                    preferredUsername: 'john',
+                }),
+            );
+
+            const view = await accountView.viewByApId(apId.toString());
+
+            // Custom host waits for ingest / Update — no live WebFinger here
+            expect(view!.handle).toBe('@john@john.onolan.org');
         });
     });
 });

--- a/src/http/api/views/account.view.integration.test.ts
+++ b/src/http/api/views/account.view.integration.test.ts
@@ -18,7 +18,7 @@ import { createFixtureManager, type FixtureManager } from '@/test/fixtures';
 vi.mock('@/lookup-helpers', () => ({
     lookupActorProfile: vi.fn(),
     lookupObject: vi.fn(),
-    resolveExternalWebfingerHost: vi.fn().mockResolvedValue({
+    resolveCustomWebfingerHost: vi.fn().mockResolvedValue({
         type: 'unavailable',
     }),
 }));

--- a/src/http/api/views/account.view.integration.test.ts
+++ b/src/http/api/views/account.view.integration.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { Person } from '@fedify/vocab';
 import type { Logger } from '@logtape/logtape';
 import type { Knex } from 'knex';
 
@@ -9,7 +10,11 @@ import { AsyncEvents } from '@/core/events';
 import { error, ok } from '@/core/result';
 import type { AccountDTO, AccountDTOWithBluesky } from '@/http/api/types';
 import { AccountView } from '@/http/api/views/account.view';
-import { lookupActorProfile } from '@/lookup-helpers';
+import {
+    lookupActorProfile,
+    lookupObject,
+    resolveCustomWebfingerHost,
+} from '@/lookup-helpers';
 import { Audience, Post, PostType } from '@/post/post.entity';
 import { KnexPostRepository } from '@/post/post.repository.knex';
 import { createTestDb } from '@/test/db';
@@ -584,6 +589,30 @@ describe('AccountView', () => {
             const view = await accountView.viewByApId(account.apId.toString());
 
             expect(view).toBeNull();
+        });
+
+        it('should use the stored WebFinger host for a known remote account', async () => {
+            const account = await fixtureManager.createExternalAccount(
+                'https://john.onolan.org/',
+            );
+
+            await db('accounts')
+                .where({ id: account.id })
+                .update({ webfinger_host: 'onolan.org' });
+
+            vi.mocked(lookupObject).mockResolvedValue(
+                new Person({
+                    id: account.apId,
+                    preferredUsername: account.username,
+                }),
+            );
+
+            const view = await accountView.viewByApId(account.apId.toString());
+
+            expect(view!.handle).toBe(`@${account.username}@onolan.org`);
+            // Re-resolving here would cost a WebFinger round trip per profile
+            // load and could regress the handle whenever that lookup failed
+            expect(resolveCustomWebfingerHost).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/http/api/views/account.view.ts
+++ b/src/http/api/views/account.view.ts
@@ -8,7 +8,11 @@ import { getError, getValue, isError } from '@/core/result';
 import { getAttachments, getHandle } from '@/helpers/activitypub/actor';
 import { sanitizeHtml } from '@/helpers/html';
 import type { AccountDTO, AccountDTOWithBluesky } from '@/http/api/types';
-import { lookupActorProfile, lookupObject } from '@/lookup-helpers';
+import {
+    lookupActorProfile,
+    lookupObject,
+    resolveExternalWebfingerHost,
+} from '@/lookup-helpers';
 
 /**
  * Additional context that can be passed to the view
@@ -235,20 +239,22 @@ export class AccountView {
         let blockedByMe = false;
         let domainBlockedByMe = false;
 
-        if (context.requestUserAccount?.id) {
-            const externalAccount = await this.db('accounts')
-                .whereRaw('ap_id_hash = UNHEX(SHA2(?, 256))', [apId])
-                .select('id', 'ap_id')
-                .first();
+        const storedAccount = await this.db('accounts')
+            .whereRaw('ap_id_hash = UNHEX(SHA2(?, 256))', [apId])
+            .select('id', 'ap_id', 'webfinger_host')
+            .first<{
+                id: number;
+                ap_id: string;
+                webfinger_host: string | null;
+            }>();
 
-            if (externalAccount) {
-                ({ followedByMe, followsMe, blockedByMe, domainBlockedByMe } =
-                    await this.getRequestUserContextData(
-                        context.requestUserAccount.id,
-                        externalAccount.id,
-                        new URL(externalAccount.ap_id).hostname,
-                    ));
-            }
+        if (context.requestUserAccount?.id && storedAccount) {
+            ({ followedByMe, followsMe, blockedByMe, domainBlockedByMe } =
+                await this.getRequestUserContextData(
+                    context.requestUserAccount.id,
+                    storedAccount.id,
+                    new URL(storedAccount.ap_id).hostname,
+                ));
         }
 
         const icon = await actor.getIcon();
@@ -269,11 +275,35 @@ export class AccountView {
                 ]);
         }
 
+        const handle = await (async () => {
+            const username = actor.preferredUsername?.toString();
+            if (!actor.id || !username) {
+                return getHandle(actor);
+            }
+
+            // Prefer a previously persisted host so transient WebFinger failures
+            // cannot regress a correct handle, and so we skip a redundant lookup.
+            if (storedAccount?.webfinger_host) {
+                return getAccountHandle(storedAccount.webfinger_host, username);
+            }
+
+            const resolution = await resolveExternalWebfingerHost(
+                username,
+                actor.id,
+            );
+
+            if (resolution.type === 'custom') {
+                return getAccountHandle(resolution.host, username);
+            }
+
+            return getHandle(actor);
+        })();
+
         return {
             id: actor.id?.toString() || '',
             apId: actor.id?.toString() || '',
             name: actor.name?.toString() || '',
-            handle: getHandle(actor),
+            handle,
             bio: sanitizeHtml(actor.summary?.toString() || ''),
             url: actor.url?.toString() || '',
             avatarUrl: icon?.url?.toString() || '',

--- a/src/http/api/views/account.view.ts
+++ b/src/http/api/views/account.view.ts
@@ -11,7 +11,7 @@ import type { AccountDTO, AccountDTOWithBluesky } from '@/http/api/types';
 import {
     lookupActorProfile,
     lookupObject,
-    resolveExternalWebfingerHost,
+    resolveCustomWebfingerHost,
 } from '@/lookup-helpers';
 
 /**
@@ -239,22 +239,20 @@ export class AccountView {
         let blockedByMe = false;
         let domainBlockedByMe = false;
 
-        const storedAccount = await this.db('accounts')
-            .whereRaw('ap_id_hash = UNHEX(SHA2(?, 256))', [apId])
-            .select('id', 'ap_id', 'webfinger_host')
-            .first<{
-                id: number;
-                ap_id: string;
-                webfinger_host: string | null;
-            }>();
+        if (context.requestUserAccount?.id) {
+            const externalAccount = await this.db('accounts')
+                .whereRaw('ap_id_hash = UNHEX(SHA2(?, 256))', [apId])
+                .select('id', 'ap_id')
+                .first();
 
-        if (context.requestUserAccount?.id && storedAccount) {
-            ({ followedByMe, followsMe, blockedByMe, domainBlockedByMe } =
-                await this.getRequestUserContextData(
-                    context.requestUserAccount.id,
-                    storedAccount.id,
-                    new URL(storedAccount.ap_id).hostname,
-                ));
+            if (externalAccount) {
+                ({ followedByMe, followsMe, blockedByMe, domainBlockedByMe } =
+                    await this.getRequestUserContextData(
+                        context.requestUserAccount.id,
+                        externalAccount.id,
+                        new URL(externalAccount.ap_id).hostname,
+                    ));
+            }
         }
 
         const icon = await actor.getIcon();
@@ -275,19 +273,15 @@ export class AccountView {
                 ]);
         }
 
+        // This path only runs for actors we have never stored, so there is no
+        // `webfinger_host` to read and the custom handle has to be resolved live
         const handle = await (async () => {
             const username = actor.preferredUsername?.toString();
             if (!actor.id || !username) {
                 return getHandle(actor);
             }
 
-            // Prefer a previously persisted host so transient WebFinger failures
-            // cannot regress a correct handle, and so we skip a redundant lookup.
-            if (storedAccount?.webfinger_host) {
-                return getAccountHandle(storedAccount.webfinger_host, username);
-            }
-
-            const resolution = await resolveExternalWebfingerHost(
+            const resolution = await resolveCustomWebfingerHost(
                 username,
                 actor.id,
             );

--- a/src/http/api/views/account.view.ts
+++ b/src/http/api/views/account.view.ts
@@ -239,20 +239,25 @@ export class AccountView {
         let blockedByMe = false;
         let domainBlockedByMe = false;
 
-        if (context.requestUserAccount?.id) {
-            const externalAccount = await this.db('accounts')
-                .whereRaw('ap_id_hash = UNHEX(SHA2(?, 256))', [apId])
-                .select('id', 'ap_id')
-                .first();
+        // `viewByApId` resolves against internal accounts only, so every remote
+        // profile reaches this path, including ones we have already ingested
+        const storedAccount = await this.db('accounts')
+            .whereRaw('ap_id_hash = UNHEX(SHA2(?, 256))', [apId])
+            .select('id', 'ap_id', 'username', 'webfinger_host')
+            .first<{
+                id: number;
+                ap_id: string;
+                username: string;
+                webfinger_host: string | null;
+            }>();
 
-            if (externalAccount) {
-                ({ followedByMe, followsMe, blockedByMe, domainBlockedByMe } =
-                    await this.getRequestUserContextData(
-                        context.requestUserAccount.id,
-                        externalAccount.id,
-                        new URL(externalAccount.ap_id).hostname,
-                    ));
-            }
+        if (context.requestUserAccount?.id && storedAccount) {
+            ({ followedByMe, followsMe, blockedByMe, domainBlockedByMe } =
+                await this.getRequestUserContextData(
+                    context.requestUserAccount.id,
+                    storedAccount.id,
+                    new URL(storedAccount.ap_id).hostname,
+                ));
         }
 
         const icon = await actor.getIcon();
@@ -273,9 +278,20 @@ export class AccountView {
                 ]);
         }
 
-        // This path only runs for actors we have never stored, so there is no
-        // `webfinger_host` to read and the custom handle has to be resolved live
         const handle = await (async () => {
+            // Reading the stored host keeps this handle identical to every
+            // other surface, and stops a transient WebFinger failure from
+            // regressing a correct handle back to the actor host
+            if (storedAccount) {
+                return getAccountHandle(
+                    getAccountHandleHost({
+                        apId: new URL(storedAccount.ap_id),
+                        webfingerHost: storedAccount.webfinger_host,
+                    }),
+                    storedAccount.username,
+                );
+            }
+
             const username = actor.preferredUsername?.toString();
             if (!actor.id || !username) {
                 return getHandle(actor);

--- a/src/http/api/views/account.view.ts
+++ b/src/http/api/views/account.view.ts
@@ -13,6 +13,7 @@ import {
     lookupObject,
     resolveCustomWebfingerHost,
 } from '@/lookup-helpers';
+import { domainBlockMatchesAccount } from '@/moderation/domain-blocks';
 
 /**
  * Additional context that can be passed to the view
@@ -66,7 +67,6 @@ export class AccountView {
                 await this.getRequestUserContextData(
                     context.requestUserAccount.id,
                     accountData.id,
-                    new URL(accountData.ap_id).hostname,
                 ));
         }
 
@@ -182,7 +182,6 @@ export class AccountView {
                 await this.getRequestUserContextData(
                     context.requestUserAccount.id,
                     accountData.id,
-                    new URL(accountData.ap_id).hostname,
                 ));
         }
 
@@ -256,7 +255,6 @@ export class AccountView {
                 await this.getRequestUserContextData(
                     context.requestUserAccount.id,
                     storedAccount.id,
-                    new URL(storedAccount.ap_id).hostname,
                 ));
         }
 
@@ -388,7 +386,6 @@ export class AccountView {
     private async getRequestUserContextData(
         requestUserAccountId: number,
         retrievedAccountId: number,
-        retrievedAccountDomain: string,
     ) {
         let followedByMe = false;
         let followsMe = false;
@@ -423,8 +420,9 @@ export class AccountView {
             (
                 await this.db('domain_blocks')
                     .where('blocker_id', requestUserAccountId)
-                    .where('domain', retrievedAccountDomain)
-                    .first()
+                    .join('accounts', domainBlockMatchesAccount(this.db))
+                    .where('accounts.id', retrievedAccountId)
+                    .first('domain_blocks.id')
             )?.id !== undefined;
 
         return {

--- a/src/http/api/views/account.view.ts
+++ b/src/http/api/views/account.view.ts
@@ -8,11 +8,7 @@ import { getError, getValue, isError } from '@/core/result';
 import { getAttachments, getHandle } from '@/helpers/activitypub/actor';
 import { sanitizeHtml } from '@/helpers/html';
 import type { AccountDTO, AccountDTOWithBluesky } from '@/http/api/types';
-import {
-    lookupActorProfile,
-    lookupObject,
-    resolveCustomWebfingerHost,
-} from '@/lookup-helpers';
+import { lookupActorProfile, lookupObject } from '@/lookup-helpers';
 import { domainBlockMatchesAccount } from '@/moderation/domain-blocks';
 
 /**
@@ -276,36 +272,19 @@ export class AccountView {
                 ]);
         }
 
-        const handle = await (async () => {
-            // Reading the stored host keeps this handle identical to every
-            // other surface, and stops a transient WebFinger failure from
-            // regressing a correct handle back to the actor host
-            if (storedAccount) {
-                return getAccountHandle(
-                    getAccountHandleHost({
-                        apId: new URL(storedAccount.ap_id),
-                        webfingerHost: storedAccount.webfinger_host,
-                    }),
-                    storedAccount.username,
-                );
-            }
-
-            const username = actor.preferredUsername?.toString();
-            if (!actor.id || !username) {
-                return getHandle(actor);
-            }
-
-            const resolution = await resolveCustomWebfingerHost(
-                username,
-                actor.id,
-            );
-
-            if (resolution.type === 'custom') {
-                return getAccountHandle(resolution.host, username);
-            }
-
-            return getHandle(actor);
-        })();
+        // Stored host only — no live WebFinger here. Resolution belongs on
+        // ingest / actor Update, where the result is verified, conflict-checked
+        // and persisted. An unknown actor falls back to the actor host until
+        // then, matching the follower-list unknown-actor path.
+        const handle = storedAccount
+            ? getAccountHandle(
+                  getAccountHandleHost({
+                      apId: new URL(storedAccount.ap_id),
+                      webfingerHost: storedAccount.webfinger_host,
+                  }),
+                  storedAccount.username,
+              )
+            : getHandle(actor);
 
         return {
             id: actor.id?.toString() || '',

--- a/src/http/api/views/blocks.view.integration.test.ts
+++ b/src/http/api/views/blocks.view.integration.test.ts
@@ -104,6 +104,34 @@ describe('BlocksView', () => {
             expect(blockedAccounts[0].domainBlockedByMe).toBe(true);
         });
 
+        it("should return one entry when both of an account's domains are blocked", async () => {
+            const [blocker] = await fixtureManager.createInternalAccount();
+            const blockedAccount = await fixtureManager.createExternalAccount(
+                'https://actor-domain.com/',
+            );
+
+            await db('accounts')
+                .where({ id: blockedAccount.id })
+                .update({ webfinger_host: 'custom-blocked.com' });
+
+            await fixtureManager.createBlock(blocker, blockedAccount);
+            await fixtureManager.createDomainBlock(
+                blocker,
+                new URL('https://actor-domain.com'),
+            );
+            await fixtureManager.createDomainBlock(
+                blocker,
+                new URL('https://custom-blocked.com'),
+            );
+
+            const blockedAccounts = await blocksView.getBlockedAccounts(
+                blocker.id,
+            );
+
+            expect(blockedAccounts).toHaveLength(1);
+            expect(blockedAccounts[0].domainBlockedByMe).toBe(true);
+        });
+
         it("should not report another account's domain block as the viewer's own", async () => {
             const [blocker] = await fixtureManager.createInternalAccount();
             const [otherAccount] = await fixtureManager.createInternalAccount();

--- a/src/http/api/views/blocks.view.integration.test.ts
+++ b/src/http/api/views/blocks.view.integration.test.ts
@@ -103,6 +103,29 @@ describe('BlocksView', () => {
             );
             expect(blockedAccounts[0].domainBlockedByMe).toBe(true);
         });
+
+        it("should not report another account's domain block as the viewer's own", async () => {
+            const [blocker] = await fixtureManager.createInternalAccount();
+            const [otherAccount] = await fixtureManager.createInternalAccount();
+            const blockedAccount = await fixtureManager.createExternalAccount(
+                'https://actor-domain.com/',
+            );
+
+            await fixtureManager.createBlock(blocker, blockedAccount);
+            // Somebody else blocks the domain; this must not change what the
+            // viewer is told about their own moderation state
+            await fixtureManager.createDomainBlock(
+                otherAccount,
+                new URL('https://actor-domain.com'),
+            );
+
+            const blockedAccounts = await blocksView.getBlockedAccounts(
+                blocker.id,
+            );
+
+            expect(blockedAccounts).toHaveLength(1);
+            expect(blockedAccounts[0].domainBlockedByMe).toBe(false);
+        });
     });
 
     describe('getBlockedDomains', () => {

--- a/src/http/api/views/blocks.view.ts
+++ b/src/http/api/views/blocks.view.ts
@@ -10,27 +10,31 @@ export class BlocksView {
     async getBlockedAccounts(accountId: number): Promise<MinimalAccountDTO[]> {
         const db = this.db;
 
+        // An account can match a block under either of its hosts, so this has
+        // to ask whether any such block exists rather than join to them. A
+        // join fans out into one row per matching block, duplicating the
+        // account for a viewer who blocked both of its domains.
+        const domainBlockExists = db('domain_blocks')
+            .select(db.raw('1'))
+            .where('domain_blocks.blocker_id', accountId)
+            .where(domainBlockMatchesAccount(db));
+
         const results = await db('blocks')
             .select([
                 'accounts.ap_id',
                 'accounts.name',
                 'accounts.username',
                 'accounts.avatar_url',
-                'domain_blocks.domain as blocked_domain',
             ])
             .select(
-                this.db.raw(
+                db.raw(
                     'COALESCE(accounts.webfinger_host, accounts.domain) as domain',
                 ),
+                db.raw('EXISTS (?) as domain_blocked_by_me', [
+                    domainBlockExists,
+                ]),
             )
             .innerJoin('accounts', 'accounts.id', 'blocks.blocked_id')
-            .leftJoin('domain_blocks', (join) => {
-                join.on(domainBlockMatchesAccount(db)).andOnVal(
-                    'domain_blocks.blocker_id',
-                    '=',
-                    accountId.toString(),
-                );
-            })
             .where('blocks.blocker_id', accountId);
 
         return results.map((result) => ({
@@ -41,7 +45,7 @@ export class BlocksView {
             avatarUrl: result.avatar_url || null,
             followedByMe: false,
             blockedByMe: true,
-            domainBlockedByMe: !!result.blocked_domain,
+            domainBlockedByMe: !!result.domain_blocked_by_me,
             isFollowing: false,
         }));
     }

--- a/src/http/api/views/blocks.view.ts
+++ b/src/http/api/views/blocks.view.ts
@@ -2,16 +2,15 @@ import type { Knex } from 'knex';
 
 import { getAccountHandle } from '@/account/utils';
 import type { BlockedDomainDTO, MinimalAccountDTO } from '@/http/api/types';
+import { domainBlockMatchesAccount } from '@/moderation/domain-blocks';
 
 export class BlocksView {
     constructor(private readonly db: Knex) {}
 
     async getBlockedAccounts(accountId: number): Promise<MinimalAccountDTO[]> {
-        const effectiveDomainHash = this.db.raw(
-            'COALESCE(accounts.webfinger_host_hash, accounts.domain_hash)',
-        );
+        const db = this.db;
 
-        const results = await this.db('blocks')
+        const results = await db('blocks')
             .select([
                 'accounts.ap_id',
                 'accounts.name',
@@ -26,7 +25,7 @@ export class BlocksView {
             )
             .innerJoin('accounts', 'accounts.id', 'blocks.blocked_id')
             .leftJoin('domain_blocks', function () {
-                this.on('domain_blocks.domain_hash', effectiveDomainHash);
+                this.on(domainBlockMatchesAccount(db));
             })
             .where('blocks.blocker_id', accountId);
 

--- a/src/http/api/views/blocks.view.ts
+++ b/src/http/api/views/blocks.view.ts
@@ -24,8 +24,12 @@ export class BlocksView {
                 ),
             )
             .innerJoin('accounts', 'accounts.id', 'blocks.blocked_id')
-            .leftJoin('domain_blocks', function () {
-                this.on(domainBlockMatchesAccount(db));
+            .leftJoin('domain_blocks', (join) => {
+                join.on(domainBlockMatchesAccount(db)).andOnVal(
+                    'domain_blocks.blocker_id',
+                    '=',
+                    accountId.toString(),
+                );
             })
             .where('blocks.blocker_id', accountId);
 

--- a/src/http/api/views/explore.view.integration.test.ts
+++ b/src/http/api/views/explore.view.integration.test.ts
@@ -220,6 +220,47 @@ describe('ExploreView', () => {
             expect(next).toBeNull();
         });
 
+        it('should keep filtering out accounts blocked by their actor domain after a custom WebFinger host is stored', async () => {
+            const [viewer] = await fixtureManager.createInternalAccount();
+            const [accountOne] = await fixtureManager.createInternalAccount();
+            const customDomainAccount =
+                await fixtureManager.createExternalAccount(
+                    'https://actor-domain.com/',
+                );
+
+            const topic = await fixtureManager.createTopic(
+                'Science',
+                'science',
+            );
+
+            await fixtureManager.addAccountToTopic(accountOne.id, topic.id);
+            await fixtureManager.addAccountToTopic(
+                customDomainAccount.id,
+                topic.id,
+            );
+
+            // The viewer blocked the domain they were shown at the time, which
+            // was the actor host, before any custom host was resolved
+            await fixtureManager.createDomainBlock(
+                viewer,
+                new URL('https://actor-domain.com'),
+            );
+
+            await db('accounts')
+                .where({ id: customDomainAccount.id })
+                .update({ webfinger_host: 'custom.example' });
+
+            const { accounts } = await exploreView.getAccountsInTopic(
+                topic.slug,
+                viewer.id,
+            );
+
+            expect(accounts).toHaveLength(1);
+            expect(accounts.map((a) => a.id)).not.toContain(
+                customDomainAccount.apId.toString(),
+            );
+        });
+
         it('should set followedByMe field correctly', async () => {
             const [viewer] = await fixtureManager.createInternalAccount();
             const [followedAccount] =

--- a/src/http/api/views/explore.view.ts
+++ b/src/http/api/views/explore.view.ts
@@ -3,6 +3,7 @@ import type { Knex } from 'knex';
 import { getAccountHandle } from '@/account/utils';
 import { sanitizeHtml } from '@/helpers/html';
 import type { ExploreAccountDTO } from '@/http/api/types';
+import { domainBlockMatchesAccount } from '@/moderation/domain-blocks';
 
 const DEFAULT_EXPLORE_LIMIT = 20;
 
@@ -15,11 +16,9 @@ export class ExploreView {
         offset = 0,
         limit = DEFAULT_EXPLORE_LIMIT,
     ): Promise<{ accounts: ExploreAccountDTO[]; next: string | null }> {
-        const effectiveDomainHash = this.db.raw(
-            'COALESCE(accounts.webfinger_host_hash, accounts.domain_hash)',
-        );
+        const db = this.db;
 
-        const results = await this.db('accounts')
+        const results = await db('accounts')
             .select(
                 'accounts.ap_id',
                 'accounts.name',
@@ -67,10 +66,7 @@ export class ExploreView {
                 );
             })
             .leftJoin('domain_blocks', function () {
-                this.on(
-                    'domain_blocks.domain_hash',
-                    effectiveDomainHash,
-                ).andOnVal(
+                this.on(domainBlockMatchesAccount(db)).andOnVal(
                     'domain_blocks.blocker_id',
                     '=',
                     viewerAccountId.toString(),

--- a/src/http/api/views/recommendations.view.ts
+++ b/src/http/api/views/recommendations.view.ts
@@ -3,6 +3,7 @@ import type { Knex } from 'knex';
 import { getAccountHandle } from '@/account/utils';
 import { sanitizeHtml } from '@/helpers/html';
 import type { ExploreAccountDTO } from '@/http/api/types';
+import { domainBlockMatchesAccount } from '@/moderation/domain-blocks';
 
 const DEFAULT_TOPIC_SLUG = 'top';
 
@@ -74,11 +75,9 @@ export class RecommendationsView {
         excludeIds: number[],
         limit: number,
     ): Promise<RecommendationRow[]> {
-        const effectiveDomainHash = this.db.raw(
-            'COALESCE(accounts.webfinger_host_hash, accounts.domain_hash)',
-        );
+        const db = this.db;
 
-        const query = this.db('accounts')
+        const query = db('accounts')
             .select(
                 'accounts.id',
                 'accounts.ap_id',
@@ -128,10 +127,7 @@ export class RecommendationsView {
 
             // Exclude domain-blocked accounts
             .leftJoin('domain_blocks', function () {
-                this.on(
-                    'domain_blocks.domain_hash',
-                    effectiveDomainHash,
-                ).andOnVal(
+                this.on(domainBlockMatchesAccount(db)).andOnVal(
                     'domain_blocks.blocker_id',
                     '=',
                     viewerAccountId.toString(),

--- a/src/lookup-helpers.ts
+++ b/src/lookup-helpers.ts
@@ -8,11 +8,25 @@ import {
 } from '@fedify/vocab';
 import { lookupWebFinger } from '@fedify/webfinger';
 
+import { normalizeWebfingerHost } from '@/account/utils';
 import type { FedifyContext } from '@/app';
 import { error, ok, type Result } from '@/core/result';
 import { isLocalEnvironment } from '@/helpers/environment';
 
 type LookupError = 'no-links-found' | 'no-self-link' | 'lookup-error';
+
+export type ExternalWebfingerHostResolution =
+    | { type: 'custom'; host: string }
+    | { type: 'default' }
+    | { type: 'unavailable' };
+
+function getWebFingerLookupOptions() {
+    return {
+        allowPrivateAddress:
+            process.env.ALLOW_PRIVATE_ADDRESS === 'true' &&
+            isLocalEnvironment(process.env.NODE_ENV),
+    };
+}
 
 export async function lookupActor(
     ctx: FedifyContext,
@@ -80,11 +94,10 @@ export async function lookupActorProfile(
 
         const resource = `acct:${cleanHandle}`;
 
-        const webfingerData = await lookupWebFinger(resource, {
-            allowPrivateAddress:
-                process.env.ALLOW_PRIVATE_ADDRESS === 'true' &&
-                isLocalEnvironment(process.env.NODE_ENV),
-        });
+        const webfingerData = await lookupWebFinger(
+            resource,
+            getWebFingerLookupOptions(),
+        );
 
         if (!webfingerData?.links) {
             ctx.data.logger.info('No links found in WebFinger response');
@@ -112,6 +125,114 @@ export async function lookupActorProfile(
             { handle, error: err },
         );
         return error('lookup-error');
+    }
+}
+
+/**
+ * Resolve the canonical WebFinger handle host for a remote actor.
+ *
+ * Custom handle domains (Mastodon `web_domain` / Ghost alternate WebFinger
+ * hosts) are advertised only in the WebFinger `subject`, not on the actor
+ * document. Looking up `acct:{username}@{apId.host}` and reading the subject
+ * host is how remotes discover `@user@custom.example` when the actor lives at
+ * `user.example`.
+ *
+ * Returns:
+ * - `custom` when the subject host differs from the actor host
+ * - `default` when WebFinger confirms the actor host is canonical
+ * - `unavailable` when WebFinger cannot be resolved or does not verify the actor
+ */
+export async function resolveExternalWebfingerHost(
+    username: string,
+    apId: URL,
+): Promise<ExternalWebfingerHostResolution> {
+    if (!username) {
+        return { type: 'unavailable' };
+    }
+
+    const actorHost = normalizeWebfingerHost(apId.host);
+    if (!actorHost) {
+        return { type: 'unavailable' };
+    }
+
+    try {
+        const webfingerData = await lookupWebFinger(
+            `acct:${username}@${actorHost}`,
+            getWebFingerLookupOptions(),
+        );
+
+        if (!webfingerData?.links) {
+            return { type: 'unavailable' };
+        }
+
+        const selfLink = webfingerData.links.find(
+            (link) =>
+                link.rel === 'self' &&
+                link.type === 'application/activity+json',
+        );
+
+        if (!selfLink?.href) {
+            return { type: 'unavailable' };
+        }
+
+        let selfUrl: URL;
+        try {
+            selfUrl = new URL(selfLink.href);
+        } catch {
+            return { type: 'unavailable' };
+        }
+
+        if (selfUrl.href !== apId.href) {
+            // Tolerate trailing-slash / www differences that still refer to the
+            // same actor document.
+            const normalizedSelf = new URL(selfUrl.href);
+            const normalizedApId = new URL(apId.href);
+            normalizedSelf.pathname = normalizedSelf.pathname.replace(
+                /\/+$/,
+                '',
+            );
+            normalizedApId.pathname = normalizedApId.pathname.replace(
+                /\/+$/,
+                '',
+            );
+            normalizedSelf.host =
+                normalizeWebfingerHost(normalizedSelf.host) ??
+                normalizedSelf.host;
+            normalizedApId.host =
+                normalizeWebfingerHost(normalizedApId.host) ??
+                normalizedApId.host;
+
+            if (normalizedSelf.href !== normalizedApId.href) {
+                return { type: 'unavailable' };
+            }
+        }
+
+        if (
+            typeof webfingerData.subject !== 'string' ||
+            !webfingerData.subject.startsWith('acct:')
+        ) {
+            return { type: 'default' };
+        }
+
+        const subjectParts = webfingerData.subject
+            .slice('acct:'.length)
+            .split('@');
+        if (subjectParts.length !== 2 || !subjectParts[1]) {
+            return { type: 'default' };
+        }
+
+        const subjectHost = normalizeWebfingerHost(subjectParts[1]);
+        if (!subjectHost) {
+            return { type: 'default' };
+        }
+
+        if (subjectHost === actorHost) {
+            return { type: 'default' };
+        }
+
+        return { type: 'custom', host: subjectHost };
+    } catch {
+        return { type: 'unavailable' };
     }
 }
 

--- a/src/lookup-helpers.ts
+++ b/src/lookup-helpers.ts
@@ -6,7 +6,7 @@ import {
     isActor,
     type Note,
 } from '@fedify/vocab';
-import { lookupWebFinger } from '@fedify/webfinger';
+import { lookupWebFinger, type ResourceDescriptor } from '@fedify/webfinger';
 
 import { normalizeWebfingerHost } from '@/account/utils';
 import type { FedifyContext } from '@/app';
@@ -15,16 +15,26 @@ import { isLocalEnvironment } from '@/helpers/environment';
 
 type LookupError = 'no-links-found' | 'no-self-link' | 'lookup-error';
 
-export type ExternalWebfingerHostResolution =
+/**
+ * Outcome of resolving a remote actor's custom WebFinger handle host.
+ *
+ * `none` and `unavailable` are distinct so callers can tell "this actor has no
+ * custom handle" from "we could not find out", and avoid clearing a stored host
+ * because of a transient network failure.
+ */
+export type CustomWebfingerHostResolution =
     | { type: 'custom'; host: string }
-    | { type: 'default' }
+    | { type: 'none' }
     | { type: 'unavailable' };
+
+const WEBFINGER_LOOKUP_TIMEOUT_MS = 5000;
 
 function getWebFingerLookupOptions() {
     return {
         allowPrivateAddress:
             process.env.ALLOW_PRIVATE_ADDRESS === 'true' &&
             isLocalEnvironment(process.env.NODE_ENV),
+        signal: AbortSignal.timeout(WEBFINGER_LOOKUP_TIMEOUT_MS),
     };
 }
 
@@ -129,111 +139,139 @@ export async function lookupActorProfile(
 }
 
 /**
- * Resolve the canonical WebFinger handle host for a remote actor.
- *
- * Custom handle domains (Mastodon `web_domain` / Ghost alternate WebFinger
- * hosts) are advertised only in the WebFinger `subject`, not on the actor
- * document. Looking up `acct:{username}@{apId.host}` and reading the subject
- * host is how remotes discover `@user@custom.example` when the actor lives at
- * `user.example`.
- *
- * Returns:
- * - `custom` when the subject host differs from the actor host
- * - `default` when WebFinger confirms the actor host is canonical
- * - `unavailable` when WebFinger cannot be resolved or does not verify the actor
+ * Canonical form of an actor id, so trailing-slash and `www.` differences
+ * between a WebFinger self link and an actor id do not read as different actors
  */
-export async function resolveExternalWebfingerHost(
-    username: string,
-    apId: URL,
-): Promise<ExternalWebfingerHostResolution> {
-    if (!username) {
-        return { type: 'unavailable' };
-    }
+function canonicalActorId(url: URL): string {
+    const canonical = new URL(url.href);
 
-    const actorHost = normalizeWebfingerHost(apId.host);
-    if (!actorHost) {
-        return { type: 'unavailable' };
+    canonical.pathname = canonical.pathname.replace(/\/+$/, '');
+    canonical.host = normalizeWebfingerHost(canonical.host) ?? canonical.host;
+
+    return canonical.href;
+}
+
+function describesActor(webfingerData: ResourceDescriptor, apId: URL): boolean {
+    const selfLink = webfingerData.links?.find(
+        (link) =>
+            link.rel === 'self' && link.type === 'application/activity+json',
+    );
+
+    if (!selfLink?.href) {
+        return false;
     }
 
     try {
-        const webfingerData = await lookupWebFinger(
-            `acct:${username}@${actorHost}`,
-            getWebFingerLookupOptions(),
+        return (
+            canonicalActorId(new URL(selfLink.href)) === canonicalActorId(apId)
         );
+    } catch {
+        return false;
+    }
+}
 
-        if (!webfingerData?.links) {
-            return { type: 'unavailable' };
-        }
+/**
+ * Parse an `acct:` WebFinger subject. The scheme is matched case-insensitively
+ * because URI schemes are case-insensitive, even though producers emit `acct:`
+ */
+function parseAcctSubject(
+    subject: string | undefined,
+): { username: string; host: string } | null {
+    if (typeof subject !== 'string') {
+        return null;
+    }
 
-        const selfLink = webfingerData.links.find(
-            (link) =>
-                link.rel === 'self' &&
-                link.type === 'application/activity+json',
-        );
+    const match = /^acct:([^@]+)@(.+)$/i.exec(subject.trim());
+    if (!match) {
+        return null;
+    }
 
-        if (!selfLink?.href) {
-            return { type: 'unavailable' };
-        }
+    const host = normalizeWebfingerHost(match[2]);
+    if (!host) {
+        return null;
+    }
 
-        let selfUrl: URL;
-        try {
-            selfUrl = new URL(selfLink.href);
-        } catch {
-            return { type: 'unavailable' };
-        }
+    return { username: match[1].toLowerCase(), host };
+}
 
-        if (selfUrl.href !== apId.href) {
-            // Tolerate trailing-slash / www differences that still refer to the
-            // same actor document.
-            const normalizedSelf = new URL(selfUrl.href);
-            const normalizedApId = new URL(apId.href);
-            normalizedSelf.pathname = normalizedSelf.pathname.replace(
-                /\/+$/,
-                '',
-            );
-            normalizedApId.pathname = normalizedApId.pathname.replace(
-                /\/+$/,
-                '',
-            );
-            normalizedSelf.host =
-                normalizeWebfingerHost(normalizedSelf.host) ??
-                normalizedSelf.host;
-            normalizedApId.host =
-                normalizeWebfingerHost(normalizedApId.host) ??
-                normalizedApId.host;
+type WebfingerFetch =
+    | { type: 'ok'; data: ResourceDescriptor }
+    | { type: 'unavailable' };
 
-            if (normalizedSelf.href !== normalizedApId.href) {
-                return { type: 'unavailable' };
-            }
-        }
+async function fetchWebfinger(resource: string): Promise<WebfingerFetch> {
+    let data: ResourceDescriptor | null;
 
-        if (
-            typeof webfingerData.subject !== 'string' ||
-            !webfingerData.subject.startsWith('acct:')
-        ) {
-            return { type: 'default' };
-        }
-
-        const subjectParts = webfingerData.subject
-            .slice('acct:'.length)
-            .split('@');
-        if (subjectParts.length !== 2 || !subjectParts[1]) {
-            return { type: 'default' };
-        }
-
-        const subjectHost = normalizeWebfingerHost(subjectParts[1]);
-        if (!subjectHost) {
-            return { type: 'default' };
-        }
-
-        if (subjectHost === actorHost) {
-            return { type: 'default' };
-        }
-
-        return { type: 'custom', host: subjectHost };
+    try {
+        data = await lookupWebFinger(resource, getWebFingerLookupOptions());
     } catch {
         return { type: 'unavailable' };
     }
+
+    if (!data) {
+        return { type: 'unavailable' };
+    }
+
+    return { type: 'ok', data };
+}
+
+/**
+ * Resolve a remote actor's custom WebFinger handle host.
+ *
+ * Custom handle domains (Mastodon `web_domain` / Ghost alternate WebFinger
+ * hosts) are advertised only in the WebFinger `subject`, not on the actor
+ * document, so `@user@custom.example` for an actor living on `user.example` is
+ * only discoverable through WebFinger.
+ *
+ * A server can put any domain in its own `subject`, so a differing domain is
+ * only accepted once that domain's own WebFinger points back at the same actor.
+ * Without that second lookup, any instance could claim a handle on a domain it
+ * does not control.
+ */
+export async function resolveCustomWebfingerHost(
+    username: string,
+    apId: URL,
+): Promise<CustomWebfingerHostResolution> {
+    const actorHost = normalizeWebfingerHost(apId.host);
+
+    if (!username || !actorHost) {
+        return { type: 'none' };
+    }
+
+    const claimedLookup = await fetchWebfinger(`acct:${username}@${actorHost}`);
+    if (claimedLookup.type === 'unavailable') {
+        return { type: 'unavailable' };
+    }
+
+    if (!describesActor(claimedLookup.data, apId)) {
+        return { type: 'none' };
+    }
+
+    const claimed = parseAcctSubject(claimedLookup.data.subject);
+    if (!claimed || claimed.host === actorHost) {
+        return { type: 'none' };
+    }
+
+    const confirmedLookup = await fetchWebfinger(
+        `acct:${claimed.username}@${claimed.host}`,
+    );
+    if (confirmedLookup.type === 'unavailable') {
+        return { type: 'unavailable' };
+    }
+
+    if (!describesActor(confirmedLookup.data, apId)) {
+        return { type: 'none' };
+    }
+
+    const confirmed = parseAcctSubject(confirmedLookup.data.subject);
+    if (
+        !confirmed ||
+        confirmed.host !== claimed.host ||
+        confirmed.username !== claimed.username
+    ) {
+        return { type: 'none' };
+    }
+
+    return { type: 'custom', host: claimed.host };
 }
 
 export async function getLikeCountFromRemote(object: Note | Article) {

--- a/src/lookup-helpers.ts
+++ b/src/lookup-helpers.ts
@@ -235,6 +235,12 @@ export async function resolveCustomWebfingerHost(
     username: string,
     apId: URL,
 ): Promise<CustomWebfingerHostResolution> {
+    // Non-default ports are a different WebFinger authority. Using
+    // `hostname` alone would drop the port and query the wrong host.
+    if (apId.port) {
+        return { type: 'none' };
+    }
+
     // Lookup against the actor's actual host — do not strip `www.`. That host
     // and the apex are distinct origins; asking the apex to describe a www
     // actor (or vice versa) is not the same as verifying the actor's own

--- a/src/lookup-helpers.ts
+++ b/src/lookup-helpers.ts
@@ -139,14 +139,18 @@ export async function lookupActorProfile(
 }
 
 /**
- * Canonical form of an actor id, so trailing-slash and `www.` differences
- * between a WebFinger self link and an actor id do not read as different actors
+ * Canonical form of an actor id for WebFinger self-link comparison.
+ *
+ * Trailing slashes are ignored so producers that append one still match.
+ * Hostnames are compared case-insensitively (URI hostnames are). `www.` is
+ * not stripped: www.example.com and example.com are distinct security origins
+ * and must not verify each other.
  */
 function canonicalActorId(url: URL): string {
     const canonical = new URL(url.href);
 
     canonical.pathname = canonical.pathname.replace(/\/+$/, '');
-    canonical.host = normalizeWebfingerHost(canonical.host) ?? canonical.host;
+    canonical.hostname = canonical.hostname.toLowerCase();
 
     return canonical.href;
 }
@@ -231,13 +235,22 @@ export async function resolveCustomWebfingerHost(
     username: string,
     apId: URL,
 ): Promise<CustomWebfingerHostResolution> {
-    const actorHost = normalizeWebfingerHost(apId.host);
+    // Lookup against the actor's actual host — do not strip `www.`. That host
+    // and the apex are distinct origins; asking the apex to describe a www
+    // actor (or vice versa) is not the same as verifying the actor's own
+    // WebFinger. Handle comparison still uses normalizeWebfingerHost so a
+    // subject of acct:user@www.example.com on a www actor reads as "no custom
+    // host" rather than a custom apex claim.
+    const actorLookupHost = apId.hostname.toLowerCase();
+    const actorHandleHost = normalizeWebfingerHost(apId.hostname);
 
-    if (!username || !actorHost) {
+    if (!username || !actorLookupHost || !actorHandleHost) {
         return { type: 'none' };
     }
 
-    const claimedLookup = await fetchWebfinger(`acct:${username}@${actorHost}`);
+    const claimedLookup = await fetchWebfinger(
+        `acct:${username}@${actorLookupHost}`,
+    );
     if (claimedLookup.type === 'unavailable') {
         return { type: 'unavailable' };
     }
@@ -247,7 +260,7 @@ export async function resolveCustomWebfingerHost(
     }
 
     const claimed = parseAcctSubject(claimedLookup.data.subject);
-    if (!claimed || claimed.host === actorHost) {
+    if (!claimed || claimed.host === actorHandleHost) {
         return { type: 'none' };
     }
 

--- a/src/lookup-helpers.ts
+++ b/src/lookup-helpers.ts
@@ -251,6 +251,15 @@ export async function resolveCustomWebfingerHost(
         return { type: 'none' };
     }
 
+    // Callers render the handle from the actor's `preferredUsername`, so a
+    // subject naming a different local-part would have us verify one handle and
+    // display another. On a shared custom host that second handle can belong to
+    // somebody else, who then also loses the (username, host) slot to whichever
+    // row was written first.
+    if (claimed.username !== username.toLowerCase()) {
+        return { type: 'none' };
+    }
+
     const confirmedLookup = await fetchWebfinger(
         `acct:${claimed.username}@${claimed.host}`,
     );

--- a/src/lookup-helpers.unit.test.ts
+++ b/src/lookup-helpers.unit.test.ts
@@ -4,7 +4,10 @@ import { lookupWebFinger } from '@fedify/webfinger';
 
 import type { FedifyContext } from '@/app';
 import { error, ok } from '@/core/result';
-import { lookupActorProfile } from '@/lookup-helpers';
+import {
+    lookupActorProfile,
+    resolveExternalWebfingerHost,
+} from '@/lookup-helpers';
 
 vi.mock('@fedify/webfinger', () => ({
     lookupWebFinger: vi.fn(),
@@ -45,7 +48,7 @@ describe('lookupActorProfile', () => {
         );
 
         expect(lookupWebFinger).toHaveBeenCalledWith('acct:user@example.com', {
-            allowPrivateAddress: true,
+            allowPrivateAddress: expect.any(Boolean),
         });
         expect(result).toEqual(ok(new URL('https://example.com/actor')));
     });
@@ -129,5 +132,116 @@ describe('lookupActorProfile', () => {
         );
 
         expect(result).toEqual(ok(new URL('https://example.com/actor')));
+    });
+});
+
+describe('resolveExternalWebfingerHost', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns custom when the WebFinger subject host differs from the actor host', async () => {
+        (
+            lookupWebFinger as unknown as ReturnType<typeof vi.fn>
+        ).mockResolvedValue({
+            subject: 'acct:john@onolan.org',
+            links: [
+                {
+                    rel: 'self',
+                    type: 'application/activity+json',
+                    href: 'https://john.onolan.org/.ghost/activitypub/users/index',
+                },
+            ],
+        });
+
+        const result = await resolveExternalWebfingerHost(
+            'john',
+            new URL('https://john.onolan.org/.ghost/activitypub/users/index'),
+        );
+
+        expect(lookupWebFinger).toHaveBeenCalledWith(
+            'acct:john@john.onolan.org',
+            expect.any(Object),
+        );
+        expect(result).toEqual({ type: 'custom', host: 'onolan.org' });
+    });
+
+    it('returns default when the subject host matches the actor host', async () => {
+        (
+            lookupWebFinger as unknown as ReturnType<typeof vi.fn>
+        ).mockResolvedValue({
+            subject: 'acct:alice@example.com',
+            links: [
+                {
+                    rel: 'self',
+                    type: 'application/activity+json',
+                    href: 'https://example.com/users/alice',
+                },
+            ],
+        });
+
+        const result = await resolveExternalWebfingerHost(
+            'alice',
+            new URL('https://example.com/users/alice'),
+        );
+
+        expect(result).toEqual({ type: 'default' });
+    });
+
+    it('returns unavailable when the self link does not match the actor', async () => {
+        (
+            lookupWebFinger as unknown as ReturnType<typeof vi.fn>
+        ).mockResolvedValue({
+            subject: 'acct:alice@custom.example',
+            links: [
+                {
+                    rel: 'self',
+                    type: 'application/activity+json',
+                    href: 'https://example.com/users/other',
+                },
+            ],
+        });
+
+        const result = await resolveExternalWebfingerHost(
+            'alice',
+            new URL('https://example.com/users/alice'),
+        );
+
+        expect(result).toEqual({ type: 'unavailable' });
+    });
+
+    it('treats trailing-slash differences on the self link as the same actor', async () => {
+        (
+            lookupWebFinger as unknown as ReturnType<typeof vi.fn>
+        ).mockResolvedValue({
+            subject: 'acct:alice@custom.example',
+            links: [
+                {
+                    rel: 'self',
+                    type: 'application/activity+json',
+                    href: 'https://example.com/users/alice/',
+                },
+            ],
+        });
+
+        const result = await resolveExternalWebfingerHost(
+            'alice',
+            new URL('https://example.com/users/alice'),
+        );
+
+        expect(result).toEqual({ type: 'custom', host: 'custom.example' });
+    });
+
+    it('returns unavailable when WebFinger lookup fails', async () => {
+        (
+            lookupWebFinger as unknown as ReturnType<typeof vi.fn>
+        ).mockRejectedValue(new Error('network'));
+
+        const result = await resolveExternalWebfingerHost(
+            'alice',
+            new URL('https://example.com/users/alice'),
+        );
+
+        expect(result).toEqual({ type: 'unavailable' });
     });
 });

--- a/src/lookup-helpers.unit.test.ts
+++ b/src/lookup-helpers.unit.test.ts
@@ -287,6 +287,46 @@ describe('resolveCustomWebfingerHost', () => {
         expect(result).toEqual({ type: 'custom', host: 'custom.example' });
     });
 
+    it('does not treat www and apex as the same actor origin', async () => {
+        // www.example.com and example.com can be controlled independently;
+        // equating them would let one origin vouch for the other's actor id
+        webfingerMock().mockResolvedValueOnce(
+            jrd(
+                'acct:alice@custom.example',
+                'https://www.example.com/users/alice',
+            ),
+        );
+
+        const result = await resolveCustomWebfingerHost(
+            'alice',
+            new URL('https://example.com/users/alice'),
+        );
+
+        expect(result).toEqual({ type: 'none' });
+        expect(webfingerMock()).toHaveBeenCalledTimes(1);
+    });
+
+    it('looks up WebFinger on the actor host including www', async () => {
+        webfingerMock().mockResolvedValueOnce(
+            jrd(
+                'acct:alice@www.example.com',
+                'https://www.example.com/users/alice',
+            ),
+        );
+
+        const result = await resolveCustomWebfingerHost(
+            'alice',
+            new URL('https://www.example.com/users/alice'),
+        );
+
+        expect(webfingerMock()).toHaveBeenCalledWith(
+            'acct:alice@www.example.com',
+            expect.any(Object),
+        );
+        // Subject host normalizes to the same handle host as the actor — not custom
+        expect(result).toEqual({ type: 'none' });
+    });
+
     it('accepts an uppercase acct scheme', async () => {
         webfingerMock()
             .mockResolvedValueOnce(jrd('ACCT:john@onolan.org'))

--- a/src/lookup-helpers.unit.test.ts
+++ b/src/lookup-helpers.unit.test.ts
@@ -327,6 +327,18 @@ describe('resolveCustomWebfingerHost', () => {
         expect(result).toEqual({ type: 'none' });
     });
 
+    it('rejects actor ids with a non-default port instead of querying the wrong host', async () => {
+        // hostname would drop :8443 and hit example.com — refuse rather than
+        // verify through a different authority
+        const result = await resolveCustomWebfingerHost(
+            'alice',
+            new URL('https://example.com:8443/users/alice'),
+        );
+
+        expect(result).toEqual({ type: 'none' });
+        expect(webfingerMock()).not.toHaveBeenCalled();
+    });
+
     it('accepts an uppercase acct scheme', async () => {
         webfingerMock()
             .mockResolvedValueOnce(jrd('ACCT:john@onolan.org'))

--- a/src/lookup-helpers.unit.test.ts
+++ b/src/lookup-helpers.unit.test.ts
@@ -206,6 +206,24 @@ describe('resolveCustomWebfingerHost', () => {
         expect(result).toEqual({ type: 'none' });
     });
 
+    it('rejects a subject naming a different local part to the actor', async () => {
+        // The handle is rendered from the actor's preferredUsername, so
+        // accepting this would display @john@onolan.org off the back of a
+        // lookup that only ever verified @someone-else@onolan.org
+        webfingerMock().mockResolvedValueOnce(
+            jrd('acct:someone-else@onolan.org'),
+        );
+
+        const result = await resolveCustomWebfingerHost(
+            'john',
+            new URL(ACTOR_ID),
+        );
+
+        expect(result).toEqual({ type: 'none' });
+        // Rejected on the subject, without spending the confirming lookup
+        expect(webfingerMock()).toHaveBeenCalledTimes(1);
+    });
+
     it('reports unavailable when the confirming lookup fails, so a stored host is kept', async () => {
         webfingerMock()
             .mockResolvedValueOnce(jrd('acct:john@onolan.org'))

--- a/src/lookup-helpers.unit.test.ts
+++ b/src/lookup-helpers.unit.test.ts
@@ -6,7 +6,7 @@ import type { FedifyContext } from '@/app';
 import { error, ok } from '@/core/result';
 import {
     lookupActorProfile,
-    resolveExternalWebfingerHost,
+    resolveCustomWebfingerHost,
 } from '@/lookup-helpers';
 
 vi.mock('@fedify/webfinger', () => ({
@@ -49,6 +49,7 @@ describe('lookupActorProfile', () => {
 
         expect(lookupWebFinger).toHaveBeenCalledWith('acct:user@example.com', {
             allowPrivateAddress: expect.any(Boolean),
+            signal: expect.any(AbortSignal),
         });
         expect(result).toEqual(ok(new URL('https://example.com/actor')));
     });
@@ -135,96 +136,132 @@ describe('lookupActorProfile', () => {
     });
 });
 
-describe('resolveExternalWebfingerHost', () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
+describe('resolveCustomWebfingerHost', () => {
+    const ACTOR_ID = 'https://john.onolan.org/.ghost/activitypub/users/index';
 
-    it('returns custom when the WebFinger subject host differs from the actor host', async () => {
-        (
-            lookupWebFinger as unknown as ReturnType<typeof vi.fn>
-        ).mockResolvedValue({
-            subject: 'acct:john@onolan.org',
+    const webfingerMock = () =>
+        lookupWebFinger as unknown as ReturnType<typeof vi.fn>;
+
+    function jrd(subject: string, selfHref = ACTOR_ID) {
+        return {
+            subject,
             links: [
                 {
                     rel: 'self',
                     type: 'application/activity+json',
-                    href: 'https://john.onolan.org/.ghost/activitypub/users/index',
+                    href: selfHref,
                 },
             ],
-        });
+        };
+    }
 
-        const result = await resolveExternalWebfingerHost(
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns the custom host when the claimed domain confirms the actor', async () => {
+        webfingerMock()
+            .mockResolvedValueOnce(jrd('acct:john@onolan.org'))
+            .mockResolvedValueOnce(jrd('acct:john@onolan.org'));
+
+        const result = await resolveCustomWebfingerHost(
             'john',
-            new URL('https://john.onolan.org/.ghost/activitypub/users/index'),
+            new URL(ACTOR_ID),
         );
 
-        expect(lookupWebFinger).toHaveBeenCalledWith(
+        expect(webfingerMock()).toHaveBeenNthCalledWith(
+            1,
             'acct:john@john.onolan.org',
+            expect.any(Object),
+        );
+        expect(webfingerMock()).toHaveBeenNthCalledWith(
+            2,
+            'acct:john@onolan.org',
             expect.any(Object),
         );
         expect(result).toEqual({ type: 'custom', host: 'onolan.org' });
     });
 
-    it('returns default when the subject host matches the actor host', async () => {
-        (
-            lookupWebFinger as unknown as ReturnType<typeof vi.fn>
-        ).mockResolvedValue({
-            subject: 'acct:alice@example.com',
-            links: [
-                {
-                    rel: 'self',
-                    type: 'application/activity+json',
-                    href: 'https://example.com/users/alice',
-                },
-            ],
-        });
+    it('rejects a custom host the claimed domain does not vouch for', async () => {
+        const attackerId = 'https://evil.example/users/index';
 
-        const result = await resolveExternalWebfingerHost(
-            'alice',
-            new URL('https://example.com/users/alice'),
+        webfingerMock()
+            // The attacker's own server claims a handle on a domain it does not run
+            .mockResolvedValueOnce(
+                jrd('acct:index@victim-site.com', attackerId),
+            )
+            // The real victim-site.com answers with its own actor
+            .mockResolvedValueOnce(
+                jrd(
+                    'acct:index@victim-site.com',
+                    'https://victim-site.com/.ghost/activitypub/users/index',
+                ),
+            );
+
+        const result = await resolveCustomWebfingerHost(
+            'index',
+            new URL(attackerId),
         );
 
-        expect(result).toEqual({ type: 'default' });
+        expect(result).toEqual({ type: 'none' });
     });
 
-    it('returns unavailable when the self link does not match the actor', async () => {
-        (
-            lookupWebFinger as unknown as ReturnType<typeof vi.fn>
-        ).mockResolvedValue({
-            subject: 'acct:alice@custom.example',
-            links: [
-                {
-                    rel: 'self',
-                    type: 'application/activity+json',
-                    href: 'https://example.com/users/other',
-                },
-            ],
-        });
+    it('reports unavailable when the confirming lookup fails, so a stored host is kept', async () => {
+        webfingerMock()
+            .mockResolvedValueOnce(jrd('acct:john@onolan.org'))
+            .mockRejectedValueOnce(new Error('network'));
 
-        const result = await resolveExternalWebfingerHost(
-            'alice',
-            new URL('https://example.com/users/alice'),
+        const result = await resolveCustomWebfingerHost(
+            'john',
+            new URL(ACTOR_ID),
         );
 
         expect(result).toEqual({ type: 'unavailable' });
     });
 
-    it('treats trailing-slash differences on the self link as the same actor', async () => {
-        (
-            lookupWebFinger as unknown as ReturnType<typeof vi.fn>
-        ).mockResolvedValue({
-            subject: 'acct:alice@custom.example',
-            links: [
-                {
-                    rel: 'self',
-                    type: 'application/activity+json',
-                    href: 'https://example.com/users/alice/',
-                },
-            ],
-        });
+    it('returns none when the subject host matches the actor host', async () => {
+        webfingerMock().mockResolvedValue(
+            jrd('acct:alice@example.com', 'https://example.com/users/alice'),
+        );
 
-        const result = await resolveExternalWebfingerHost(
+        const result = await resolveCustomWebfingerHost(
+            'alice',
+            new URL('https://example.com/users/alice'),
+        );
+
+        expect(result).toEqual({ type: 'none' });
+        expect(webfingerMock()).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns none when the self link does not match the actor', async () => {
+        webfingerMock().mockResolvedValue(
+            jrd('acct:alice@custom.example', 'https://example.com/users/other'),
+        );
+
+        const result = await resolveCustomWebfingerHost(
+            'alice',
+            new URL('https://example.com/users/alice'),
+        );
+
+        expect(result).toEqual({ type: 'none' });
+    });
+
+    it('treats trailing-slash differences on the self link as the same actor', async () => {
+        webfingerMock()
+            .mockResolvedValueOnce(
+                jrd(
+                    'acct:alice@custom.example',
+                    'https://example.com/users/alice/',
+                ),
+            )
+            .mockResolvedValueOnce(
+                jrd(
+                    'acct:alice@custom.example',
+                    'https://example.com/users/alice',
+                ),
+            );
+
+        const result = await resolveCustomWebfingerHost(
             'alice',
             new URL('https://example.com/users/alice'),
         );
@@ -232,12 +269,39 @@ describe('resolveExternalWebfingerHost', () => {
         expect(result).toEqual({ type: 'custom', host: 'custom.example' });
     });
 
-    it('returns unavailable when WebFinger lookup fails', async () => {
-        (
-            lookupWebFinger as unknown as ReturnType<typeof vi.fn>
-        ).mockRejectedValue(new Error('network'));
+    it('accepts an uppercase acct scheme', async () => {
+        webfingerMock()
+            .mockResolvedValueOnce(jrd('ACCT:john@onolan.org'))
+            .mockResolvedValueOnce(jrd('ACCT:john@onolan.org'));
 
-        const result = await resolveExternalWebfingerHost(
+        const result = await resolveCustomWebfingerHost(
+            'john',
+            new URL(ACTOR_ID),
+        );
+
+        expect(result).toEqual({ type: 'custom', host: 'onolan.org' });
+    });
+
+    it('passes a timeout signal to every lookup', async () => {
+        webfingerMock().mockResolvedValue(
+            jrd('acct:alice@example.com', 'https://example.com/users/alice'),
+        );
+
+        await resolveCustomWebfingerHost(
+            'alice',
+            new URL('https://example.com/users/alice'),
+        );
+
+        expect(webfingerMock()).toHaveBeenCalledWith(
+            'acct:alice@example.com',
+            expect.objectContaining({ signal: expect.any(AbortSignal) }),
+        );
+    });
+
+    it('returns unavailable when the first WebFinger lookup fails', async () => {
+        webfingerMock().mockRejectedValue(new Error('network'));
+
+        const result = await resolveCustomWebfingerHost(
             'alice',
             new URL('https://example.com/users/alice'),
         );

--- a/src/moderation/domain-blocks.ts
+++ b/src/moderation/domain-blocks.ts
@@ -1,0 +1,20 @@
+import type { Knex } from 'knex';
+
+/**
+ * Join condition matching a domain block against an account.
+ *
+ * An account can be seen under two domains: the host its actor lives on, and
+ * the custom handle host from its WebFinger subject. A block is recorded with
+ * whichever one the reader was shown, so both have to match, otherwise storing
+ * a custom host would silently unblock an account blocked from a surface that
+ * displayed the actor host.
+ */
+export function domainBlockMatchesAccount(
+    db: Knex,
+    accountsTable = 'accounts',
+): Knex.Raw {
+    return db.raw('domain_blocks.domain_hash IN (??, ??)', [
+        `${accountsTable}.domain_hash`,
+        `${accountsTable}.webfinger_host_hash`,
+    ]);
+}

--- a/src/moderation/domain-blocks.ts
+++ b/src/moderation/domain-blocks.ts
@@ -48,22 +48,20 @@ export function accountMatchesDomain(
 }
 
 /**
- * Whether a set of blocked domains covers an account seen under either host.
+ * Whether a set of blocked domains covers an account known under any of
+ * `hosts`.
  *
  * The in-memory counterpart to `domainBlockMatchesAccount`, for views that
- * already hold the reader's blocked domains.
+ * already hold the reader's blocked domains. Pass every host the account can be
+ * seen under — its actor host, its custom handle host, and for an actor
+ * resolved from a collection, the URL the collection listed it under, which a
+ * redirect to a canonical actor id can move to another domain.
  */
 export function isAccountDomainBlocked(
     blockedDomains: Set<string>,
-    actorHost: string,
-    webfingerHost: string | null = null,
+    ...hosts: (string | null | undefined)[]
 ): boolean {
-    if (blockedDomains.has(actorHost.toLowerCase())) {
-        return true;
-    }
-
-    return (
-        webfingerHost !== null &&
-        blockedDomains.has(webfingerHost.toLowerCase())
+    return hosts.some(
+        (host) => !!host && blockedDomains.has(host.toLowerCase()),
     );
 }

--- a/src/moderation/domain-blocks.ts
+++ b/src/moderation/domain-blocks.ts
@@ -1,13 +1,18 @@
 import type { Knex } from 'knex';
 
 /**
- * Join condition matching a domain block against an account.
- *
  * An account can be seen under two domains: the host its actor lives on, and
- * the custom handle host from its WebFinger subject. A block is recorded with
- * whichever one the reader was shown, so both have to match, otherwise storing
- * a custom host would silently unblock an account blocked from a surface that
- * displayed the actor host.
+ * the custom handle host from its WebFinger subject.
+ *
+ * A domain block is recorded with whichever one the reader was shown
+ * (`DomainBlockedEvent` carries the displayed host), so every comparison has to
+ * consider both. Matching `domain_hash` alone lets a block taken from a surface
+ * showing a custom handle hide the account from some surfaces while its posts,
+ * follows and notifications survive, which is worse than not blocking at all.
+ */
+
+/**
+ * Join condition matching a domain block against an account.
  */
 export function domainBlockMatchesAccount(
     db: Knex,
@@ -17,4 +22,48 @@ export function domainBlockMatchesAccount(
         `${accountsTable}.domain_hash`,
         `${accountsTable}.webfinger_host_hash`,
     ]);
+}
+
+/**
+ * Condition matching every account visible under `domain`.
+ *
+ * Used at block time, where the blocked domain is known and the accounts it
+ * covers have to be found in order to tear down follows, posts and
+ * notifications.
+ */
+export function accountMatchesDomain(
+    db: Knex,
+    domain: string,
+    accountsTable = 'accounts',
+): Knex.Raw {
+    return db.raw(
+        '(?? = UNHEX(SHA2(LOWER(?), 256)) OR ?? = UNHEX(SHA2(LOWER(?), 256)))',
+        [
+            `${accountsTable}.domain_hash`,
+            domain,
+            `${accountsTable}.webfinger_host_hash`,
+            domain,
+        ],
+    );
+}
+
+/**
+ * Whether a set of blocked domains covers an account seen under either host.
+ *
+ * The in-memory counterpart to `domainBlockMatchesAccount`, for views that
+ * already hold the reader's blocked domains.
+ */
+export function isAccountDomainBlocked(
+    blockedDomains: Set<string>,
+    actorHost: string,
+    webfingerHost: string | null = null,
+): boolean {
+    if (blockedDomains.has(actorHost.toLowerCase())) {
+        return true;
+    }
+
+    return (
+        webfingerHost !== null &&
+        blockedDomains.has(webfingerHost.toLowerCase())
+    );
 }

--- a/src/moderation/domain-blocks.unit.test.ts
+++ b/src/moderation/domain-blocks.unit.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAccountDomainBlocked } from '@/moderation/domain-blocks';
+
+describe('isAccountDomainBlocked', () => {
+    it('matches the actor host', () => {
+        const blocked = new Set(['john.onolan.org']);
+
+        expect(isAccountDomainBlocked(blocked, 'john.onolan.org', null)).toBe(
+            true,
+        );
+    });
+
+    it('matches the custom handle host', () => {
+        const blocked = new Set(['onolan.org']);
+
+        expect(
+            isAccountDomainBlocked(blocked, 'john.onolan.org', 'onolan.org'),
+        ).toBe(true);
+    });
+
+    it('matches the URL a collection listed an actor under', () => {
+        // `lookupObject` can redirect to a canonical actor id on another
+        // domain, and the reader may have blocked either of them
+        const blocked = new Set(['listed.example']);
+
+        expect(
+            isAccountDomainBlocked(
+                blocked,
+                'canonical.example',
+                'listed.example',
+            ),
+        ).toBe(true);
+    });
+
+    it('ignores hosts that are not known', () => {
+        const blocked = new Set(['onolan.org']);
+
+        expect(
+            isAccountDomainBlocked(blocked, 'john.onolan.org', null, undefined),
+        ).toBe(false);
+    });
+
+    it('compares case insensitively', () => {
+        const blocked = new Set(['onolan.org']);
+
+        expect(isAccountDomainBlocked(blocked, 'ONOLAN.ORG')).toBe(true);
+    });
+
+    it('treats subdomains as distinct domains', () => {
+        const blocked = new Set(['onolan.org']);
+
+        expect(isAccountDomainBlocked(blocked, 'john.onolan.org')).toBe(false);
+    });
+});

--- a/src/moderation/moderation.service.integration.test.ts
+++ b/src/moderation/moderation.service.integration.test.ts
@@ -184,6 +184,75 @@ describe('ModerationService', () => {
             expect(users).toEqual([bobUserId, charlieUserId]);
         });
 
+        it("should keep filtering by the author's actor domain after a custom WebFinger host is stored", async () => {
+            const [
+                [aliceAccount, , aliceUserId],
+                [bobAccount, , bobUserId],
+                [, , charlieUserId],
+            ] = await Promise.all([
+                fixtureManager.createInternalAccount(),
+                fixtureManager.createInternalAccount(
+                    null,
+                    'blocked-domain.com',
+                ),
+                fixtureManager.createInternalAccount(),
+            ]);
+
+            const post = await fixtureManager.createPost(bobAccount);
+
+            // Alice blocks the domain she was shown, bob's actor host
+            await fixtureManager.createDomainBlock(
+                aliceAccount,
+                bobAccount.apId,
+            );
+
+            // Bob later turns out to have a custom handle domain. Keying this
+            // filter on the custom host alone would let his posts back into
+            // Alice's feed while Explore still hid him.
+            await client('accounts')
+                .where({ id: bobAccount.id })
+                .update({ webfinger_host: 'custom-handle.com' });
+
+            const users = await moderationService.filterUsersForPost(
+                [aliceUserId, bobUserId, charlieUserId],
+                post,
+            );
+
+            expect(users).toEqual([bobUserId, charlieUserId]);
+        });
+
+        it("should filter out users that have blocked the author's custom handle domain", async () => {
+            const [
+                [aliceAccount, , aliceUserId],
+                [bobAccount, , bobUserId],
+                [, , charlieUserId],
+            ] = await Promise.all([
+                fixtureManager.createInternalAccount(),
+                fixtureManager.createInternalAccount(null, 'actor-host.com'),
+                fixtureManager.createInternalAccount(),
+            ]);
+
+            const post = await fixtureManager.createPost(bobAccount);
+
+            await client('accounts')
+                .where({ id: bobAccount.id })
+                .update({ webfinger_host: 'custom-handle.com' });
+
+            // Alice blocks from a surface showing @bob@custom-handle.com, so
+            // that is the host recorded against the block
+            await fixtureManager.createDomainBlock(
+                aliceAccount,
+                new URL('https://custom-handle.com'),
+            );
+
+            const users = await moderationService.filterUsersForPost(
+                [aliceUserId, bobUserId, charlieUserId],
+                post,
+            );
+
+            expect(users).toEqual([bobUserId, charlieUserId]);
+        });
+
         it("should filter out users that have blocked the reposter's domain", async () => {
             const [
                 [aliceAccount, , aliceUserId],

--- a/src/moderation/moderation.service.ts
+++ b/src/moderation/moderation.service.ts
@@ -1,5 +1,6 @@
 import type { Knex } from 'knex';
 
+import { domainBlockMatchesAccount } from '@/moderation/domain-blocks';
 import type { Post } from '@/post/post.entity';
 
 export class ModerationService {
@@ -37,11 +38,7 @@ export class ModerationService {
             }
 
             const domainBlock = await this.db('domain_blocks')
-                .join(
-                    'accounts',
-                    'domain_blocks.domain_hash',
-                    'accounts.domain_hash',
-                )
+                .join('accounts', domainBlockMatchesAccount(this.db))
                 .innerJoin('users', 'accounts.id', 'users.account_id')
                 .where({
                     'domain_blocks.blocker_id': post.author.id,
@@ -67,11 +64,7 @@ export class ModerationService {
             .select('blocker_id');
 
         const domainBlocks = await this.db('domain_blocks')
-            .join(
-                'accounts',
-                'domain_blocks.domain_hash',
-                'accounts.domain_hash',
-            )
+            .join('accounts', domainBlockMatchesAccount(this.db))
             .whereIn('blocker_id', Array.from(userAccountMap.values()))
             .whereIn(
                 'accounts.id',
@@ -105,7 +98,7 @@ export class ModerationService {
             WHERE blocker_id = ? AND blocked_id = ?
             UNION ALL
             SELECT 1 AS blocked FROM domain_blocks
-            INNER JOIN accounts ON domain_blocks.domain_hash = accounts.domain_hash
+            INNER JOIN accounts ON domain_blocks.domain_hash IN (accounts.domain_hash, accounts.webfinger_host_hash)
             WHERE domain_blocks.blocker_id = ? AND accounts.id = ?
             LIMIT 1`,
             [

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -446,7 +446,7 @@ export class NotificationService {
         await this.db('notifications')
             .join('accounts', 'notifications.account_id', 'accounts.id')
             .where('notifications.user_id', user.id)
-            .andWhere(accountMatchesDomain(this.db, domain.host))
+            .andWhere(accountMatchesDomain(this.db, domain.hostname))
             .delete();
     }
 

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -2,6 +2,7 @@ import type { Knex } from 'knex';
 
 import { error, ok, type Result } from '@/core/result';
 import { sanitizeHtml } from '@/helpers/html';
+import { accountMatchesDomain } from '@/moderation/domain-blocks';
 import type { ModerationService } from '@/moderation/moderation.service';
 import type { Post } from '@/post/post.entity';
 
@@ -445,9 +446,7 @@ export class NotificationService {
         await this.db('notifications')
             .join('accounts', 'notifications.account_id', 'accounts.id')
             .where('notifications.user_id', user.id)
-            .andWhereRaw('accounts.domain_hash = UNHEX(SHA2(LOWER(?), 256))', [
-                domain.host,
-            ])
+            .andWhere(accountMatchesDomain(this.db, domain.host))
             .delete();
     }
 


### PR DESCRIPTION
## Summary

Remote Ghost instances ignored alternate WebFinger domains and rendered handles from the actor host, so a publisher on a custom domain showed up elsewhere as `@john@john.onolan.org` instead of `@john@onolan.org` (#2118). This resolves the WebFinger `subject` host when an external account is ingested or refreshed, stores it on the row, and reads the stored value on every display surface — feeds, posts, profiles and follower lists.

**A claimed handle is verified before it is stored.** Reading the subject from the actor's own server proves nothing about the domain it names, so any instance could serve an actor at `evil.example`, answer its WebFinger with `acct:index@victim-site.com`, and render as a real Ghost site in feeds, notifications and search on every receiving instance. A single Follow or Like is enough to get the row written. A differing domain is now only accepted once that domain's own WebFinger independently points back at the same actor, which is what Mastodon requires before trusting a subject from another host. For #2118 the second lookup at `onolan.org` redirects to `john.onolan.org` and returns the matching self link, so it passes; the spoofing case fails because `victim-site.com` answers with its own actor.

The subject's local-part has to match the actor's username too. Handles are rendered from `preferredUsername`, so an actor named `alice` advertising `acct:bob@custom.example` — with `custom.example` genuinely confirming `bob` — would otherwise be displayed as `@alice@custom.example`, a handle nobody verified, which on a shared custom-handle host can belong to somebody else and takes their slot in the `UNIQUE (username, webfinger_host_hash)` index. Both lookups carry a 5s timeout; without one, a remote that accepts the connection and never sends headers stalls the caller for undici's default header timeout.

**Resolution happens on write paths only.** An earlier revision of this PR backfilled from `getByApId` / `ensureByApId`. Those run for every inbound Create, Like, Announce and Follow, so that cost an outbound request per known actor, repeated indefinitely for any actor whose lookup never succeeded. Resolution now happens when an external account is created, and on actor `Update` — which is what Ghost federates when a publisher sets a custom domain. A known account is one indexed read again. The refresh writes only the `webfinger_host` column rather than saving the whole row, so a slow lookup can no longer overwrite profile fields another instance updated meanwhile.

Populating this column reached further than display, so three things came with it:

- `getByWebfingerHandle` had no internal-only filter, and the column had only ever been set on accounts we host. Writing it to external rows made our own `/.well-known/webfinger` answer for accounts hosted elsewhere, and made `createInternalAccount` reject a publisher moving to Ghost(Pro) on a domain some remote row already held. That lookup now joins `users`, so it only resolves accounts we host.
- `NULL` already means "use the actor host" to every reader of the column. Writing the actor host back into it as a "we checked this" marker would give the column two meanings and put every external account into the `UNIQUE (username, webfinger_host_hash)` index, so only verified custom hosts are stored.
- Domain blocks are recorded against whichever host the reader was shown, so a block taken from a surface displaying a custom handle has to match an account under either host. Matching `domain_hash` alone meant a block could hide an account from Explore while its posts still arrived in the feed and the follow survived — worse than not blocking. Every comparison now goes through `src/moderation/domain-blocks.ts`: feed fan-out, `canInteractWithAccount`, Explore, Recommendations, Blocks, search, profile `domainBlockedByMe`, the follower and following lists, and the block-time teardown of follows, feed entries and notifications. Blocking by the displayed handle domain keeps working; that arrived with #1821 and is covered by tests.

Two Blocks-list correctness gaps showed up once that either-host matching landed:

- `getBlockedAccounts` used a join with no `blocker_id` scope (pre-existing on `main`) and then, after matching both hashes, could return **two rows for one account** when the viewer had blocked both of its domains. It now asks via an `EXISTS` subquery scoped to the viewer, so the answer is a boolean and the list stays one entry per blocked account.
- Unknown actors on the follower/following fallback path can redirect to a canonical id on another host; `domainBlockedByMe` now checks both the listed URL host and the resolved actor host, consistent with the rendered handle.

Known limitation: remote accounts that set a custom domain before the sending instance runs this code keep `webfinger_host = NULL` until their next profile edit, which then federates an `Update` and corrects them. There is no backfill migration, so #2118 stays visibly unfixed for already-known follows until then — worth a conscious call before this ships.

## Test plan

- [ ] Unit and integration: reciprocal verification (accepts a confirming domain, rejects a spoofed one, rejects a mismatched local-part, tolerates timeouts), internal-only `getByWebfingerHandle`, domain blocks matching either host on both the feed and Explore, stored-host display on profile views, Blocks list stays one entry when both hosts are blocked and ignores another viewer's domain block
- [ ] Self-hosted: receive activity from an account with a custom WebFinger domain and confirm the feed, its profile, and follower lists all show the subject host rather than the actor host
- [ ] Self-hosted: serve an actor whose WebFinger subject claims a domain it does not control, and confirm the handle falls back to the actor host
- [ ] Block a remote account's displayed handle domain and confirm its posts stop arriving in the feed, the follow is torn down, and it disappears from Explore and search
- [ ] Block both the actor host and the custom handle for the same account and confirm the blocked-accounts list shows it once
- [ ] Change a publisher's custom domain and confirm the federated actor `Update` refreshes the stored host on the receiving instance
- [ ] Accounts without a custom domain still render `@user@actor-host` as before
